### PR TITLE
Implement initial protocol test stub generation

### DIFF
--- a/codegen/smithy-python-codegen/build.gradle.kts
+++ b/codegen/smithy-python-codegen/build.gradle.kts
@@ -33,4 +33,5 @@ buildscript {
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.python.codegen;
+
+import java.util.TreeSet;
+import java.util.logging.Logger;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.OperationIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.protocoltests.traits.AppliesTo;
+import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase;
+import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase;
+import software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait;
+import software.amazon.smithy.protocoltests.traits.HttpResponseTestCase;
+import software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait;
+import software.amazon.smithy.utils.CaseUtils;
+
+/**
+ * Generates protocol tests for a given HTTP protocol.
+ *
+ * <p>This should preferably be instantiated and used within an
+ * implementation of a `ProtocolGeneration`
+ */
+final class HttpProtocolTestGenerator implements Runnable {
+
+    private static final Logger LOGGER = Logger.getLogger(HttpProtocolTestGenerator.class.getName());
+
+    private final PythonSettings settings;
+    private final Model model;
+    private final ShapeId protocol;
+    private final ServiceShape service;
+    private final PythonWriter writer;
+    private final GenerationContext context;
+
+    HttpProtocolTestGenerator(
+            GenerationContext context,
+            ShapeId protocol,
+            PythonWriter writer
+    ) {
+        this.settings = context.settings();
+        this.model = context.model();
+        this.protocol = protocol;
+        this.service = settings.getService(model);
+        this.writer = writer;
+        this.context = context;
+    }
+
+    /**
+     * Generates the HTTP-based protocol tests for the given protocol in the model.
+     */
+    @Override
+    public void run() {
+        OperationIndex operationIndex = OperationIndex.of(model);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+
+        // Use a TreeSet to have a fixed ordering of tests.
+        for (OperationShape operation : new TreeSet<>(topDownIndex.getContainedOperations(service))) {
+
+            // TODO: Add settings to configure which tests are generated (client or server)
+            generateOperationTests(AppliesTo.CLIENT, operation, operationIndex);
+        }
+    }
+
+    private void generateOperationTests(
+            AppliesTo implementation,
+            OperationShape operation,
+            OperationIndex operationIndex) {
+
+        // Request Tests
+        operation.getTrait(HttpRequestTestsTrait.class).ifPresent(trait -> {
+            for (HttpRequestTestCase testCase : trait.getTestCasesFor(implementation)) {
+                onlyIfProtocolMatches(testCase, () -> generateRequestTest(testCase));
+            }
+        });
+
+        // Response Tests
+        operation.getTrait(HttpResponseTestsTrait.class).ifPresent(trait -> {
+            for (HttpResponseTestCase testCase : trait.getTestCasesFor(implementation)) {
+                onlyIfProtocolMatches(testCase, () -> generateResponseTest(testCase));
+            }
+        });
+
+        // Error Tests
+        // 3. Generate test cases for each error on each operation.
+        for (StructureShape error : operationIndex.getErrors(operation, service)) {
+            if (!error.hasTag("server-only")) {
+                error.getTrait(HttpResponseTestsTrait.class).ifPresent(trait -> {
+                    for (HttpResponseTestCase testCase : trait.getTestCasesFor(implementation)) {
+                        onlyIfProtocolMatches(testCase,
+                                () -> generateErrorResponseTest(operation, error, testCase));
+                    }
+                });
+            }
+        }
+    }
+
+    private void generateRequestTest(HttpRequestTestCase testCase) {
+        // TODO: Generate the real request test logic, add logic for skipping
+        writeTestBlock(testCase, testCase.getId(), false, () -> {
+            writer.write("pass");
+        });
+    }
+
+    private void generateResponseTest(HttpResponseTestCase testCase) {
+        // TODO: Generate the real response test logic, add logic for skipping
+        writeTestBlock(testCase, testCase.getId(), true, () -> {
+            writer.write("pass");
+        });
+    }
+
+    private void generateErrorResponseTest(
+            OperationShape operation,
+            StructureShape error,
+            HttpResponseTestCase testCase) {
+        // TODO: Generate the real error response test logic, add logic for skipping
+        writeTestBlock(testCase,
+                String.format("%s_error_%s", testCase.getId(), operation.getId().getName()),
+                false,
+                () -> {
+            writer.write("pass");
+        });
+    }
+
+    // Only generate test cases when protocol matches the target protocol.
+    private <T extends HttpMessageTestCase> void onlyIfProtocolMatches(T testCase, Runnable runnable) {
+        if (testCase.getProtocol().equals(protocol)) {
+            LOGGER.fine(() -> String.format("Generating protocol test case for %s.%s",
+                    service.getId(),
+                    testCase.getId())
+            );
+            runnable.run();
+        }
+    }
+
+    // write the test block, which may include certain decorators (i.e. `skip`)
+    private void writeTestBlock(
+            HttpMessageTestCase testCase,
+            String testName,
+            boolean shouldSkip,
+            Runnable f
+    ) {
+        LOGGER.fine(String.format("Writing test block for %s", testName));
+
+        // Skipped tests are still generated, just not run.
+        if (shouldSkip) {
+            LOGGER.fine(String.format("Marking test (%s) as skipped.", testName));
+            writer.addDependency(SmithyPythonDependency.PYTEST);
+            writer.addImport(SmithyPythonDependency.PYTEST.packageName(), "mark", "mark");
+            writer.write("@mark.skip()");
+        }
+        writer.openBlock("async def test_$L():", "", CaseUtils.toSnakeCase(testName), () -> {
+            testCase.getDocumentation().ifPresent(writer::writeDocs);
+            f.run();
+        });
+    }
+}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
@@ -173,6 +173,19 @@ public final class PythonWriter extends SymbolWriter<PythonWriter, ImportDeclara
         return this;
     }
 
+    /**
+     * Imports a type using an alias from a module only if necessary.
+     *
+     * @param namespace Module to import the type from.
+     * @param name Type to import.
+     * @param alias The name to import the type as.
+     * @return Returns the writer.
+     */
+    public PythonWriter addImport(String namespace, String name, String alias) {
+        getImportContainer().addImport(namespace, name, alias);
+        return this;
+    }
+
     @Override
     public String toString() {
         String contents = getImportContainer().toString() + super.toString();

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SetupGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SetupGenerator.java
@@ -112,6 +112,9 @@ final class SetupGenerator {
 
                     [tool.black]
                     target-version = ["py311"]
+
+                    [tool.pytest.ini_options]
+                    asyncio_mode = "auto"
                     """);
 
             writer.popState();

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -37,6 +37,16 @@ public final class SmithyPythonDependency {
             true
     );
 
+    /**
+     * testing framework used in generated functional tests.
+     */
+    public static final PythonDependency PYTEST = new PythonDependency(
+            "pytest",
+            ">=7.2.0",
+            Type.TEST_DEPENDENCY,
+            false
+    );
+
     private SmithyPythonDependency() {}
 
     /**


### PR DESCRIPTION
### Description
Test stubs for request/response/response-error tests can be generated using running an instance of `HttpProtocolTestGenerator`. We can use this class within the implementation of a `ProtocolGenerator` to generate a suite of tests for the protocol


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



### Testing
When codegen is ran for the test model (`Weather`), the following is generated:

```python
# Code generated by smithy-python-codegen DO NOT EDIT.

from pytest import mark


async def test_write_get_city_assertions():
    """Does something
    """
    pass

@mark.skip()
async def test_write_get_city_response_assertions():
    """Does something
    """
    pass

async def test_write_no_such_resource_assertions_error_get_city():
    """Does something
    """
    pass

async def test_write_no_such_resource_assertions_error_get_city_announcements():
    """Does something
    """
    pass

async def test_write_no_such_resource_assertions_error_get_city_image():
    """Does something
    """
    pass

async def test_write_list_cities_assertions():
    """Does something
    """
    pass

```

The output includes request/response/error-response protocol tests for the client
> 
```
@mark.skip()
test_write_get_city_response_assertions
```

The test above is skipped due to a `true` value for `shouldSkip`, this is for example only.