### PR TITLE
Fix SymbolVisitor handling of union members

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
@@ -386,6 +386,15 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol memberShape(MemberShape shape) {
+        var container = model.expectShape(shape.getContainer());
+        if (container.isUnionShape()) {
+            // Union members, unlike other shape members, have types generated for them.
+            var containerSymbol = container.accept(this);
+            var name = containerSymbol.getName() + StringUtils.capitalize(shape.getMemberName());
+            return createSymbolBuilder(shape, name, format("%s.models", settings.getModuleName()))
+                .definitionFile(format("./%s/models.py", settings.getModuleName()))
+                .build();
+        }
         Shape targetShape = model.getShape(shape.getTarget())
                 .orElseThrow(() -> new CodegenException("Shape not found: " + shape.getTarget()));
         return toSymbol(targetShape);


### PR DESCRIPTION
Union members get actual classes generated for them, but we were treating them like we treat members of other shapes in the SymbolVisitor - namely just forwarding the symbol of the target. This isn't what we actually want, so this fixes that to return a symbol representing the generated union member type. The union generator was also updated to account for this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
