### PR TITLE
Add a basic endpoint provider

### DIFF
--- a/python-packages/smithy-python/smithy_python/_private/http/__init__.py
+++ b/python-packages/smithy-python/smithy_python/_private/http/__init__.py
@@ -85,7 +85,7 @@ class Endpoint(http_interface.Endpoint):
 
 
 @dataclass
-class BasicEndpointParams:
+class StaticEndpointParams:
     """
     Static endpoint params.
 
@@ -95,10 +95,10 @@ class BasicEndpointParams:
     url: str | URL
 
 
-class BasicEndpointResolver(http_interface.EndpointResolver[BasicEndpointParams]):
-    """A basic endpoint resolver that just forwards a static url."""
+class StaticEndpointResolver(http_interface.EndpointResolver[StaticEndpointParams]):
+    """A basic endpoint resolver that forwards a static url."""
 
-    async def resolve_endpoint(self, params: BasicEndpointParams) -> Endpoint:
+    async def resolve_endpoint(self, params: StaticEndpointParams) -> Endpoint:
         # If it's not a string, it's already a parsed URL so just pass it along.
         if not isinstance(params.url, str):
             return Endpoint(url=params.url)

--- a/python-packages/smithy-python/smithy_python/interfaces/http.py
+++ b/python-packages/smithy-python/smithy_python/interfaces/http.py
@@ -32,10 +32,16 @@ class Endpoint(Protocol):
     headers: HeadersList
 
 
+# EndpointParams are defined in the generated client, so we use a TypeVar here.
+# More specific EndpointParams implementations are subtypes of less specific ones. But
+# consumers of less specific EndpointParams implementations are subtypes of consumers
+# of more specific ones.
 EndpointParams = TypeVar("EndpointParams", contravariant=True)
 
 
 class EndpointResolver(Protocol[EndpointParams]):
+    """Resolves an operation's endpoint based given parameters."""
+
     async def resolve_endpoint(self, params: EndpointParams) -> Endpoint:
         raise NotImplementedError()
 

--- a/python-packages/smithy-python/smithy_python/interfaces/http.py
+++ b/python-packages/smithy-python/smithy_python/interfaces/http.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Optional, Protocol
+from typing import Any, Optional, Protocol, TypeVar
 
 # Defining headers as a list instead of a mapping to avoid ambiguity and
 # the nuances of multiple fields in a mapping style interface
@@ -25,6 +25,19 @@ class Response(Protocol):
     status_code: int  # HTTP status code
     headers: HeadersList
     body: Any
+
+
+class Endpoint(Protocol):
+    url: URL
+    headers: HeadersList
+
+
+EndpointParams = TypeVar("EndpointParams", contravariant=True)
+
+
+class EndpointResolver(Protocol[EndpointParams]):
+    async def resolve_endpoint(self, params: EndpointParams) -> Endpoint:
+        raise NotImplementedError()
 
 
 @dataclass(kw_only=True)

--- a/python-packages/smithy-python/tests/unit/test_http.py
+++ b/python-packages/smithy-python/tests/unit/test_http.py
@@ -1,4 +1,10 @@
-from smithy_python._private.http import URL, Request, Response
+from smithy_python._private.http import (
+    URL,
+    BasicEndpointParams,
+    BasicEndpointResolver,
+    Request,
+    Response,
+)
 
 
 def test_url() -> None:
@@ -41,3 +47,35 @@ def test_resposne() -> None:
     assert response.status_code == 200
     assert response.headers == [("foo", "bar")]
     assert response.body == b"test body"
+
+
+async def test_endpoint_provider_with_url_string() -> None:
+    params = BasicEndpointParams(
+        url="https://foo.example.com/spam:8080?foo=bar&foo=baz"
+    )
+    expected = URL(
+        hostname="foo.example.com",
+        path="/spam",
+        scheme="https",
+        query_params=[("foo", "bar"), ("foo", "baz")],
+        port=8080,
+    )
+    resolver = BasicEndpointResolver()
+    result = await resolver.resolve_endpoint(params=params)
+    assert result.url == expected
+    assert result.headers == []
+
+
+async def test_endpoint_provider_with_url_object() -> None:
+    expected = URL(
+        hostname="foo.example.com",
+        path="/spam",
+        scheme="https",
+        query_params=[("foo", "bar"), ("foo", "baz")],
+        port=8080,
+    )
+    params = BasicEndpointParams(url=expected)
+    resolver = BasicEndpointResolver()
+    result = await resolver.resolve_endpoint(params=params)
+    assert result.url == expected
+    assert result.headers == []

--- a/python-packages/smithy-python/tests/unit/test_http.py
+++ b/python-packages/smithy-python/tests/unit/test_http.py
@@ -1,9 +1,9 @@
 from smithy_python._private.http import (
     URL,
-    BasicEndpointParams,
-    BasicEndpointResolver,
     Request,
     Response,
+    StaticEndpointParams,
+    StaticEndpointResolver,
 )
 
 
@@ -50,7 +50,7 @@ def test_resposne() -> None:
 
 
 async def test_endpoint_provider_with_url_string() -> None:
-    params = BasicEndpointParams(
+    params = StaticEndpointParams(
         url="https://foo.example.com/spam:8080?foo=bar&foo=baz"
     )
     expected = URL(
@@ -60,7 +60,7 @@ async def test_endpoint_provider_with_url_string() -> None:
         query_params=[("foo", "bar"), ("foo", "baz")],
         port=8080,
     )
-    resolver = BasicEndpointResolver()
+    resolver = StaticEndpointResolver()
     result = await resolver.resolve_endpoint(params=params)
     assert result.url == expected
     assert result.headers == []
@@ -74,8 +74,8 @@ async def test_endpoint_provider_with_url_object() -> None:
         query_params=[("foo", "bar"), ("foo", "baz")],
         port=8080,
     )
-    params = BasicEndpointParams(url=expected)
-    resolver = BasicEndpointResolver()
+    params = StaticEndpointParams(url=expected)
+    resolver = StaticEndpointResolver()
     result = await resolver.resolve_endpoint(params=params)
     assert result.url == expected
     assert result.headers == []


### PR DESCRIPTION
This adds a basic endpoint provider that simply forwards along a static endpoint, parsing it if it's a string.

In the near future we should move all of these http implementations out into a more public space, but for now I elected to keep things together to keep this change as simple as possible.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
