### PR TITLE
Typed documents

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SetupGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SetupGenerator.java
@@ -129,6 +129,10 @@ final class SetupGenerator {
                     strict = True
                     warn_unused_configs = True
 
+                    # This should be removable after mypy 0.990, it's needed to allow the document
+                    # alias to successfully be checked.
+                    enable_recursive_aliases = true
+
                     [mypy-awscrt]
                     ignore_missing_imports = True
 

--- a/designs/shapes.md
+++ b/designs/shapes.md
@@ -22,11 +22,11 @@ are generated into python types and type hints from a Smithy model.
 | bigInteger | int |
 | bigDecimal | decimal.Decimal |
 | timestamp | datetime.datetime |
-| document | Any* |
+| document | Document* = dict[str, 'Document'] | list['Document'] | str | int | float | bool | None |
 
-*Documents aren't easily representable in Python type hints due to a lack of
-support for recursive definitions. See [this issue](https://github.com/python/typing/issues/182)
-on the typing repo for more details.
+*Mypy only has experimental support for recursive definitions, but it should be on by default by 0.990.
+See [this issue](https://github.com/python/typing/issues/182) on the typing repo for more details. In
+the meantime we can use a flag to turn it on.
 
 ## Trait-influenced shapes
 
@@ -132,11 +132,11 @@ appear in every referencing structure.
 
 ### intEnums
 
-```python```
+```python
 class MyIntEnum(IntEnum):
     SPAM = 1
     EGGS = 2
-``````
+```
 
 IntEnums will use the native `IntEnum` type. This will allow customers to
 easily specify the enum value without having to reference the actual number. It

--- a/lockfiles/mypy
+++ b/lockfiles/mypy
@@ -9,41 +9,12 @@
 #     "CPython>=3.10"
 #   ],
 #   "generated_with_requirements": [
-#     "mypy==0.950"
+#     "mypy==0.982"
 #   ]
 # }
 # --- END PANTS LOCKFILE METADATA ---
 
-mypy-extensions==0.4.3; python_version >= "3.6" \
-    --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
-    --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
-mypy==0.950; python_version >= "3.6" \
-    --hash=sha256:cf9c261958a769a3bd38c3e133801ebcd284ffb734ea12d01457cb09eacf7d7b \
-    --hash=sha256:b5b5bd0ffb11b4aba2bb6d31b8643902c48f990cc92fda4e21afac658044f0c0 \
-    --hash=sha256:5e7647df0f8fc947388e6251d728189cfadb3b1e558407f93254e35abc026e22 \
-    --hash=sha256:eaff8156016487c1af5ffa5304c3e3fd183edcb412f3e9c72db349faf3f6e0eb \
-    --hash=sha256:563514c7dc504698fb66bb1cf897657a173a496406f1866afae73ab5b3cdb334 \
-    --hash=sha256:dd4d670eee9610bf61c25c940e9ade2d0ed05eb44227275cce88701fee014b1f \
-    --hash=sha256:ca75ecf2783395ca3016a5e455cb322ba26b6d33b4b413fcdedfc632e67941dc \
-    --hash=sha256:6003de687c13196e8a1243a5e4bcce617d79b88f83ee6625437e335d89dfebe2 \
-    --hash=sha256:4c653e4846f287051599ed8f4b3c044b80e540e88feec76b11044ddc5612ffed \
-    --hash=sha256:e19736af56947addedce4674c0971e5dceef1b5ec7d667fe86bcd2b07f8f9075 \
-    --hash=sha256:ef7beb2a3582eb7a9f37beaf38a28acfd801988cde688760aea9e6cc4832b10b \
-    --hash=sha256:0112752a6ff07230f9ec2f71b0d3d4e088a910fdce454fdb6553e83ed0eced7d \
-    --hash=sha256:ee0a36edd332ed2c5208565ae6e3a7afc0eabb53f5327e281f2ef03a6bc7687a \
-    --hash=sha256:77423570c04aca807508a492037abbd72b12a1fb25a385847d191cd50b2c9605 \
-    --hash=sha256:5ce6a09042b6da16d773d2110e44f169683d8cc8687e79ec6d1181a72cb028d2 \
-    --hash=sha256:5b231afd6a6e951381b9ef09a1223b1feabe13625388db48a8690f8daa9b71ff \
-    --hash=sha256:0384d9f3af49837baa92f559d3fa673e6d2652a16550a9ee07fc08c736f5e6f8 \
-    --hash=sha256:1fdeb0a0f64f2a874a4c1f5271f06e40e1e9779bf55f9567f149466fc7a55038 \
-    --hash=sha256:61504b9a5ae166ba5ecfed9e93357fd51aa693d3d434b582a925338a2ff57fd2 \
-    --hash=sha256:a952b8bc0ae278fc6316e6384f67bb9a396eb30aced6ad034d3a76120ebcc519 \
-    --hash=sha256:eaea21d150fb26d7b4856766e7addcf929119dd19fc832b22e71d942835201ef \
-    --hash=sha256:a4d9898f46446bfb6405383b57b96737dcfd0a7f25b748e78ef3e8c576bba3cb \
-    --hash=sha256:1b333cfbca1762ff15808a0ef4f71b5d3eed8528b23ea1c3fb50543c867d68de
-tomli==2.0.1; python_version < "3.11" and python_version >= "3.7" \
-    --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
-    --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
-typing-extensions==4.2.0; python_version >= "3.7" \
-    --hash=sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708 \
-    --hash=sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376
+mypy-extensions==0.4.3; python_version >= "3.7"
+mypy==0.982; python_version >= "3.7"
+tomli==2.0.1; python_version < "3.11" and python_version >= "3.7"
+typing-extensions==4.4.0; python_version >= "3.7"

--- a/pants.toml
+++ b/pants.toml
@@ -37,7 +37,7 @@ interpreter_constraints = [">=3.10"]
 report = "xml"
 
 [mypy]
-version = "mypy==0.950"
+version = "mypy==0.982"
 lockfile = "lockfiles/mypy"
 interpreter_constraints = [">=3.10"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ src_paths = ["smithy_python", "tests"]
 strict = true
 warn_unused_configs = true
 
+# This should be removable after mypy 0.990, it's needed to allow the document
+# alias to successfully be checked.
+enable_recursive_aliases = true
+
 [[tool.mypy.overrides]]
 module = ["awscrt", "pytest"]
 ignore_missing_imports = true

--- a/python-packages/smithy-python/pyproject.toml
+++ b/python-packages/smithy-python/pyproject.toml
@@ -10,6 +10,10 @@ src_paths = ["smithy_python", "tests"]
 strict = true
 warn_unused_configs = true
 
+# This should be removable after mypy 0.990, it's needed to allow the document
+# alias to successfully be checked.
+enable_recursive_aliases = true
+
 [[tool.mypy.overrides]]
 module = ["awscrt", "pytest"]
 ignore_missing_imports = true

--- a/python-packages/smithy-python/smithy_python/types.py
+++ b/python-packages/smithy-python/smithy_python/types.py
@@ -1,0 +1,5 @@
+from typing import TypeAlias
+
+Document: TypeAlias = (
+    dict[str, "Document"] | list["Document"] | str | int | float | bool | None
+)


### PR DESCRIPTION
~~This PR depends on #53, only the latest commit contains new changes.~~

mypy finally has support for recursive type definitions so we can finally have a good type for documents. It's locked behind a flag until 0.990 or so, but we can set that in the config files until then.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
