### PR TITLE
Fix generated methods for empty errors

### DIFF
--- a/codegen/smithy-python-codegen-test/model/main.smithy
+++ b/codegen/smithy-python-codegen-test/model/main.smithy
@@ -111,7 +111,7 @@ operation GetCity {
         cityData: JsonString
         binaryCityData: JsonBlob
     }
-    errors: [NoSuchResource]
+    errors: [NoSuchResource, EmptyError]
 }
 
 // Tests that HTTP protocol tests are generated.
@@ -210,6 +210,12 @@ apply NoSuchResource @httpResponseTests([
         }
     }
 ])
+
+// This will have a synthetic message member added to it, even
+// though it doesn't actually have one.
+@error("client")
+@httpError(400)
+structure EmptyError {}
 
 // The paginated trait indicates that the operation may
 // return truncated results.

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
@@ -160,7 +160,7 @@ final class StructureGenerator implements Runnable {
         var nullableIndex = NullableIndex.of(model);
         writer.openBlock("def __init__(", "):", () -> {
             writer.write("self,");
-            if (!shape.members().isEmpty()) {
+            if (!shape.members().isEmpty() || isError) {
                 // Adding this star to the front prevents the use of positional arguments.
                 writer.write("*,");
             }
@@ -443,7 +443,7 @@ final class StructureGenerator implements Runnable {
                         than the parameter names as keys to be mostly compatible with boto3."""));
             });
 
-            if (shape.members().isEmpty()) {
+            if (shape.members().isEmpty() && !isError) {
                 writer.write("return $L()", shapeName);
                 return;
             }


### PR DESCRIPTION
Errors always have a message property added whether or no the source shape had one. The `__init__` and `fromdict` methods weren't generating properly when the error had no members at all because of this.

The diff for an empty error after this change is something like:


```diff
@@ -4,6 +4,7 @@ class EmptyError(ApiError[Literal["EmptyError"]]):

     def __init__(
         self,
+        *,
         message: str,
     ):
         self._has: dict[str, bool] = {}
@@ -49,4 +50,8 @@ class EmptyError(ApiError[Literal["EmptyError"]]):
         The dictionary is expected to use the modeled shape names rather than the
         parameter names as keys to be mostly compatible with boto3.
         """
-        return EmptyError()
+        kwargs: Dict[str, Any] = {
+            "message": d["message"],
+        }
+
+        return EmptyError(**kwargs)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
