### PR TITLE
Update deps

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     signing
     checkstyle
     jacoco
-    id("com.github.spotbugs") version "4.7.1"
+    id("com.github.spotbugs") version "5.0.3"
     id("io.codearte.nexus-staging") version "0.30.0"
 }
 

--- a/codegen/gradle/wrapper/gradle-wrapper.properties
+++ b/codegen/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/codegen/smithy-python-codegen/build.gradle.kts
+++ b/codegen/smithy-python-codegen/build.gradle.kts
@@ -18,6 +18,6 @@ extra["displayName"] = "Smithy :: Python :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.python.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:[1.12.0,2.0.0[")
-    implementation("software.amazon.smithy:smithy-waiters:[1.12.0,2.0.0[")
+    api("software.amazon.smithy:smithy-codegen-core:[1.16.0,2.0.0[")
+    implementation("software.amazon.smithy:smithy-waiters:[1.16.0,2.0.0[")
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenVisitor.java
@@ -42,6 +42,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.transform.ModelTransformer;
 
 /**
  * Orchestrates Python client generation.
@@ -61,8 +62,9 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     CodegenVisitor(PluginContext context) {
         settings = PythonSettings.from(context.getSettings());
-        model = context.getModel();
-        modelWithoutTraitShapes = context.getModelWithoutTraitShapes();
+        ModelTransformer transformer = ModelTransformer.create();
+        model = transformer.createDedicatedInputAndOutput(context.getModel(), "Input", "Output");
+        modelWithoutTraitShapes = transformer.getModelWithoutTraitShapes(model);
         service = settings.getService(model);
         fileManifest = context.getFileManifest();
         LOGGER.info(() -> "Generating Python client for service " + service.getId());

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
@@ -16,10 +16,8 @@
 package software.amazon.smithy.python.codegen;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.StringJoiner;
 import java.util.function.BiFunction;
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -138,16 +136,6 @@ public final class PythonWriter extends CodeWriter {
      * @return Returns the writer.
      */
     public PythonWriter addImport(Symbol symbol, String alias, SymbolReference.ContextOption... options) {
-        LOGGER.finest(() -> {
-            StringJoiner stackTrace = new StringJoiner("\n");
-            for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
-                stackTrace.add(element.toString());
-            }
-            return String.format(
-                    "Adding Python import %s as `%s` (%s); Stack trace: %s",
-                    symbol, alias, Arrays.toString(options), stackTrace);
-        });
-
         // Always add dependencies.
         dependencies.addAll(symbol.getDependencies());
 


### PR DESCRIPTION
This updates a the dependency versions for gradle, spotbugs, and smithy. One of the features introduced in Smithy 1.16 was a built in way to add synthetic input / output shapes to operations, so I added that in. The `GetCurrentTime` operation showcases this as it does not define an input shape.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
