### PR TITLE
Retry config

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigGenerator.java
@@ -39,6 +39,16 @@ final class ConfigGenerator implements Runnable {
                     .build(),
                 true,
                 "The list of interceptors, which are hooks that are called during the execution of a request."
+            ),
+            new ConfigField(
+                "retry_strategy",
+                Symbol.builder()
+                    .name("RetryStrategy")
+                    .namespace("smithy_python.interfaces.retries", ".")
+                    .addDependency(SmithyPythonDependency.SMITHY_PYTHON)
+                    .build(),
+                true,
+                "The retry strategy for issuing retry tokens and computing retry delays."
             )
     );
 


### PR DESCRIPTION
_Replaces #89 which originated from my fork (which I now deleted to make sure this never happens again)._

Making the retry strategy configurable. This goes together with #71.

I expected there to be more to this, but from looking at existing examples this seems to be all there is to do for making an implementation configurable. Questions:

1. I saw two patterns for configurable settings. First, the one that only allows for configuring Python implementations, for example `Config.http_client`. Second, config fields that allow for codegen-ed implementations through sections, as introduced in #67, for example `Config.endpoint_resolver`. Which one is the right choice for the retry strategy? And how do we decide this in general?
2. The type annotation for `Config.http_client` is `AsyncHttpClient`, an interface. The type annotation for `Config.endpoint_resolver` is `EndpointResolver`, an implementation. Why the difference?
3. How do/will config defaults work? For example, the default retry strategy if not configured otherwise should be `smithy_python.retries.SimpleRetryStrategy(max_retries=5)` (for now).

For reference, the spec asks for the following for retries config:

> * SDKs MUST allow the customer and service to provide an implementation of *RetryStrategy*.
> * SDKs MAY require customers to use a Plugin to configure the RetryStrategy.
> * SDKs MUST support the built-in strategies STANDARD, ADAPTIVE.
> * SDKs MAY support the built-in strategy LEGACY when required to maintain backwards-compatibility.
> * SDKs MUST support a *MaxAttempts* configuration to override the defaults of STANDARD and ADAPTIVE.
> * SDKs SHOULD include a default RetryStrategy of STANDARD.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

