### PR TITLE
Update HTTP client interfaces

### DIFF
--- a/python-packages/smithy-python/smithy_python/interfaces/http.py
+++ b/python-packages/smithy-python/smithy_python/interfaces/http.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, Optional, Protocol
 
 # Defining headers as a list instead of a mapping to avoid ambiguity and
@@ -26,11 +27,30 @@ class Response(Protocol):
     body: Any
 
 
-class Session(Protocol):
-    def send(self, request: Request) -> Response:
-        pass  # pragma: no cover
+@dataclass(kw_only=True)
+class HttpRequestConfiguration:
+    """Request-level HTTP configuration.
+
+    :param read_timeout: How long, in seconds, the client will attempt to read the
+    first byte over an established, open connection before timing out.
+    """
+
+    read_timeout: float | None = None
 
 
-class AsyncSession(Protocol):
-    async def send(self, request: Request) -> Response:
-        pass  # pragma: no cover
+class HttpClient(Protocol):
+    """A synchronous HTTP client interface."""
+
+    def send(
+        self, request: Request, request_config: HttpRequestConfiguration
+    ) -> Response:
+        pass
+
+
+class AsyncHttpClient(Protocol):
+    """An asynchronous HTTP client interface."""
+
+    async def send(
+        self, request: Request, request_config: HttpRequestConfiguration
+    ) -> Response:
+        pass


### PR DESCRIPTION
This updates the HTTP client interface classes to add request-level configuration. It also renames them to be more consistent with how we talk about them.

In the future we're also going to have to provide actual implementations for these, including ensuring we have as much control over connections and such as possible. But for now we just need to have usable targets for code generation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
