### PR TITLE
Refactor PythonWriter to use CodegenWriter

### DIFF
--- a/codegen/config/checkstyle/checkstyle.xml
+++ b/codegen/config/checkstyle/checkstyle.xml
@@ -32,7 +32,7 @@
     <!-- Files must contain a copyright header. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright 20(20|21) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright 20\d\d Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -40,10 +40,12 @@ import software.amazon.smithy.utils.StringUtils;
  */
 public final class CodegenUtils {
 
-    // The maximum preferred line length for generated code. In most cases it won't
-    // be practical to try to adhere to this in the generator, but we can make some
-    // amount of effort. Eventually a formatter like black will be run on the output
-    // to fix any lingering issues.
+    /**
+     * The maximum preferred line length for generated code. In most cases it won't
+     * be practical to try to adhere to this in the generator, but we can make some
+     * amount of effort. Eventually a formatter like black will be run on the output
+     * to fix any lingering issues.
+     */
     public static final int MAX_PREFERRED_LINE_LENGTH = 88;
 
     static final Set<String> ERROR_MESSAGE_MEMBER_NAMES = SetUtils.of(

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenVisitor.java
@@ -106,22 +106,18 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         writers.useFileWriter(serviceError.getDefinitionFile(), serviceError.getNamespace(), writer -> {
             // TODO: subclass a shared error
             writer.openBlock("class $L(Exception):", "", serviceError.getName(), () -> {
-                writer.openDocComment(() -> {
-                    writer.write("Base error for all errors in the service.");
-                });
+                writer.writeDocs("Base error for all errors in the service.");
                 writer.write("pass");
             });
         });
 
         var apiError = CodegenUtils.getApiError(settings);
         writers.useFileWriter(apiError.getDefinitionFile(), apiError.getNamespace(), writer -> {
-            writer.addStdlibImport("Generic", "Generic", "typing");
-            writer.addStdlibImport("TypeVar", "TypeVar", "typing");
+            writer.addStdlibImport("typing", "Generic");
+            writer.addStdlibImport("typing", "TypeVar");
             writer.write("T = TypeVar('T')");
             writer.openBlock("class $L($T, Generic[T]):", "", apiError.getName(), serviceError, () -> {
-                writer.openDocComment(() -> {
-                    writer.write("Base error for all api errors in the service.");
-                });
+                writer.writeDocs("Base error for all api errors in the service.");
                 writer.write("code: T");
                 writer.openBlock("def __init__(self, message: str):", "", () -> {
                     writer.write("super().__init__(message)");
@@ -130,9 +126,9 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
             });
 
             var unknownApiError = CodegenUtils.getUnknownApiError(settings);
-            writer.addStdlibImport("Literal", "Literal", "typing");
+            writer.addStdlibImport("typing", "Literal");
             writer.openBlock("class $L($T[Literal['Unknown']]):", "", unknownApiError.getName(), apiError, () -> {
-                writer.openDocComment(() -> writer.write("Error representing any unknown api errors"));
+                writer.writeDocs("Error representing any unknown api errors");
                 writer.write("code: Literal['Unknown'] = 'Unknown'");
             });
         });
@@ -216,7 +212,7 @@ final class CodegenVisitor extends ShapeVisitor.Default<Void> {
         var timestamp = CodegenUtils.getDefaultTimestamp(settings);
         if (!model.getTimestampShapes().isEmpty()) {
             writers.useFileWriter(timestamp.getDefinitionFile(), timestamp.getNamespace(), writer -> {
-                writer.addStdlibImport("datetime", "datetime", "datetime");
+                writer.addStdlibImport("datetime", "datetime");
                 writer.write("$L = datetime(1970, 1, 1)", timestamp.getName());
             });
         }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CollectionGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CollectionGenerator.java
@@ -58,8 +58,8 @@ final class CollectionGenerator implements Runnable {
         var asDictSymbol = symbol.expectProperty("asDict", Symbol.class);
         var target = model.expectShape(shape.getMember().getTarget());
         var targetSymbol = symbolProvider.toSymbol(target);
-        writer.addStdlibImport("List", "List", "typing");
-        writer.addStdlibImport("Any", "Any", "typing");
+        writer.addStdlibImport("typing", "List");
+        writer.addStdlibImport("typing", "Any");
         writer.openBlock("def $L(given: $T) -> List[Any]:", "", asDictSymbol.getName(), symbol, () -> {
             if (target.isUnionShape() || target.isStructureShape()) {
                 writer.write("return [v.as_dict() for v in given]");
@@ -77,8 +77,8 @@ final class CollectionGenerator implements Runnable {
         var fromDictSymbol = symbol.expectProperty("fromDict", Symbol.class);
         var target = model.expectShape(shape.getMember().getTarget());
         var targetSymbol = symbolProvider.toSymbol(target);
-        writer.addStdlibImport("List", "List", "typing");
-        writer.addStdlibImport("Any", "Any", "typing");
+        writer.addStdlibImport("typing", "List");
+        writer.addStdlibImport("typing", "Any");
         writer.openBlock("def $L(given: List[Any]) -> $T:", "", fromDictSymbol.getName(), symbol, () -> {
             if (target.isUnionShape() || target.isStructureShape()) {
                 writer.write("return [$T.from_dict(v) for v in given]", targetSymbol);

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/EnumGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/EnumGenerator.java
@@ -48,7 +48,7 @@ final class EnumGenerator implements Runnable {
         enumTrait.getEnumDefinitionValues();
         writer.openBlock("class $L:", "", enumSymbol.getName(), () -> {
             shape.getTrait(DocumentationTrait.class).ifPresent(trait -> {
-                writer.openDocComment(() -> writer.write(writer.formatDocs(trait.getValue())));
+                writer.writeDocs(writer.formatDocs(trait.getValue()));
             });
 
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ImportDeclarations.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ImportDeclarations.java
@@ -19,6 +19,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
 import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.writer.ImportContainer;
 import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -26,7 +28,7 @@ import software.amazon.smithy.utils.StringUtils;
  * Internal class used for aggregating imports of a file.
  */
 @SmithyInternalApi
-final class ImportDeclarations {
+final class ImportDeclarations implements ImportContainer {
 
     private final Map<String, Map<String, String>> stdlibImports = new TreeMap<>();
     private final Map<String, Map<String, String>> externalImports = new TreeMap<>();
@@ -40,8 +42,15 @@ final class ImportDeclarations {
         this.localNamespace = namespace;
     }
 
-    ImportDeclarations addImport(String namespace, String name) {
-        return addImport(namespace, name, name);
+    @Override
+    public void importSymbol(Symbol symbol, String alias) {
+        if (!symbol.getNamespace().isEmpty() && !symbol.getNamespace().equals(localNamespace)) {
+            if (symbol.getProperty("stdlib", Boolean.class).orElse(false)) {
+                addStdlibImport(symbol.getNamespace(), symbol.getName(), alias);
+            } else {
+                addImport(symbol.getNamespace(), symbol.getName(), alias);
+            }
+        }
     }
 
     ImportDeclarations addImport(String namespace, String name, String alias) {

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/MapGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/MapGenerator.java
@@ -60,8 +60,8 @@ public class MapGenerator implements Runnable {
         var target = model.expectShape(shape.getValue().getTarget());
         var targetSymbol = symbolProvider.toSymbol(target);
 
-        writer.addStdlibImport("Any", "Any", "typing");
-        writer.addStdlibImport("Dict", "Dict", "typing");
+        writer.addStdlibImport("typing", "Any");
+        writer.addStdlibImport("typing", "Dict");
         writer.openBlock("def $L(given: $T) -> Dict[str, Any]:", "", asDictSymbol.getName(), symbol, () -> {
             if (target.isUnionShape() || target.isStructureShape()) {
                 writer.write("return {k: v.as_dict() for k, v in given.items()}");
@@ -78,8 +78,8 @@ public class MapGenerator implements Runnable {
         var target = model.expectShape(shape.getValue().getTarget());
         var targetSymbol = symbolProvider.toSymbol(target);
 
-        writer.addStdlibImport("Any", "Any", "typing");
-        writer.addStdlibImport("Dict", "Dict", "typing");
+        writer.addStdlibImport("typing", "Any");
+        writer.addStdlibImport("typing", "Dict");
         writer.openBlock("def $L(given: Dict[str, Any]) -> $T:", "", fromDictSymbol.getName(), symbol, () -> {
             if (target.isUnionShape() || target.isStructureShape()) {
                 writer.write("return {k: $T.from_dict(v) for k, v in given.items()}");

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
@@ -88,8 +88,8 @@ final class StructureGenerator implements Runnable {
      * Renders a normal, non-error structure.
      */
     private void renderStructure() {
-        writer.addStdlibImport("Dict", "Dict", "typing");
-        writer.addStdlibImport("Any", "Any", "typing");
+        writer.addStdlibImport("typing", "Dict");
+        writer.addStdlibImport("typing", "Any");
         var symbol = symbolProvider.toSymbol(shape);
         writer.openBlock("class $L:", "", symbol.getName(), () -> {
             writeInit(false);
@@ -100,9 +100,9 @@ final class StructureGenerator implements Runnable {
     }
 
     private void renderError() {
-        writer.addStdlibImport("Dict", "Dict", "typing");
-        writer.addStdlibImport("Any", "Any", "typing");
-        writer.addStdlibImport("Literal", "Literal", "typing");
+        writer.addStdlibImport("typing", "Dict");
+        writer.addStdlibImport("typing", "Any");
+        writer.addStdlibImport("typing", "Literal");
         // TODO: Implement protocol-level customization of the error code
         var code = shape.getId().getName();
         var symbol = symbolProvider.toSymbol(shape);
@@ -140,7 +140,7 @@ final class StructureGenerator implements Runnable {
             for (MemberShape member : optionalMembers) {
                 var memberName = symbolProvider.toMemberName(member);
                 if (nullableIndex.isNullable(member)) {
-                    writer.addStdlibImport("Optional", "Optional", "typing");
+                    writer.addStdlibImport("typing", "Optional");
                     String formatString = format("$L: Optional[%s] = None,", getTargetFormat(member));
                     writer.write(formatString, memberName, symbolProvider.toSymbol(member));
                 } else {
@@ -169,7 +169,7 @@ final class StructureGenerator implements Runnable {
 
     private void writeClassDocs(boolean isError) {
         if (hasDocs()) {
-            writer.openDocComment(() -> {
+            writer.writeDocs(() -> {
                 shape.getTrait(DocumentationTrait.class).ifPresent(trait -> {
                     writer.write(writer.formatDocs(trait.getValue()));
                 });
@@ -250,7 +250,7 @@ final class StructureGenerator implements Runnable {
 
     private void writeAsDict(boolean isError) {
         writer.openBlock("def as_dict(self) -> Dict[str, Any]:", "", () -> {
-            writer.openDocComment(() -> {
+            writer.writeDocs(() -> {
                 writer.write("Converts the $L to a dictionary.\n", symbolProvider.toSymbol(shape).getName());
                 writer.write(writer.formatDocs("""
                         The dictionary uses the modeled shape names rather than the parameter names \
@@ -318,7 +318,7 @@ final class StructureGenerator implements Runnable {
         writer.write("@staticmethod");
         var shapeName = symbolProvider.toSymbol(shape).getName();
         writer.openBlock("def from_dict(d: Dict[str, Any]) -> $S:", "", shapeName, () -> {
-            writer.openDocComment(() -> {
+            writer.writeDocs(() -> {
                 writer.write("Creates a $L from a dictionary.\n", shapeName);
                 writer.write(writer.formatDocs("""
                         The dictionary is expected to use the modeled shape names rather \

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/UnionGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/UnionGenerator.java
@@ -54,8 +54,8 @@ final class UnionGenerator implements Runnable {
     @Override
     public void run() {
         var parentName = symbolProvider.toSymbol(shape).getName();
-        writer.addStdlibImport("Dict", "Dict", "typing");
-        writer.addStdlibImport("Any", "Any", "typing");
+        writer.addStdlibImport("typing", "Dict");
+        writer.addStdlibImport("typing", "Any");
 
         var memberNames = new ArrayList<String>();
         for (MemberShape member : shape.members()) {
@@ -65,7 +65,7 @@ final class UnionGenerator implements Runnable {
 
             writer.openBlock("class $L():", "", memberName, () -> {
                 member.getMemberTrait(model, DocumentationTrait.class).ifPresent(trait -> {
-                    writer.openDocComment(() -> writer.write(trait.getValue()));
+                    writer.writeDocs(trait.getValue());
                 });
                 writer.openBlock("def __init__(self, value: $T):", "", memberSymbol, () -> {
                     writer.write("self.value = value");
@@ -131,7 +131,7 @@ final class UnionGenerator implements Runnable {
         memberNames.add(parentName + "Unknown");
 
         shape.getTrait(DocumentationTrait.class).ifPresent(trait -> writer.writeComment(trait.getValue()));
-        writer.addStdlibImport("Union", "Union", "typing");
+        writer.addStdlibImport("typing", "Union");
         writer.write("$L = Union[$L]", parentName, String.join(", ", memberNames));
 
         writeGlobalFromDict();


### PR DESCRIPTION
This refactors the `PythonWriter` to implement `CodegenWriter`, which handles a lot of the dependency management mess.

As part of this, I changed a few existing interfaces. Namely I made the `importStdLibDependency` use a more consistent argument layout, and updated existing calls of it to use the two argument form where possible (which was all cases).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
