### PR TITLE
Move pre-shape-generation steps to dedicated hook

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=[1.26.0,1.27.0[
+smithyVersion=[1.26.1,1.27.0[
 smithyGradleVersion=0.6.0

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -56,7 +56,6 @@ public final class CodegenUtils {
     private CodegenUtils() {}
 
     static Symbol getDefaultWrapperFunction(PythonSettings settings) {
-        // TODO: move these into the models file once we can do generation before shapes again
         return Symbol.builder()
                 .name("_default")
                 .namespace(format("%s.models", settings.getModuleName()), ".")
@@ -73,7 +72,6 @@ public final class CodegenUtils {
     }
 
     static Symbol getServiceError(PythonSettings settings) {
-        // TODO: put these back in errors
         return Symbol.builder()
                 .name("ServiceError")
                 .namespace(format("%s.errors", settings.getModuleName()), ".")
@@ -82,7 +80,6 @@ public final class CodegenUtils {
     }
 
     static Symbol getApiError(PythonSettings settings) {
-        // TODO: put these back in errors
         return Symbol.builder()
                 .name("ApiError")
                 .namespace(format("%s.errors", settings.getModuleName()), ".")
@@ -91,7 +88,6 @@ public final class CodegenUtils {
     }
 
     static Symbol getUnknownApiError(PythonSettings settings) {
-        // TODO: put these back in errors
         return Symbol.builder()
                 .name("UnknownApiError")
                 .namespace(format("%s.errors", settings.getModuleName()), ".")

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -59,16 +59,16 @@ public final class CodegenUtils {
         // TODO: move these into the models file once we can do generation before shapes again
         return Symbol.builder()
                 .name("_default")
-                .namespace(format("%s.utils", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/utils.py", settings.getModuleName()))
+                .namespace(format("%s.models", settings.getModuleName()), ".")
+                .definitionFile(format("./%s/models.py", settings.getModuleName()))
                 .build();
     }
 
     static Symbol getDefaultWrapperClass(PythonSettings settings) {
         return Symbol.builder()
                 .name("_DEFAULT")
-                .namespace(format("%s.utils", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/utils.py", settings.getModuleName()))
+                .namespace(format("%s.models", settings.getModuleName()), ".")
+                .definitionFile(format("./%s/models.py", settings.getModuleName()))
                 .build();
     }
 
@@ -76,8 +76,8 @@ public final class CodegenUtils {
         // TODO: put these back in errors
         return Symbol.builder()
                 .name("ServiceError")
-                .namespace(format("%s.utils", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/utils.py", settings.getModuleName()))
+                .namespace(format("%s.errors", settings.getModuleName()), ".")
+                .definitionFile(format("./%s/errors.py", settings.getModuleName()))
                 .build();
     }
 
@@ -85,8 +85,8 @@ public final class CodegenUtils {
         // TODO: put these back in errors
         return Symbol.builder()
                 .name("ApiError")
-                .namespace(format("%s.utils", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/utils.py", settings.getModuleName()))
+                .namespace(format("%s.errors", settings.getModuleName()), ".")
+                .definitionFile(format("./%s/errors.py", settings.getModuleName()))
                 .build();
     }
 
@@ -94,8 +94,8 @@ public final class CodegenUtils {
         // TODO: put these back in errors
         return Symbol.builder()
                 .name("UnknownApiError")
-                .namespace(format("%s.utils", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/utils.py", settings.getModuleName()))
+                .namespace(format("%s.errors", settings.getModuleName()), ".")
+                .definitionFile(format("./%s/errors.py", settings.getModuleName()))
                 .build();
     }
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
@@ -71,9 +71,14 @@ final class DirectedPythonCodegen implements DirectedCodegen<GenerationContext, 
     }
 
     @Override
-    public void generateService(GenerateServiceDirective<GenerationContext, PythonSettings> directive) {
+    public void customizeBeforeShapeGeneration(CustomizeDirective<GenerationContext, PythonSettings> directive) {
         generateDefaultWrapper(directive.settings(), directive.context().writerDelegator());
         generateServiceErrors(directive.settings(), directive.context().writerDelegator());
+    }
+
+    @Override
+    public void generateService(GenerateServiceDirective<GenerationContext, PythonSettings> directive) {
+        // TODO: implement client generation here
     }
 
     private void generateDefaultWrapper(PythonSettings settings, WriterDelegator<PythonWriter> writers) {


### PR DESCRIPTION
We have a few bits of code generation that need to happen before we do the shape code generation. Previously we were leveraging the service generation hook, but then it got moved to being called after the rest of the shapes were generated. We had to move things into temporary locations to make things work, but now there's an explicit hook before shape generation we can use.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
