### PR TITLE
Update to a python 3.10 compatible black

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==21.9b0
+black==21.11b1
 flake8<3.10
 mypy<1.0
 pytest<6.3

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     version=find_version("smithy_python", "__init__.py"),
     description="Core libraries for Smithy defined services in Python",
     long_description=open("README.md", "r", encoding="utf-8").read(),
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author="Amazon Web Services",
     url="https://github.com/awslabs/smithy-python",
     scripts=[],
@@ -45,8 +45,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/smithy_python/_private/middleware.py
+++ b/smithy_python/_private/middleware.py
@@ -59,7 +59,7 @@ class SerializeInput(Generic[Input]):
         *,
         param: Input,
         request: Optional[Request] = None,
-        context: Optional[Context] = None
+        context: Optional[Context] = None,
     ) -> None:
         self.input: Input = param
         self.request: Optional[Request] = request
@@ -86,7 +86,7 @@ class FinalizeInput(Generic[Input]):
         param: Input,
         request: Request,
         response: Optional[Response] = None,
-        context: Optional[Context] = None
+        context: Optional[Context] = None,
     ) -> None:
         self.input: Input = param
         self.request: Request = request
@@ -103,7 +103,7 @@ class DeserializeInput(Generic[Input]):
         param: Input,
         request: Request,
         response: Response,
-        context: Optional[Context] = None
+        context: Optional[Context] = None,
     ) -> None:
         self.input: Input = param
         self.request: Request = request

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39
+envlist = py310
 
 skipsdist = True
 
@@ -14,7 +14,7 @@ commands =
 deps =
     -r requirements-dev.txt
 commands =
-    black --check --diff smithy_python tests
+    black --target-version py310 --check --diff smithy_python tests
     flake8 smithy_python tests
 
 [testenv:type]


### PR DESCRIPTION
This updates black to a version that supports handling python 3.10 syntax like match statements.

mypy is still working on it sadly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
