### PR TITLE
Change managing team for smithy-python repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add core contributors to all prs by default
-* @awslabs/aws-sdk-python
+* @awslabs/aws-smithy-python


### PR DESCRIPTION
This PR will move from aws-sdk-python@ to aws-smithy-python as the managing group for this repository to allow more granular control.