### PR TITLE
Fix pyproject dependencies

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SetupGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SetupGenerator.java
@@ -90,7 +90,7 @@ final class SetupGenerator {
                     """, settings.getModuleName(), settings.getModuleVersion(), settings.getModuleDescription());
 
             Optional.ofNullable(dependencies.get(Type.DEPENDENCY.getType())).ifPresent(deps -> {
-                writer.openBlock("requires = [", "]", () -> writeDependencyList(writer, deps.values()));
+                writer.openBlock("dependencies = [", "]", () -> writeDependencyList(writer, deps.values()));
             });
 
             Optional.ofNullable(dependencies.get(Type.TEST_DEPENDENCY.getType())).ifPresent(deps -> {

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -31,8 +31,8 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_PYTHON = new PythonDependency(
             "smithy_python",
-            // TODO: switch to https link when this repo is made public
-            "git+ssh://git@github.com/awslabs/smithy-python.git@develop",
+            // You'll need to locally install this before we publish
+            "0.0.1",
             Type.DEPENDENCY,
             true
     );


### PR DESCRIPTION
The requirements list needs to be called dependencies. Also, using a github link for smithy_python prevents us from using our local changes in CI and general testing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
