### PR TITLE
Add ProtocolGenerator functions to set serde names

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/ProtocolGenerator.java
@@ -15,8 +15,14 @@
 
 package software.amazon.smithy.python.codegen.integration;
 
+import static java.lang.String.format;
+
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.python.codegen.ApplicationProtocol;
+import software.amazon.smithy.python.codegen.GenerationContext;
+import software.amazon.smithy.utils.CaseUtils;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -49,4 +55,59 @@ public interface ProtocolGenerator {
      * @return Returns the created application protocol.
      */
     ApplicationProtocol getApplicationProtocol();
+
+
+    /**
+     * Generates the name of a serializer function for shapes of a service that is not protocol-specific.
+     *
+     * @param context The code generation context.
+     * @param shapeId The shape the serializer function is being generated for.
+     * @return Returns the generated function name.
+     */
+    default String getSerializationFunctionName(GenerationContext context, ToShapeId shapeId) {
+        var shapeSymbol = context.symbolProvider().toSymbol(context.model().expectShape(shapeId.toShapeId()));
+        return "_serialize_" + CaseUtils.toSnakeCase(shapeSymbol.getName());
+    }
+
+    /**
+     * Generates the symbol for a serializer function for shapes of a service that is not protocol-specific.
+     *
+     * @param context The code generation context.
+     * @param shapeId The shape the serializer function is being generated for.
+     * @return Returns the generated symbol.
+     */
+    default Symbol getSerializationFunction(GenerationContext context, ToShapeId shapeId) {
+        return Symbol.builder()
+                .name(getSerializationFunctionName(context, shapeId))
+                .namespace(format("%s.serialize", context.settings().getModuleName()), "")
+                .definitionFile(format("./%s/serialize.py", context.settings().getModuleName()))
+                .build();
+    }
+
+    /**
+     * Generates the name of a deserializer function for shapes of a service that is not protocol-specific.
+     *
+     * @param context The code generation context.
+     * @param shapeId The shape the deserializer function is being generated for.
+     * @return Returns the generated function name.
+     */
+    default String getDeserializationFunctionName(GenerationContext context, ToShapeId shapeId) {
+        var shapeSymbol = context.symbolProvider().toSymbol(context.model().expectShape(shapeId.toShapeId()));
+        return "_deserialize_" + CaseUtils.toSnakeCase(shapeSymbol.getName());
+    }
+
+    /**
+     * Generates the symbol for a deserializer function for shapes of a service that is not protocol-specific.
+     *
+     * @param context The code generation context.
+     * @param shapeId The shape the deserializer function is being generated for.
+     * @return Returns the generated symbol.
+     */
+    default Symbol getDeserializationFunction(GenerationContext context, ToShapeId shapeId) {
+        return Symbol.builder()
+                .name(getDeserializationFunctionName(context, shapeId))
+                .namespace(format("%s.deserialize", context.settings().getModuleName()), "")
+                .definitionFile(format("./%s/deserialize.py", context.settings().getModuleName()))
+                .build();
+    }
 }


### PR DESCRIPTION
This adds a few functions to the ProtocolGenerator that set the name and location of the serialization and deserialization functions. It doesn't implement them of course, but this will allow us to write the client implementations by referencing these. The actual ProtocolGenerator implementation will provide the python implementation.

That eventual implementation will just be a pair of flat python files with (de)serialization functions. We don't have some sort of `Serializer` object because we won't be negotiating protocols at runtime - we'll only ever be generating a single protocol with no plan to make them runtime pluggable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
