### PR TITLE
Use Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,17 +42,22 @@ jobs:
   test-codegen:
     runs-on: ubuntu-latest
     name: Java ${{ matrix.java }}
-    strategy:
-      matrix:
-        java: [8, 11]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+      - name: Download Coretto 17 JDK
+        run: |
+          download_url="https://corretto.aws/downloads/latest/amazon-corretto-17-x64-linux-jdk.tar.gz"
+          wget -O $RUNNER_TEMP/java_package.tar.gz $download_url
+
+      - name: Set up Coretto 17 JDK
+        uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
+          distribution: 'jdkfile'
+          jdkFile: ${{ runner.temp }}/java_package.tar.gz
+          java-version: 17
+          architecture: x64
 
       - name: clean and build
         run: cd codegen && ./gradlew clean build -Plog-tests


### PR DESCRIPTION
Java 17 is GA! Unfortunately the default providers for github actions haven't cut a release yet. Fortunately, Coretto has!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
