### PR TITLE
Add request multiplexer

### DIFF
--- a/designs/ssdk.md
+++ b/designs/ssdk.md
@@ -125,7 +125,7 @@ service: ExampleService[Context] = ExampleService()
 
 class Context(TypedDict):
     foo: str
-    
+
 [...]
 
 app = SimpleContextMiddleware(service, lambda scope: {"foo": scope["type"]})

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 black==21.11b1
 flake8<3.10
-mypy<1.0
+-e git+git://github.com/python/mypy.git@9b3147701f054bf8ef42bd96e33153b05976a5e1#egg=mypy
 pytest<6.3
 pytest-asyncio<0.16.0
 pytest-cov<3.1

--- a/smithy_python/mux.py
+++ b/smithy_python/mux.py
@@ -1,0 +1,215 @@
+import functools
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from smithy_python.interfaces.http import Request
+
+# Represents an operation name
+OP = TypeVar("OP")
+
+# Represents a service name
+S = TypeVar("S")
+
+
+@dataclass()
+class ServiceCoordinate(Generic[S, OP]):
+    """Identifies an operation on a service."""
+
+    service: S
+    operation: OP
+
+
+@dataclass()
+class PathLiteralSegment:
+    """Represents a path segment that has a static value."""
+
+    value: str
+
+
+@dataclass()
+class PathLabelSegment:
+    """Represents a path segment that has a single variable value."""
+
+
+@dataclass()
+class PathGreedySegment:
+    """Represents one or more path segments with variable values."""
+
+
+PathSegment = PathLiteralSegment | PathLabelSegment | PathGreedySegment
+
+
+@dataclass()
+class QueryLiteralSegment:
+    """Represents a query key with a static value."""
+
+    key: str
+    value: str | None
+
+
+@dataclass()
+class QueryValueSegment:
+    """Represents a query key with a variable value."""
+
+    key: str
+
+
+QuerySegment = QueryLiteralSegment | QueryValueSegment
+
+
+@functools.total_ordering
+class UriSpec(Generic[S, OP]):
+    _EMPTY_PATHS = ("", "/")
+
+    def __init__(
+        self,
+        target: ServiceCoordinate[S, OP],
+        method: str = "GET",
+        path_segments: list[PathSegment] | None = None,
+        query_segments: list[QuerySegment] | None = None,
+    ):
+        """Represents the conditions to identify a single operation.
+
+        :param target: The service and operation that this spec targets.
+        :param method: The expected HTTP method for the operation.
+        :param path_segments: A list of the expected path segments for the operation.
+        :param query_segments: A list of the expected query segments for the operation.
+        """
+        self._method = method
+        self._path_segments = path_segments or []
+        self._query_segments = query_segments or []
+        self._rank = len(self._path_segments) + len(self._query_segments)
+        self._target = target
+
+    @property
+    def target(self) -> ServiceCoordinate[S, OP]:
+        """Returns the target service and operation for the spec."""
+        return self._target
+
+    def match(self, request: Request) -> bool:
+        """Determines whether a given request satisfies the operation's spec.
+
+        :param request: The request to inspect.
+        :return: True if the request matches the operation's spec.
+        """
+        if request.method != self._method:
+            return False
+
+        if request.url.path in self._EMPTY_PATHS:
+            # Both of these cases would produce [''] after a split, which isn't
+            # what we want because they both represent the 0 segment case.
+            request_path_segments = []
+        else:
+            request_path_segments = request.url.path.strip("/").split("/")
+
+        request_path_index = 0
+        for i, segment in enumerate(self._path_segments):
+            if request_path_index >= len(request_path_segments):
+                return False
+
+            path_segment = request_path_segments[request_path_index]
+            match segment:
+                case PathLiteralSegment():
+                    if segment.value != path_segment:
+                        return False
+                    request_path_index += 1
+                case PathLabelSegment():
+                    request_path_index += 1
+                case PathGreedySegment():
+                    # Greedy labels can consume any number of segments, so we can just
+                    # immediately advance to the last X segments of the request, where
+                    # X is the number of defined segments remaining.
+                    remaining_segments = len(self._path_segments) - i - 1
+                    new_path_index = len(request_path_segments) - remaining_segments
+                    if new_path_index == request_path_index:
+                        # Greedy labels must consume at least one segment.
+                        return False
+                    request_path_index = new_path_index
+
+        if request_path_index < len(request_path_segments):
+            # We have no more defined path segments, but still have segments left in
+            # the URI.
+            return False
+
+        if len(self._query_segments) == 0:
+            return True
+
+        if len(request.url.query_params) == 0:
+            return False
+
+        query_map = self._get_query_map(request.url.query_params)
+        for query_segment in self._query_segments:
+            if query_segment.key not in query_map:
+                return False
+
+            if isinstance(query_segment, QueryLiteralSegment):
+                # Convert any None's to empty strings. A protocol could
+                # theoretically treat them differently, but for now we don't.
+                segment_value = query_segment.value or ""
+                query_value = query_map[query_segment.key] or ""
+                if segment_value != query_value:
+                    return False
+
+        return True
+
+    # Ideally this should go on the request object and be cached
+    def _get_query_map(
+        self, query_list: list[tuple[str, str]]
+    ) -> dict[str, str | None | list[str | None]]:
+        """Creates a map of query key to value or values from a list of tuples.
+
+        If a key appears more than once, the value inherently becomes a list.
+
+        :param query_list: A list of tuples where the first value is the query key and
+            the second is the query value.
+        :return: A map of query keys to values.
+        """
+        query_map: dict[str, str | None | list[str | None]] = {}
+        for entry in query_list:
+            if entry[0] in query_map:
+                # The key is already present, so the value must be or become a list.
+                former = query_map[entry[0]]
+                if isinstance(former, list):
+                    former.append(entry[1])
+                else:
+                    query_map[entry[0]] = [former, entry[1]]
+
+            query_map[entry[0]] = entry[1]
+
+        return query_map
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, UriSpec):
+            return NotImplemented
+        return all(
+            [
+                self._method == other._method,
+                self._target == other.target,
+                self._path_segments == other._path_segments,
+                self._query_segments == other._query_segments,
+            ]
+        )
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, UriSpec):
+            return NotImplemented
+        return self._rank < other._rank
+
+
+class HttpBindingMux(Generic[S, OP]):
+    def __init__(self, specs: Iterable[UriSpec[S, OP]]):
+        """
+        Contains the specs for every operation in a service and handles matching
+        requests against them.
+
+        :param specs: An iterable containing one UriSpec for each operation in the
+            service.
+        """
+        self._specs: list[UriSpec[S, OP]] = sorted(specs)
+
+    def match(self, request: Request) -> ServiceCoordinate[S, OP] | None:
+        for spec in self._specs:
+            if spec.match(request):
+                return spec.target
+        return None

--- a/tests/unit/test_mux.py
+++ b/tests/unit/test_mux.py
@@ -1,0 +1,333 @@
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+import pytest
+
+from smithy_python.interfaces.http import URL, HeadersList, Request
+from smithy_python.mux import (
+    HttpBindingMux,
+    PathGreedySegment,
+    PathLabelSegment,
+    PathLiteralSegment,
+    QueryLiteralSegment,
+    QueryValueSegment,
+    ServiceCoordinate,
+    UriSpec,
+)
+
+
+@dataclass(init=False)
+class TestURL:
+    path: str
+    query_params: list[tuple[str, str]]
+    scheme: str = "https"
+    hostname: str = "com.example"
+    port: int | None = None
+
+    def __init__(self, path: str = "/", query: list[tuple[str, str]] | None = None):
+        self.path = path
+        self.query_params = query or []
+
+
+@dataclass(init=False)
+class TestRequest:
+    url: URL
+    method: str
+    headers: HeadersList
+    body: Any
+
+    def __init__(self, method: str = "GET", url: URL | None = None):
+        self.headers = []
+        self.method = method
+        self.url = url or TestURL()
+        self.body = None
+
+
+class TestUriSpec:
+    coordinate = ServiceCoordinate("MyService", "MyOperation")
+
+    def test_matches_method(self) -> None:
+        spec = UriSpec(self.coordinate, "GET")
+        assert spec.match(TestRequest("GET"))
+        assert not spec.match(TestRequest("PUT"))
+
+    def test_matches_path_literal(self) -> None:
+        spec = UriSpec(
+            target=self.coordinate, path_segments=[PathLiteralSegment("foo")]
+        )
+        assert spec.match(TestRequest(url=TestURL("/foo")))
+        assert not spec.match(TestRequest(url=TestURL("/bar")))
+        assert not spec.match(TestRequest(url=TestURL("/")))
+        assert not spec.match(TestRequest(url=TestURL("")))
+        assert not spec.match(TestRequest(url=TestURL("/foo/bar")))
+
+    def test_handles_leading_and_trailing_slashes(self) -> None:
+        spec = UriSpec(
+            target=self.coordinate, path_segments=[PathLiteralSegment("foo")]
+        )
+        assert spec.match(TestRequest(url=TestURL("foo")))
+        assert spec.match(TestRequest(url=TestURL("/foo")))
+        assert spec.match(TestRequest(url=TestURL("/foo/")))
+        assert spec.match(TestRequest(url=TestURL("foo/")))
+
+    def test_matches_path_label(self) -> None:
+        spec = UriSpec(target=self.coordinate, path_segments=[PathLabelSegment()])
+        assert spec.match(TestRequest(url=TestURL("/foo")))
+        assert spec.match(TestRequest(url=TestURL("/bar")))
+        assert not spec.match(TestRequest(url=TestURL("/")))
+        assert not spec.match(TestRequest(url=TestURL("/foo/bar")))
+
+    def test_matches_greedy_label(self) -> None:
+        spec = UriSpec(target=self.coordinate, path_segments=[PathGreedySegment()])
+        assert spec.match(TestRequest(url=TestURL("/foo")))
+        assert spec.match(TestRequest(url=TestURL("/foo/bar")))
+        assert spec.match(TestRequest(url=TestURL("/foo/bar/baz")))
+        assert not spec.match(TestRequest(url=TestURL("/")))
+
+    def test_matches_segment_after_greedy_label(self) -> None:
+        spec = UriSpec(
+            target=self.coordinate,
+            path_segments=[PathGreedySegment(), PathLiteralSegment("spam")],
+        )
+        assert spec.match(TestRequest(url=TestURL("/foo/spam")))
+        assert spec.match(TestRequest(url=TestURL("/foo/bar/spam")))
+        assert spec.match(TestRequest(url=TestURL("/foo/bar/baz/spam")))
+        assert not spec.match(TestRequest(url=TestURL("/foo/bar")))
+
+    def test_matches_query_literal(self) -> None:
+        spec = UriSpec(
+            target=self.coordinate, query_segments=[QueryLiteralSegment("foo", "bar")]
+        )
+        assert spec.match(TestRequest(url=TestURL(query=[("foo", "bar")])))
+        assert not spec.match(TestRequest(url=TestURL(query=[("foo", "baz")])))
+        assert not spec.match(TestRequest(url=TestURL(query=[("foo", "")])))
+        assert not spec.match(
+            TestRequest(url=TestURL(query=[("foo", "bar"), ("foo", "baz")]))
+        )
+
+    def test_matches_query_literal_with_empty_value(self) -> None:
+        spec = UriSpec(
+            target=self.coordinate, query_segments=[QueryLiteralSegment("foo", "")]
+        )
+        assert spec.match(TestRequest(url=TestURL(query=[("foo", "")])))
+        assert not spec.match(TestRequest(url=TestURL(query=[("foo", "bar")])))
+        assert not spec.match(
+            TestRequest(url=TestURL(query=[("foo", ""), ("foo", "bar")]))
+        )
+
+    def test_matches_query_literal_with_null_value(self) -> None:
+        spec = UriSpec(
+            target=self.coordinate, query_segments=[QueryLiteralSegment("foo", None)]
+        )
+        assert spec.match(TestRequest(url=TestURL(query=[("foo", "")])))
+        assert not spec.match(TestRequest(url=TestURL(query=[("foo", "bar")])))
+        assert not spec.match(
+            TestRequest(url=TestURL(query=[("foo", ""), ("foo", "bar")]))
+        )
+
+    def test_matches_query_value(self) -> None:
+        spec = UriSpec(
+            target=self.coordinate, query_segments=[QueryValueSegment("foo")]
+        )
+        assert spec.match(TestRequest(url=TestURL(query=[("foo", "")])))
+        assert spec.match(TestRequest(url=TestURL(query=[("foo", "bar")])))
+        assert spec.match(TestRequest(url=TestURL(query=[("foo", "baz")])))
+        assert spec.match(
+            TestRequest(url=TestURL(query=[("foo", "bar"), ("foo", "baz")]))
+        )
+
+    def test_matches_multiple_query(self) -> None:
+        spec = UriSpec(
+            target=self.coordinate,
+            query_segments=[
+                QueryLiteralSegment("spam", "eggs"),
+                QueryValueSegment("foo"),
+            ],
+        )
+        assert spec.match(
+            TestRequest(url=TestURL(query=[("spam", "eggs"), ("foo", "bar")]))
+        )
+        assert not spec.match(TestRequest(url=TestURL(query=[("spam", "eggs")])))
+        assert not spec.match(
+            TestRequest(url=TestURL(query=[("spam", "wrong"), ("foo", "bar")]))
+        )
+
+    def test_matches_path_and_query(self) -> None:
+        spec = UriSpec(
+            target=self.coordinate,
+            path_segments=[PathLiteralSegment("foo")],
+            query_segments=[QueryLiteralSegment("spam", "eggs")],
+        )
+        assert spec.match(
+            TestRequest(url=TestURL(path="/foo", query=[("spam", "eggs")]))
+        )
+        assert not spec.match(
+            TestRequest(url=TestURL(path="/bar", query=[("spam", "eggs")]))
+        )
+        assert not spec.match(
+            TestRequest(url=TestURL(path="/foo", query=[("spam", "wrong")]))
+        )
+
+
+TEST_SERVICE = Literal["Test"]
+TEST_OPERATIONS = Literal[
+    "A", "LessSpecificA", "Greedy", "MiddleGreedy", "Delete", "QueryKeyOnly"
+]
+
+
+def _coordinate(o: TEST_OPERATIONS) -> ServiceCoordinate[TEST_SERVICE, TEST_OPERATIONS]:
+    return ServiceCoordinate(cast(TEST_SERVICE, "Test"), o)
+
+
+@pytest.fixture()
+def mux_fixture() -> HttpBindingMux[TEST_SERVICE, TEST_OPERATIONS]:
+    return HttpBindingMux(
+        [
+            UriSpec(
+                _coordinate("A"),
+                path_segments=[
+                    PathLiteralSegment("a"),
+                    PathLabelSegment(),
+                    PathLabelSegment(),
+                ],
+            ),
+            UriSpec(
+                _coordinate("LessSpecificA"),
+                path_segments=[
+                    PathLiteralSegment("a"),
+                    PathLabelSegment(),
+                    PathGreedySegment(),
+                ],
+            ),
+            UriSpec(
+                _coordinate("Greedy"),
+                path_segments=[PathLiteralSegment("greedy"), PathGreedySegment()],
+            ),
+            UriSpec(
+                _coordinate("MiddleGreedy"),
+                path_segments=[
+                    PathLiteralSegment("mg"),
+                    PathGreedySegment(),
+                    PathLiteralSegment("y"),
+                    PathLiteralSegment("z"),
+                ],
+            ),
+            UriSpec(
+                _coordinate("Delete"),
+                method="DELETE",
+                query_segments=[
+                    QueryLiteralSegment("foo", "bar"),
+                    QueryValueSegment("baz"),
+                ],
+            ),
+            UriSpec(
+                _coordinate("QueryKeyOnly"),
+                path_segments=[PathLiteralSegment("query_key_only")],
+                query_segments=[QueryLiteralSegment("foo", "")],
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    ["expected_operation", "req"],
+    [
+        ("LessSpecificA", TestRequest(url=TestURL(path="/a/b/c/d"))),
+        ("LessSpecificA", TestRequest(url=TestURL(path="/a/b/c/d/e"))),
+        ("A", TestRequest(url=TestURL(path="/a/b/c"))),
+        ("A", TestRequest(url=TestURL(path="/a/b/c/"))),
+        ("A", TestRequest(url=TestURL(path="/a/b/c", query=[("abc", "def")]))),
+        ("A", TestRequest(url=TestURL(path="/a/b/c", query=[("abc", "")]))),
+        ("Greedy", TestRequest(url=TestURL(path="/greedy/a/b/c/d"))),
+        (
+            "Greedy",
+            TestRequest(url=TestURL(path="/greedy/a/b/c/d", query=[("abc", "def")])),
+        ),
+        ("MiddleGreedy", TestRequest(url=TestURL(path="/mg/a/x/y/z"))),
+        (
+            "MiddleGreedy",
+            TestRequest(url=TestURL(path="/mg/a/b/c/d/y/z", query=[("abc", "def")])),
+        ),
+        (
+            "MiddleGreedy",
+            TestRequest(url=TestURL(path="/mg/a/b/y/c/d/y/z", query=[("abc", "def")])),
+        ),
+        (
+            "MiddleGreedy",
+            TestRequest(url=TestURL(path="/mg/a/b/y/z/d/y/z", query=[("abc", "def")])),
+        ),
+        (
+            "Delete",
+            TestRequest(
+                method="DELETE", url=TestURL(query=[("foo", "bar"), ("baz", "quux")])
+            ),
+        ),
+        # TODO: is this right?
+        # (
+        #     "Delete",
+        #     TestRequest(
+        #         method="DELETE",
+        #         url=TestURL(query=[("foo", "bar"), ("foo", "corge"), ("baz", "quux")]),
+        #     ),
+        # ),
+        (
+            "Delete",
+            TestRequest(
+                method="DELETE", url=TestURL(query=[("foo", "bar"), ("baz", "")])
+            ),
+        ),
+        (
+            "Delete",
+            TestRequest(
+                method="DELETE",
+                url=TestURL(query=[("foo", "bar"), ("baz", "quux"), ("baz", "grault")]),
+            ),
+        ),
+        # TODO: is this right?
+        # (
+        #     "QueryKeyOnly",
+        #     TestRequest(url=TestURL(path="/query_key_only", query=[("foo", "bar")])),
+        # ),
+        (
+            "QueryKeyOnly",
+            TestRequest(url=TestURL(path="/query_key_only", query=[("foo", "")])),
+        ),
+    ],
+)
+def test_mux_match(
+    mux_fixture: HttpBindingMux[TEST_SERVICE, TEST_OPERATIONS],
+    expected_operation: TEST_OPERATIONS,
+    req: Request,
+) -> None:
+    match = mux_fixture.match(req)
+    assert match and match.operation == expected_operation
+
+
+@pytest.mark.parametrize(
+    "req",
+    [
+        TestRequest(method="POST", url=TestURL(path="/a/b/c")),
+        TestRequest(method="PUT", url=TestURL(path="/a/b/c")),
+        TestRequest(method="PATCH", url=TestURL(path="/a/b/c")),
+        TestRequest(method="OPTIONS", url=TestURL(path="/a/b/c")),
+        TestRequest(url=TestURL(path="/a")),
+        TestRequest(url=TestURL(path="/a/b")),
+        TestRequest(url=TestURL(path="/greedy")),
+        TestRequest(url=TestURL(path="/greedy/")),
+        TestRequest(url=TestURL(path="/mg")),
+        TestRequest(url=TestURL(path="/mg/q")),
+        TestRequest(url=TestURL(path="/mg/z")),
+        TestRequest(url=TestURL(path="/mg/y/z")),
+        TestRequest(url=TestURL(path="/mg/a/z")),
+        TestRequest(url=TestURL(path="/mg/a/y/z/a")),
+        TestRequest(url=TestURL(path="/mg/a/y/a")),
+        TestRequest(url=TestURL(path="/mg/a/b/z/c")),
+        TestRequest(method="DELETE", url=TestURL(query=[("foo", "bar")])),
+        TestRequest(method="DELETE", url=TestURL(query=[("baz", "quux")])),
+        TestRequest(method="DELETE"),
+    ],
+)
+def test_mux_miss(
+    mux_fixture: HttpBindingMux[TEST_SERVICE, TEST_OPERATIONS], req: Request
+) -> None:
+    assert not mux_fixture.match(req)


### PR DESCRIPTION
This adds in a fairly simple request multiplexer to be used for SSDKs. Since it's using match, I pinned us to a a version of mypy that supports it. Hopefully they actually cut a release sometime soon.

This code will ideally go in a separate package that only the ssdks depend on, but for the sake of having a legible PR I put the code here until a plan for handling multiple packages is settled on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
