### PR TITLE
Write protocol test skeletons (input, command, assertions)

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -15,15 +15,32 @@
 
 package software.amazon.smithy.python.codegen;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.TreeSet;
 import java.util.logging.Logger;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.BooleanNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeVisitor;
+import software.amazon.smithy.model.node.NullNode;
+import software.amazon.smithy.model.node.NumberNode;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.protocoltests.traits.AppliesTo;
 import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase;
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase;
@@ -31,6 +48,7 @@ import software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait;
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestCase;
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait;
 import software.amazon.smithy.utils.CaseUtils;
+import software.amazon.smithy.utils.Pair;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -100,7 +118,6 @@ public final class HttpProtocolTestGenerator implements Runnable {
         });
 
         // Error Tests
-        // 3. Generate test cases for each error on each operation.
         for (StructureShape error : operationIndex.getErrors(operation, service)) {
             if (!error.hasTag("server-only")) {
                 error.getTrait(HttpResponseTestsTrait.class).ifPresent(trait -> {
@@ -114,18 +131,49 @@ public final class HttpProtocolTestGenerator implements Runnable {
     }
 
     private void generateRequestTest(OperationShape operation, HttpRequestTestCase testCase) {
-        // TODO: Generate the real request test logic, add logic for skipping
-        var name = String.format("%s_request_%s", testCase.getId(), operation.getId().getName());
-        writeTestBlock(testCase, name, false, () -> {
-            writer.write("pass");
+        // TODO: add logic for checking if should skip
+        writeTestBlock(
+                testCase,
+                String.format("%s_request_%s", testCase.getId(), operation.getId().getName()),
+                false,
+                () -> {
+            // TODO: Instantiate the client with the request interceptor
+            writeClientBlock(context.symbolProvider().toSymbol(service), testCase, Optional.empty());
+
+            // Generate the input using the expected shape and params
+            var inputShape = model.expectShape(operation.getInputShape(), StructureShape.class);
+
+            writer.write("input_ = $C\n",
+                    (Runnable) () -> testCase.getParams().accept(new ValueNodeVisitor(inputShape))
+            );
+
+            writer.write("actual = await client.$T(input_)\n", context.symbolProvider().toSymbol(operation));
+
+            // TODO: Correctly assert the response and other values
+            writeAssertionBlock(testCase, List.of(Pair.of("actual", "actual")));
         });
     }
 
     private void generateResponseTest(OperationShape operation, HttpResponseTestCase testCase) {
         // TODO: Generate the real response test logic, add logic for skipping
-        var name = String.format("%s_response_%s", testCase.getId(), operation.getId().getName());
-        writeTestBlock(testCase, name, true, () -> {
-            writer.write("pass");
+        writeTestBlock(
+                testCase,
+                String.format("%s_response_%s", testCase.getId(), operation.getId().getName()),
+                true,
+                () -> {
+            // TODO: Instantiate the client and interceptor
+            writeClientBlock(context.symbolProvider().toSymbol(service), testCase, Optional.empty());
+
+            // Create an empty input object to pass
+            var inputShape = model.expectShape(operation.getInputShape(), StructureShape.class);
+            writer.write("input_ = $C\n",
+                    (Runnable) () -> (ObjectNode.builder().build()).accept(new ValueNodeVisitor(inputShape))
+            );
+            // Pass input to the operation and call it
+            writer.write("actual = client.$T(input_)\n", context.symbolProvider().toSymbol(operation));
+
+            // TODO: Correctly assert the response and other values
+            writeAssertionBlock(testCase, List.of(Pair.of("actual", "actual")));
         });
     }
 
@@ -134,9 +182,23 @@ public final class HttpProtocolTestGenerator implements Runnable {
             StructureShape error,
             HttpResponseTestCase testCase) {
         // TODO: Generate the real error response test logic, add logic for skipping
-        var name = String.format("%s_error_%s", testCase.getId(), operation.getId().getName());
-        writeTestBlock(testCase, name, false, () -> {
-            writer.write("pass");
+        writeTestBlock(testCase,
+                String.format("%s_error_%s", testCase.getId(), operation.getId().getName()),
+                false,
+                () -> {
+            // TODO: Instantiate the client and interceptor
+            writeClientBlock(context.symbolProvider().toSymbol(service), testCase, Optional.empty());
+
+            // Create an empty input object to pass
+            var inputShape = model.expectShape(operation.getInputShape(), StructureShape.class);
+            writer.write("input_ = $C\n",
+                    (Runnable) () -> (ObjectNode.builder().build()).accept(new ValueNodeVisitor(inputShape))
+            );
+            // Pass input to the operation and call it
+            writer.write("actual = client.$T(input_)\n", context.symbolProvider().toSymbol(operation));
+
+            // TODO: Correctly assert the response and other values
+            writeAssertionBlock(testCase, List.of(Pair.of("actual", "actual")));
         });
     }
 
@@ -159,11 +221,11 @@ public final class HttpProtocolTestGenerator implements Runnable {
             Runnable f
     ) {
         LOGGER.fine(String.format("Writing test block for %s", testName));
+        writer.addDependency(SmithyPythonDependency.PYTEST);
 
         // Skipped tests are still generated, just not run.
         if (shouldSkip) {
             LOGGER.fine(String.format("Marking test (%s) as skipped.", testName));
-            writer.addDependency(SmithyPythonDependency.PYTEST);
             writer.addImport(SmithyPythonDependency.PYTEST.packageName(), "mark", "mark");
             writer.write("@mark.skip()");
         }
@@ -171,5 +233,169 @@ public final class HttpProtocolTestGenerator implements Runnable {
             testCase.getDocumentation().ifPresent(writer::writeDocs);
             f.run();
         });
+    }
+
+    // write the client block, which may have additional configuration that should
+    // be written when instantiating the client
+    private void writeClientBlock(
+            Symbol serviceSymbol,
+            HttpMessageTestCase testCase,
+            Optional<Runnable> additionalConfigurator
+    ) {
+        LOGGER.fine(String.format("Writing client block for %s in %s", serviceSymbol.getName(), testCase.getId()));
+
+        writer.openBlock("client = $T(", ")\n", serviceSymbol, () -> {
+            additionalConfigurator.ifPresent(Runnable::run);
+        });
+    }
+
+    private void writeAssertionBlock(
+            HttpMessageTestCase testCase,
+            List<Pair<Object, Object>> assertions
+    ) {
+        LOGGER.fine(String.format("Writing assertions block for %s", testCase.getId()));
+
+        assertions.forEach((assertion) -> {
+            writer.write("assert $L == $L", assertion.left, assertion.right);
+        });
+    }
+
+    /**
+     * NodeVisitor implementation for converting node values for
+     * input shape(s) to proper Python values in the generated code.
+     */
+    private final class ValueNodeVisitor implements NodeVisitor<Void> {
+        private final Shape inputShape;
+
+        private ValueNodeVisitor(Shape inputShape) {
+            this.inputShape = inputShape;
+        }
+
+        @Override
+        public Void arrayNode(ArrayNode node) {
+            writer.openBlock("[", "]", () -> {
+                ValueNodeVisitor targetVisitor = inputShape.asListShape().map((listShape) ->
+                        new ValueNodeVisitor(model.expectShape(listShape.getMember().getTarget()))
+                ).orElse(this);
+
+                node.getElements().forEach(elementNode -> {
+                    writer.write("$C, ", (Runnable) () -> elementNode.accept(targetVisitor));
+                });
+            });
+            return null;
+        }
+
+        @Override
+        public Void booleanNode(BooleanNode node) {
+            writer.writeInline(node.getValue() ? "True" : "False");
+            return null;
+        }
+
+        @Override
+        public Void nullNode(NullNode node) {
+            writer.writeInline("None");
+            return null;
+        }
+
+        @Override
+        public Void numberNode(NumberNode node) {
+            // TODO: Add support for timestamp, int-enum, and others
+            writer.writeInline("$L", node.getValue().toString());
+            return null;
+        }
+
+        @Override
+        public Void objectNode(ObjectNode node) {
+            if (inputShape.isStructureShape()) {
+                structureShape((StructureShape) inputShape, node);
+            } else if (inputShape.isMapShape()) {
+                mapShape((MapShape) inputShape, node);
+            } else if (inputShape.isUnionShape()) {
+                unionShape((UnionShape) inputShape, node);
+            } else if (inputShape.isDocumentShape()) {
+                documentShape((DocumentShape) inputShape, node);
+            }
+            return null;
+        }
+
+        @Override
+        public Void stringNode(StringNode node) {
+            if (inputShape.isBlobShape()) {
+                writer.write("b$S", node.getValue());
+            } else {
+                writer.write("$S", node.getValue());
+            }
+            return null;
+        }
+
+        private Void structureShape(StructureShape shape, ObjectNode node) {
+            writer.openBlock("$T(", ")",
+                    context.symbolProvider().toSymbol(shape),
+                    () -> structureMemberShapes(shape, node)
+            );
+            return null;
+        }
+
+        private Void structureMemberShapes(StructureShape container, ObjectNode node) {
+            node.getMembers().forEach((keyNode, valueNode) -> {
+                var memberShape = container.getMember(keyNode.getValue()).orElseThrow(() ->
+                        new CodegenException("unknown memberShape: " + keyNode.getValue())
+                );
+                var targetShape = model.expectShape(memberShape.getTarget());
+                writer.write("$L = $C,",
+                        context.symbolProvider().toMemberName(memberShape),
+                        (Runnable) () -> valueNode.accept(new ValueNodeVisitor(targetShape))
+                );
+            });
+            return null;
+        }
+
+        private Void mapShape(MapShape shape, ObjectNode node) {
+            writer.openBlock("{", "}",
+                    () -> node.getMembers().forEach((keyNode, valueNode) -> {
+                        var targetShape = model.expectShape(shape.getValue().getTarget());
+                        writer.write("$S: $C,",
+                                keyNode.getValue(),
+                                (Runnable) () -> valueNode.accept(new ValueNodeVisitor(targetShape))
+                        );
+                    })
+            );
+            return null;
+        }
+
+        private Void documentShape(DocumentShape shape, ObjectNode node) {
+            writer.openBlock("{", "}",
+                    () -> node.getMembers().forEach((keyNode, valueNode) -> {
+                        writer.write("$S: $C,",
+                                keyNode.getValue(),
+                                (Runnable) () -> valueNode.accept(this)
+                        );
+                    })
+            );
+            return null;
+        }
+
+        private Void unionShape(UnionShape shape, ObjectNode node) {
+            if (node.getMembers().size() == 1) {
+                node.getMembers().forEach((keyNode, valueNode) -> {
+                    var memberShape = shape.getMember(keyNode.getValue())
+                            .orElseThrow(() -> new CodegenException("unknown member: " + keyNode.getValue()));
+                    var targetShape = model.expectShape(memberShape.getTarget());
+                    unionShape(memberShape, targetShape, valueNode);
+                });
+            } else {
+                throw new CodegenException("exactly 1 named member must be set.");
+            }
+            return null;
+        }
+
+        private Void unionShape(MemberShape memberShape, Shape targetShape, Node node) {
+            writer.openBlock("$T(", ")",
+                    context.symbolProvider().toSymbol(memberShape),
+                    () -> writer.write("value = $C",
+                            (Runnable) () -> node.accept(new ValueNodeVisitor(targetShape)))
+            );
+            return null;
+        }
     }
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.codegen.core.SymbolWriter;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -204,7 +205,9 @@ public final class PythonWriter extends SymbolWriter<PythonWriter, ImportDeclara
         public String apply(Object type, String indent) {
             if (type instanceof Symbol) {
                 Symbol typeSymbol = (Symbol) type;
-                addUseImports(typeSymbol);
+                if (!isOperationSymbol(typeSymbol)) {
+                    addUseImports(typeSymbol);
+                }
                 return typeSymbol.getName();
             } else if (type instanceof SymbolReference) {
                 SymbolReference typeSymbol = (SymbolReference) type;
@@ -215,5 +218,9 @@ public final class PythonWriter extends SymbolWriter<PythonWriter, ImportDeclara
                         "Invalid type provided to $T. Expected a Symbol, but found `" + type + "`");
             }
         }
+    }
+
+    private Boolean isOperationSymbol(Symbol typeSymbol) {
+        return typeSymbol.getProperty("shape", Shape.class).map(Shape::isOperationShape).orElse(false);
     }
 }


### PR DESCRIPTION
As part of these changes, some test skeletons are written. A basic implementation of a `NodeVisitor` is added, which is used to convert from node values to python values. A small change was made to PythonWriter to skip the import of operation symbols, since they are methods of the service object.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
