### PR TITLE
Fill out list of python reserved words

### DIFF
--- a/codegen/smithy-python-codegen-test/model/main.smithy
+++ b/codegen/smithy-python-codegen-test/model/main.smithy
@@ -264,6 +264,10 @@ operation ListCities {
         someEnum: StringYesNo
         aString: String
         defaults: Defaults
+        escaping: MemberEscaping
+        escapeTrue: True
+        escapeFalse: False
+        escapeNone: None
 
         @required
         items: CitySummaries
@@ -364,6 +368,70 @@ structure Defaults {
     @required
     requiredDefaultDocument: Document = "eggs"
 }
+
+// This structure has members that need to be escaped.
+structure MemberEscaping {
+    // This first set of member names are all reserved words that are a syntax
+    // error to use as identifiers. A full list of these can be found here:
+    // https://docs.python.org/3/reference/lexical_analysis.html#keywords
+    and: String
+    as: String
+    assert: String
+    break: String
+    class: String
+    continue: String
+    def: String
+    del: String
+    elif: String
+    else: String
+    except: String
+    finally: String
+    for: String
+    from: String
+    global: String
+    if: String
+    import: String
+    in: String
+    is: String
+    lambda: String
+    nonlocal: String
+    not: String
+    or: String
+    pass: String
+    raise: String
+    return: String
+    try: String
+    while: String
+    with: String
+    yield: String
+
+    // These are built-in types, but not reserved words. They can be shadowed,
+    // but the shadowing naturally makes it impossible to use them later in
+    // scope. A listing of these can be found here:
+    // https://docs.python.org/3/library/stdtypes.html
+    bool: Boolean
+    dict: StringMap
+    float: Float
+    int: Integer
+    list: StringList
+    str: String
+    bytes: Blob
+    bytearray: Blob
+
+    // We don't actually use these, but they're here for completeness.
+    complex: Float
+    tuple: StringList
+    range: StringList
+    memoryview: Blob
+    set: StringList
+    frozenset: StringList
+}
+
+// These would result in class names that produce syntax errors since they're
+// reserved words.
+structure True {}
+structure False {}
+structure None {}
 
 @timestampFormat("date-time")
 timestamp DateTime

--- a/codegen/smithy-python-codegen/src/main/resources/software/amazon/smithy/python/codegen/reserved-class-names.txt
+++ b/codegen/smithy-python-codegen/src/main/resources/software/amazon/smithy/python/codegen/reserved-class-names.txt
@@ -1,0 +1,11 @@
+# Python reserved words for class names
+#
+# Most of python's reserved words are lower-case, so there isn't much
+# here. Furthermore, import aliases can resolve any other conflicts
+# with non-reserved builtins or other conflicting classes.
+#
+# A full list of reserved words can be found here:
+# https://docs.python.org/3/reference/lexical_analysis.html#keywords
+True
+False
+None

--- a/codegen/smithy-python-codegen/src/main/resources/software/amazon/smithy/python/codegen/reserved-member-names.txt
+++ b/codegen/smithy-python-codegen/src/main/resources/software/amazon/smithy/python/codegen/reserved-member-names.txt
@@ -1,0 +1,72 @@
+# Python reserved words for members.
+
+# The following are reserved words that can't be used as identifiers at all.
+# For example, the following would produce a syntax error:
+#
+# class Foo:
+#     pass: int
+#
+# A full list of these can be found here:
+#
+# https://docs.python.org/3/reference/lexical_analysis.html#keywords
+#
+# Note that None, True, and False aren't here - members are always lower
+# cased, so they'll never match here. Those are in the clas names reserve
+# list.
+and
+as
+assert
+break
+class
+continue
+def
+del
+elif
+else
+except
+finally
+for
+from
+global
+if
+import
+in
+is
+lambda
+nonlocal
+not
+or
+pass
+raise
+return
+try
+while
+with
+yield
+
+# The following aren't reserved words, but are built-in types / functions that
+# would break if you ever tried to refer to the type again in scope. For
+# example:
+#
+# class Foo:
+#     str: str
+#
+#     def __init__(self, str: str):
+#         pass
+#
+# That would have an exception in the definition of __init__ since when you use
+# `str` as the type after you've defined `str` in scope, it thinks you're
+# referencing `Foo.str` rather than the built-in type (or a type at all).
+#
+# A listing of these types can be found here:
+# https://docs.python.org/3/library/stdtypes.html
+#
+# Note though that we only need to escape the types we use.
+bool
+bytes
+bytearray
+dict
+float
+int
+list
+str


### PR DESCRIPTION
This updates the reserved words lists to pull from static text files which contain a complete set of python reserved words. It adds triggering entries into the test model as test cases.

This unfortunately will cause a bunch of warnings to pop up when you build the test project, but we do want users to see those so it is expected behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
