### PR TITLE
Generate client config

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -55,6 +55,22 @@ public final class CodegenUtils {
 
     private CodegenUtils() {}
 
+    static Symbol getConfigSymbol(PythonSettings settings) {
+        return Symbol.builder()
+                .name("Config")
+                .namespace(format("%s.config", settings.getModuleName()), ".")
+                .definitionFile(format("./%s/config.py", settings.getModuleName()))
+                .build();
+    }
+
+    static Symbol getPluginSymbol(PythonSettings settings) {
+        return Symbol.builder()
+                .name("Plugin")
+                .namespace(format("%s.config", settings.getModuleName()), ".")
+                .definitionFile(format("./%s/config.py", settings.getModuleName()))
+                .build();
+    }
+
     static Symbol getDefaultWrapperFunction(PythonSettings settings) {
         return Symbol.builder()
                 .name("_default")

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigField.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigField.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.python.codegen;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Represents a property to be added to the generated client config object.
+ *
+ * @param name The name of the config field. This MUST be snake_cased.
+ * @param type The type of the config field.
+ * @param isOptional Whether the field is optional or not.
+ * @param documentation Any relevant documentation for the config field.
+ */
+@SmithyUnstableApi
+public record ConfigField(String name, Symbol type, boolean isOptional, String documentation) {
+}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigGenerator.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.python.codegen;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.python.codegen.integration.PythonIntegration;
+import software.amazon.smithy.python.codegen.integration.RuntimeClientPlugin;
+
+/**
+ * Generates the client's config object.
+ */
+final class ConfigGenerator implements Runnable {
+
+    // This list contains any fields that should unconditionally be added to every
+    // config object. This should be as minimal as possible, and importantly should
+    // not contain any HTTP related config since Smithy is transport agnostic.
+    private static final List<ConfigField> BASE_FIELDS = Arrays.asList(
+            new ConfigField(
+                "interceptors",
+                Symbol.builder()
+                        .name("list[Interceptor]")
+                        .addReference(Symbol.builder()
+                                .name("Interceptor")
+                                .namespace("smithy_python.interfaces.interceptor", ".")
+                                .addDependency(SmithyPythonDependency.SMITHY_PYTHON)
+                                .build())
+                        .build(),
+                true,
+                "The list of interceptors, which are hooks that are called during the execution of a request."
+            )
+    );
+
+    private final GenerationContext context;
+
+    ConfigGenerator(GenerationContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void run() {
+        var config = CodegenUtils.getConfigSymbol(context.settings());
+        context.writerDelegator().useFileWriter(
+                config.getDefinitionFile(), config.getNamespace(), this::generateConfig);
+
+        // Generate the plugin symbol. This is just a callable. We could do something
+        // like have a class to implement, but that seems unnecessarily burdensome for
+        // a single function.
+        var plugin = CodegenUtils.getPluginSymbol(context.settings());
+        context.writerDelegator().useFileWriter(plugin.getDefinitionFile(), plugin.getNamespace(), writer -> {
+            writer.addStdlibImport("typing", "Callable");
+            writer.addStdlibImport("typing", "TypeAlias");
+            writer.writeComment("A callable that allows customizing the config object on each request.");
+            writer.write("$L: TypeAlias = Callable[[$T], None]", plugin.getName(), config);
+        });
+    }
+
+    private void generateConfig(PythonWriter writer) {
+        var symbol = CodegenUtils.getConfigSymbol(context.settings());
+
+        // Initialize the list of config fields with our base fields. Here a new
+        // list is constructed because that base list is immutable.
+        var fields = new ArrayList<>(BASE_FIELDS);
+
+        // Add any relevant config fields from plugins.
+        for (PythonIntegration integration : context.integrations()) {
+            for (RuntimeClientPlugin plugin : integration.getClientPlugins()) {
+                fields.addAll(plugin.getConfigFields());
+            }
+        }
+
+        writer.addStdlibImport("dataclasses", "dataclass");
+        writer.write("@dataclass(kw_only=True)");
+        writer.openBlock("class $L:", "", symbol.getName(), () -> {
+            writer.writeDocs(() -> {
+                writer.write("Configuration for $L\n", context.settings().getService().getName());
+
+                // This way of using iterators lets us easily have different behavior for the
+                // last field, namely to not add an extra blank line.
+                var iter = fields.iterator();
+                while (iter.hasNext()) {
+                    // Write out the documentation for the fields.
+                    var field = iter.next();
+                    writer.write(writer.formatDocs(String.format(
+                            ":param %s: %s", field.name(), field.documentation())));
+                    if (iter.hasNext()) {
+                        // Put a blank line between fields, but don't leave one at the end of the doc string.
+                        writer.write("");
+                    }
+                }
+            });
+
+            for (ConfigField field : fields) {
+                var formatString = "$L: $T";
+                if (field.isOptional()) {
+                    // We *could* provide a hook to set a default value, but that's a bit awkward and fraught with
+                    // footgun issues. Instead, people can set a default using `plugins` which are capable of
+                    // modifying the config object.
+                    formatString += " | None = None";
+                }
+                writer.write(formatString, field.name(), field.type());
+            }
+        });
+    }
+}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
@@ -74,6 +74,7 @@ final class DirectedPythonCodegen implements DirectedCodegen<GenerationContext, 
     public void customizeBeforeShapeGeneration(CustomizeDirective<GenerationContext, PythonSettings> directive) {
         generateDefaultWrapper(directive.settings(), directive.context().writerDelegator());
         generateServiceErrors(directive.settings(), directive.context().writerDelegator());
+        new ConfigGenerator(directive.context()).run();
     }
 
     @Override

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/PythonIntegration.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/PythonIntegration.java
@@ -39,4 +39,13 @@ public interface PythonIntegration extends SmithyIntegration<PythonSettings, Pyt
     default List<ProtocolGenerator> getProtocolGenerators() {
         return Collections.emptyList();
     }
+
+    /**
+     * Gets a list of plugins to apply to the generated client.
+     *
+     * @return Returns the list of RuntimePlugins to apply to the client.
+     */
+    default List<RuntimeClientPlugin> getClientPlugins() {
+        return Collections.emptyList();
+    }
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RuntimeClientPlugin.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.python.codegen.integration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import software.amazon.smithy.python.codegen.ConfigField;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Represents a runtime plugin for a client that hooks into various aspects
+ * of Python code generation, including adding configuration settings
+ * to clients and interceptors to both clients and commands.
+ *
+ * <p>These runtime client plugins are registered through the
+ * {@link PythonIntegration} SPI and applied to the code generator at
+ * build-time.
+ */
+@SmithyUnstableApi
+public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientPlugin> {
+    private final List<ConfigField> configFields;
+
+    private RuntimeClientPlugin(Builder builder) {
+        configFields = Collections.unmodifiableList(builder.configFields);
+    }
+
+    /**
+     * Gets the config fields that will be added to the client config by this plugin.
+     *
+     * @return Returns the config fields to add to the client config.
+     */
+    public List<ConfigField> getConfigFields() {
+        return configFields;
+    }
+
+    /**
+     * @return Returns a new builder for a {@link RuntimeClientPlugin}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public SmithyBuilder<RuntimeClientPlugin> toBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds a {@link RuntimeClientPlugin}.
+     */
+    public static final class Builder implements SmithyBuilder<RuntimeClientPlugin> {
+        private List<ConfigField> configFields = new ArrayList<>();
+
+        Builder() {
+        }
+
+        @Override
+        public RuntimeClientPlugin build() {
+            return new RuntimeClientPlugin(this);
+        }
+
+        /**
+         * Sets the list of config fields to add to the client's config object.
+         *
+         * @param configFields The list of config fields to add to the client's config object.
+         * @return Returns the builder.
+         */
+        public Builder configFields(List<ConfigField> configFields) {
+            this.configFields = configFields;
+            return this;
+        }
+
+        /**
+         * Adds a single config field which will be added to the client's config object.
+         *
+         * @param configField A config field to add to the client's config object.
+         * @return Returns the builder.
+         */
+        public Builder addConfigField(ConfigField configField) {
+            this.configFields.add(configField);
+            return this;
+        }
+    }
+}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RuntimeClientPlugin.java
@@ -44,6 +44,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     private final OperationPredicate operationPredicate;
     private final List<ConfigField> configFields;
 
+    // TODO: Add "plugin" and interceptor initialization
+
     private RuntimeClientPlugin(Builder builder) {
         servicePredicate = builder.servicePredicate;
         operationPredicate = builder.operationPredicate;


### PR DESCRIPTION
This adds client config generation. Config fields can be added by `PythonIntegration`s by way of the introduced `RuntimePlugin`s.

Example output:

```python
# Code generated by smithy-python-codegen DO NOT EDIT.

from dataclasses import dataclass
from typing import Callable, TypeAlias

from smithy_python.interfaces.interceptor import Interceptor


@dataclass(kw_only=True)
class Config:
    """Configuration for Weather

    :param interceptors: The list of interceptors, which are hooks that are called
    during the execution of a request.
    """

    interceptors: list[Interceptor] | None = None


# A callable that allows customizing the config object on each request.
Plugin: TypeAlias = Callable[[Config], None]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
