### PR TITLE
Use shared isJson function

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -53,16 +53,6 @@ public final class CodegenUtils {
 
     private CodegenUtils() {}
 
-    /**
-     * Detects if an annotated mediatype indicates JSON contents.
-     *
-     * @param mediaType The media type to inspect.
-     * @return If the media type indicates JSON contents.
-     */
-    public static boolean isJsonMediaType(String mediaType) {
-        return mediaType.equals("application/json") || mediaType.endsWith("+json");
-    }
-
     static Symbol getDefaultTimestamp(PythonSettings settings) {
         return Symbol.builder()
                 .name("DEFAULT_TIMESTAMP")

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
@@ -57,6 +57,7 @@ import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.CaseUtils;
+import software.amazon.smithy.utils.MediaType;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -141,7 +142,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
         if (shape.hasTrait(MediaTypeTrait.class)) {
             var mediaType = shape.expectTrait(MediaTypeTrait.class).getValue();
-            if (CodegenUtils.isJsonMediaType(mediaType)) {
+            if (MediaType.isJson(mediaType)) {
                 return createSymbolBuilder(shape, "Union[bytes, bytearray, JsonBlob]")
                         .addReference(createStdlibReference("Union", "typing"))
                         .addReference(Symbol.builder()
@@ -302,7 +303,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         }
         if (shape.hasTrait(MediaTypeTrait.class)) {
             var mediaType = shape.expectTrait(MediaTypeTrait.class).getValue();
-            if (CodegenUtils.isJsonMediaType(mediaType)) {
+            if (MediaType.isJson(mediaType)) {
                 return createSymbolBuilder(shape, "Union[str, JsonString]")
                         .addReference(createStdlibReference("Union", "typing"))
                         .addReference(Symbol.builder()


### PR DESCRIPTION
This removes the custom `isJson` function for media types in favor of the shared function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
