### PR TITLE
Bump minimum smithy version to 1.18

### DIFF
--- a/codegen/smithy-python-codegen/build.gradle.kts
+++ b/codegen/smithy-python-codegen/build.gradle.kts
@@ -18,6 +18,6 @@ extra["displayName"] = "Smithy :: Python :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.python.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:[1.16.0,2.0.0[")
-    implementation("software.amazon.smithy:smithy-waiters:[1.16.0,2.0.0[")
+    api("software.amazon.smithy:smithy-codegen-core:[1.18.0,2.0.0[")
+    implementation("software.amazon.smithy:smithy-waiters:[1.18.0,2.0.0[")
 }


### PR DESCRIPTION
The new version of smithy includes a lot of scaffolding that we'll no longer need to do. This just bumps the minimum version so we can safely use it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
