### PR TITLE
Generate specialized json strings / blobs

### DIFF
--- a/codegen/smithy-python-codegen-test/model/main.smithy
+++ b/codegen/smithy-python-codegen-test/model/main.smithy
@@ -166,7 +166,16 @@ structure GetCityOutput {
     coordinates: CityCoordinates,
 
     city: CitySummary,
+
+    cityData: JsonString,
+    binaryCityData: JsonBlob,
 }
+
+@mediaType("application/json")
+string JsonString
+
+@mediaType("application/json")
+blob JsonBlob
 
 // This structure is nested within GetCityOutput.
 structure CityCoordinates {

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -53,6 +53,16 @@ public final class CodegenUtils {
 
     private CodegenUtils() {}
 
+    /**
+     * Detects if an annotated mediatype indicates JSON contents.
+     *
+     * @param mediaType The media type to inspect.
+     * @return If the media type indicates JSON contents.
+     */
+    public static boolean isJsonMediaType(String mediaType) {
+        return mediaType.equals("application/json") || mediaType.endsWith("+json");
+    }
+
     static Symbol getDefaultTimestamp(PythonSettings settings) {
         return Symbol.builder()
                 .name("DEFAULT_TIMESTAMP")

--- a/smithy_python/mediatypes.py
+++ b/smithy_python/mediatypes.py
@@ -1,0 +1,36 @@
+import json
+from typing import Any
+
+
+class JsonString(str):
+    """A string that contains json data which can be lazily loaded."""
+
+    _json = None
+
+    def as_json(self) -> Any:
+        if not self._json:
+            self._json = json.loads(self)
+        return self._json
+
+    @staticmethod
+    def from_json(j: Any) -> "JsonString":
+        json_string = JsonString(json.dumps(j))
+        json_string._json = j
+        return json_string
+
+
+class JsonBlob(bytes):
+    """Bytes that contain json data which can be lazily loaded."""
+
+    _json = None
+
+    def as_json(self) -> Any:
+        if not self._json:
+            self._json = json.loads(self.decode(encoding="utf-8"))
+        return self._json
+
+    @staticmethod
+    def from_json(j: Any) -> "JsonBlob":
+        json_string = JsonBlob(json.dumps(j).encode(encoding="utf-8"))
+        json_string._json = j
+        return json_string

--- a/tests/unit/test_mediatypes.py
+++ b/tests/unit/test_mediatypes.py
@@ -1,0 +1,53 @@
+from smithy_python.mediatypes import JsonString, JsonBlob
+
+
+def test_json_string() -> None:
+    json_string = JsonString("{}")
+    assert json_string == "{}"
+    assert json_string.as_json() == {}
+    assert isinstance(json_string, str)
+
+
+def test_json_string_is_lazy() -> None:
+    json_string = JsonString("{}")
+
+    # Since as_json hasn't been called yet, the json shouldn't have been
+    # parsed yet.
+    assert json_string._json is None
+
+    json_string.as_json()
+
+    # Now that as_json has been called, the parsed result should be
+    # cached.
+    assert json_string._json == {}
+
+
+def test_string_from_json_immediately_caches() -> None:
+    json_string = JsonString.from_json({})
+    assert json_string._json == {}
+
+
+def test_json_blob() -> None:
+    json_blob = JsonBlob(b"{}")
+    assert json_blob == b"{}"
+    assert json_blob.as_json() == {}
+    assert isinstance(json_blob, bytes)
+
+
+def test_json_blob_is_lazy() -> None:
+    json_blob = JsonBlob(b"{}")
+
+    # Since as_json hasn't been called yet, the json shouldn't have been
+    # parsed yet.
+    assert json_blob._json is None
+
+    json_blob.as_json()
+
+    # Now that as_json has been called, the parsed result should be
+    # cached.
+    assert json_blob._json == {}
+
+
+def test_blob_from_json_immediately_caches() -> None:
+    json_blob = JsonBlob.from_json({})
+    assert json_blob._json == {}


### PR DESCRIPTION
This adds in specialized json strings / blobs. Right now these are the only mediatypes we're generating, but in the future we could theoretically generate for more. And once we start adding in extension points for the generator itself, it'll be possible for plugins to add their own.

This depends on: https://github.com/awslabs/smithy-python/pull/28, only the last commit in this pr is new.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
