### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add core contributors to all prs by default
+* @awslabs/aws-sdk-python


### PR DESCRIPTION
Adding in CODEOWNERS file to ensure Python team members are added to each PR.
