### PR TITLE
Write protocol test skeletons (input, command, assertions)

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CollectionGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CollectionGenerator.java
@@ -19,6 +19,7 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.traits.SparseTrait;
 
 /**
  * Generates private helper methods for collections.
@@ -58,14 +59,15 @@ final class CollectionGenerator implements Runnable {
         var asDictSymbol = symbol.expectProperty("asDict", Symbol.class);
         var target = model.expectShape(shape.getMember().getTarget());
         var targetSymbol = symbolProvider.toSymbol(target);
+        var sparseGuard = shape.hasTrait(SparseTrait.class) ? " if v is not None else None" : "";
         writer.addStdlibImport("typing", "List");
         writer.addStdlibImport("typing", "Any");
         writer.openBlock("def $L(given: $T) -> List[Any]:", "", asDictSymbol.getName(), symbol, () -> {
             if (target.isUnionShape() || target.isStructureShape()) {
-                writer.write("return [v.as_dict() for v in given]");
+                writer.write("return [v.as_dict()$L for v in given]", sparseGuard);
             } else if (target.isMapShape() || target instanceof CollectionShape) {
                 var targetAsDictSymbol = targetSymbol.expectProperty("asDict", Symbol.class);
-                writer.write("return [$T(v) for v in given]", targetAsDictSymbol);
+                writer.write("return [$T(v)$L for v in given]", targetAsDictSymbol, sparseGuard);
             } else {
                 writer.write("return given");
             }
@@ -77,14 +79,15 @@ final class CollectionGenerator implements Runnable {
         var fromDictSymbol = symbol.expectProperty("fromDict", Symbol.class);
         var target = model.expectShape(shape.getMember().getTarget());
         var targetSymbol = symbolProvider.toSymbol(target);
+        var sparseGuard = shape.hasTrait(SparseTrait.class) ? " if v is not None else None" : "";
         writer.addStdlibImport("typing", "List");
         writer.addStdlibImport("typing", "Any");
         writer.openBlock("def $L(given: List[Any]) -> $T:", "", fromDictSymbol.getName(), symbol, () -> {
             if (target.isUnionShape() || target.isStructureShape()) {
-                writer.write("return [$T.from_dict(v) for v in given]", targetSymbol);
+                writer.write("return [$T.from_dict(v)$L for v in given]", targetSymbol, sparseGuard);
             } else if (target.isMapShape() || target instanceof CollectionShape) {
                 var targetFromDictSymbol = targetSymbol.expectProperty("fromDict", Symbol.class);
-                writer.write("return [$T(v) for v in given]", targetFromDictSymbol);
+                writer.write("return [$T(v)$L for v in given]", targetFromDictSymbol, sparseGuard);
             } else {
                 writer.write("return given");
             }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -15,15 +15,33 @@
 
 package software.amazon.smithy.python.codegen;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.TreeSet;
 import java.util.logging.Logger;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.BooleanNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeVisitor;
+import software.amazon.smithy.model.node.NullNode;
+import software.amazon.smithy.model.node.NumberNode;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.protocoltests.traits.AppliesTo;
 import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase;
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase;
@@ -31,6 +49,7 @@ import software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait;
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestCase;
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait;
 import software.amazon.smithy.utils.CaseUtils;
+import software.amazon.smithy.utils.Pair;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -100,7 +119,6 @@ public final class HttpProtocolTestGenerator implements Runnable {
         });
 
         // Error Tests
-        // 3. Generate test cases for each error on each operation.
         for (StructureShape error : operationIndex.getErrors(operation, service)) {
             if (!error.hasTag("server-only")) {
                 error.getTrait(HttpResponseTestsTrait.class).ifPresent(trait -> {
@@ -114,18 +132,49 @@ public final class HttpProtocolTestGenerator implements Runnable {
     }
 
     private void generateRequestTest(OperationShape operation, HttpRequestTestCase testCase) {
-        // TODO: Generate the real request test logic, add logic for skipping
-        var name = String.format("%s_request_%s", testCase.getId(), operation.getId().getName());
-        writeTestBlock(testCase, name, false, () -> {
-            writer.write("pass");
+        // TODO: add logic for checking if should skip
+        writeTestBlock(
+                testCase,
+                String.format("%s_request_%s", testCase.getId(), operation.getId().getName()),
+                false,
+                () -> {
+            // TODO: Instantiate the client with the request interceptor
+            writeClientBlock(context.symbolProvider().toSymbol(service), testCase, Optional.empty());
+
+            // Generate the input using the expected shape and params
+            var inputShape = model.expectShape(operation.getInputShape(), StructureShape.class);
+
+            writer.write("input_ = $C\n",
+                    (Runnable) () -> testCase.getParams().accept(new ValueNodeVisitor(inputShape))
+            );
+
+            writer.write("actual = await client.$T(input_)\n", context.symbolProvider().toSymbol(operation));
+
+            // TODO: Correctly assert the response and other values
+            writeAssertionBlock(testCase, List.of(Pair.of("actual", "actual")));
         });
     }
 
     private void generateResponseTest(OperationShape operation, HttpResponseTestCase testCase) {
         // TODO: Generate the real response test logic, add logic for skipping
-        var name = String.format("%s_response_%s", testCase.getId(), operation.getId().getName());
-        writeTestBlock(testCase, name, true, () -> {
-            writer.write("pass");
+        writeTestBlock(
+                testCase,
+                String.format("%s_response_%s", testCase.getId(), operation.getId().getName()),
+                true,
+                () -> {
+            // TODO: Instantiate the client and interceptor
+            writeClientBlock(context.symbolProvider().toSymbol(service), testCase, Optional.empty());
+
+            // Create an empty input object to pass
+            var inputShape = model.expectShape(operation.getInputShape(), StructureShape.class);
+            writer.write("input_ = $C\n",
+                    (Runnable) () -> (ObjectNode.builder().build()).accept(new ValueNodeVisitor(inputShape))
+            );
+            // Pass input to the operation and call it
+            writer.write("actual = client.$T(input_)\n", context.symbolProvider().toSymbol(operation));
+
+            // TODO: Correctly assert the response and other values
+            writeAssertionBlock(testCase, List.of(Pair.of("actual", "actual")));
         });
     }
 
@@ -134,9 +183,23 @@ public final class HttpProtocolTestGenerator implements Runnable {
             StructureShape error,
             HttpResponseTestCase testCase) {
         // TODO: Generate the real error response test logic, add logic for skipping
-        var name = String.format("%s_error_%s", testCase.getId(), operation.getId().getName());
-        writeTestBlock(testCase, name, false, () -> {
-            writer.write("pass");
+        writeTestBlock(testCase,
+                String.format("%s_error_%s", testCase.getId(), operation.getId().getName()),
+                false,
+                () -> {
+            // TODO: Instantiate the client and interceptor
+            writeClientBlock(context.symbolProvider().toSymbol(service), testCase, Optional.empty());
+
+            // Create an empty input object to pass
+            var inputShape = model.expectShape(operation.getInputShape(), StructureShape.class);
+            writer.write("input_ = $C\n",
+                    (Runnable) () -> (Node.objectNode()).accept(new ValueNodeVisitor(inputShape))
+            );
+            // Pass input to the operation and call it
+            writer.write("actual = client.$T(input_)\n", context.symbolProvider().toSymbol(operation));
+
+            // TODO: Correctly assert the response and other values
+            writeAssertionBlock(testCase, List.of(Pair.of("actual", "actual")));
         });
     }
 
@@ -159,11 +222,11 @@ public final class HttpProtocolTestGenerator implements Runnable {
             Runnable f
     ) {
         LOGGER.fine(String.format("Writing test block for %s", testName));
+        writer.addDependency(SmithyPythonDependency.PYTEST);
 
         // Skipped tests are still generated, just not run.
         if (shouldSkip) {
             LOGGER.fine(String.format("Marking test (%s) as skipped.", testName));
-            writer.addDependency(SmithyPythonDependency.PYTEST);
             writer.addImport(SmithyPythonDependency.PYTEST.packageName(), "mark", "mark");
             writer.write("@mark.skip()");
         }
@@ -171,5 +234,188 @@ public final class HttpProtocolTestGenerator implements Runnable {
             testCase.getDocumentation().ifPresent(writer::writeDocs);
             f.run();
         });
+    }
+
+    // write the client block, which may have additional configuration that should
+    // be written when instantiating the client
+    private void writeClientBlock(
+            Symbol serviceSymbol,
+            HttpMessageTestCase testCase,
+            Optional<Runnable> additionalConfigurator
+    ) {
+        LOGGER.fine(String.format("Writing client block for %s in %s", serviceSymbol.getName(), testCase.getId()));
+
+        writer.openBlock("client = $T(", ")\n", serviceSymbol, () -> {
+            additionalConfigurator.ifPresent(Runnable::run);
+        });
+    }
+
+    private void writeAssertionBlock(
+            HttpMessageTestCase testCase,
+            List<Pair<Object, Object>> assertions
+    ) {
+        LOGGER.fine(String.format("Writing assertions block for %s", testCase.getId()));
+
+        assertions.forEach((assertion) -> {
+            writer.write("assert $L == $L", assertion.left, assertion.right);
+        });
+    }
+
+    /**
+     * NodeVisitor implementation for converting node values for
+     * input shape(s) to proper Python values in the generated code.
+     */
+    private final class ValueNodeVisitor implements NodeVisitor<Void> {
+        private final Shape inputShape;
+
+        private ValueNodeVisitor(Shape inputShape) {
+            this.inputShape = inputShape;
+        }
+
+        @Override
+        public Void arrayNode(ArrayNode node) {
+            writer.openBlock("[", "]", () -> {
+                // The target visitor won't change if the input shape is a union
+                ValueNodeVisitor targetVisitor;
+                if (inputShape instanceof CollectionShape) {
+                    var target = model.expectShape(((CollectionShape) inputShape).getMember().getTarget());
+                    targetVisitor = new ValueNodeVisitor(target);
+                } else {
+                    targetVisitor = this;
+                }
+
+                node.getElements().forEach(elementNode -> {
+                    writer.write("$C, ", (Runnable) () -> elementNode.accept(targetVisitor));
+                });
+            });
+            return null;
+        }
+
+        @Override
+        public Void booleanNode(BooleanNode node) {
+            writer.writeInline(node.getValue() ? "True" : "False");
+            return null;
+        }
+
+        @Override
+        public Void nullNode(NullNode node) {
+            writer.writeInline("None");
+            return null;
+        }
+
+        @Override
+        public Void numberNode(NumberNode node) {
+            // TODO: Add support for timestamp, int-enum, and others
+            if (inputShape.isTimestampShape()) {
+                writer.addStdlibImport("datetime", "datetime");
+                writer.writeInline("datetime.fromtimestamp($L)", node.getValue());
+            } else if (inputShape.isFloatShape() || inputShape.isDoubleShape()) {
+                writer.writeInline("float($L)", node.getValue());
+            } else {
+                writer.writeInline("$L", node.getValue());
+            }
+            return null;
+        }
+
+        @Override
+        public Void objectNode(ObjectNode node) {
+            switch (inputShape.getType()) {
+                case STRUCTURE -> structureShape((StructureShape) inputShape, node);
+                case MAP -> mapShape((MapShape) inputShape, node);
+                case UNION -> unionShape((UnionShape) inputShape, node);
+                case DOCUMENT -> documentShape((DocumentShape) inputShape, node);
+                default -> throw new CodegenException("unexpected input shape: " + inputShape.getType());
+            }
+            return null;
+        }
+
+        @Override
+        public Void stringNode(StringNode node) {
+            if (inputShape.isBlobShape()) {
+                writer.writeInline("b$S", node.getValue());
+            } else if (inputShape.isFloatShape() || inputShape.isDoubleShape()) {
+                var value = switch (node.getValue()) {
+                    case "NaN" -> "nan";
+                    case "Infinity" -> "inf";
+                    case "-Infinity" -> "-inf";
+                    default -> throw new CodegenException("Invalid value: " + node.getValue());
+                };
+
+                writer.writeInline("float($S)", value);
+            } else {
+                writer.writeInline("$S", node.getValue());
+            }
+            return null;
+        }
+
+        private Void structureShape(StructureShape shape, ObjectNode node) {
+            writer.openBlock("$T(", ")",
+                    context.symbolProvider().toSymbol(shape),
+                    () -> structureMemberShapes(shape, node)
+            );
+            return null;
+        }
+
+        private Void structureMemberShapes(StructureShape container, ObjectNode node) {
+            node.getMembers().forEach((keyNode, valueNode) -> {
+                var memberShape = container.getMember(keyNode.getValue()).orElseThrow(() ->
+                        new CodegenException("unknown memberShape: " + keyNode.getValue())
+                );
+                var targetShape = model.expectShape(memberShape.getTarget());
+                writer.write("$L = $C,",
+                        context.symbolProvider().toMemberName(memberShape),
+                        (Runnable) () -> valueNode.accept(new ValueNodeVisitor(targetShape))
+                );
+            });
+            return null;
+        }
+
+        private Void mapShape(MapShape shape, ObjectNode node) {
+            writer.openBlock("{", "}",
+                    () -> node.getMembers().forEach((keyNode, valueNode) -> {
+                        var targetShape = model.expectShape(shape.getValue().getTarget());
+                        writer.write("$S: $C,",
+                                keyNode.getValue(),
+                                (Runnable) () -> valueNode.accept(new ValueNodeVisitor(targetShape))
+                        );
+                    })
+            );
+            return null;
+        }
+
+        private Void documentShape(DocumentShape shape, ObjectNode node) {
+            writer.openBlock("{", "}",
+                    () -> node.getMembers().forEach((keyNode, valueNode) -> {
+                        writer.write("$S: $C,",
+                                keyNode.getValue(),
+                                (Runnable) () -> valueNode.accept(this)
+                        );
+                    })
+            );
+            return null;
+        }
+
+        private Void unionShape(UnionShape shape, ObjectNode node) {
+            if (node.getMembers().size() == 1) {
+                node.getMembers().forEach((keyNode, valueNode) -> {
+                    var memberShape = shape.getMember(keyNode.getValue())
+                            .orElseThrow(() -> new CodegenException("unknown member: " + keyNode.getValue()));
+                    var targetShape = model.expectShape(memberShape.getTarget());
+                    unionShape(memberShape, targetShape, valueNode);
+                });
+            } else {
+                throw new CodegenException("exactly 1 named member must be set.");
+            }
+            return null;
+        }
+
+        private Void unionShape(MemberShape memberShape, Shape targetShape, Node node) {
+            writer.openBlock("$T(", ")",
+                    context.symbolProvider().toSymbol(memberShape),
+                    () -> writer.write("value = $C",
+                            (Runnable) () -> node.accept(new ValueNodeVisitor(targetShape)))
+            );
+            return null;
+        }
     }
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ImportDeclarations.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ImportDeclarations.java
@@ -54,8 +54,12 @@ final class ImportDeclarations implements ImportContainer {
     }
 
     ImportDeclarations addImport(String namespace, String name, String alias) {
+        var isTestModule = this.localNamespace.startsWith("tests");
         if (namespace.startsWith(settings.getModuleName())) {
-            return addImportToMap(relativize(namespace), name, alias, localImports);
+            // if the module is for tests, we shouldn't relativize the imports
+            //  as python will complain that the imports are beyond the top-level package
+            var ns = isTestModule ? namespace : relativize(namespace);
+            return addImportToMap(ns, name, alias, localImports);
         }
         return addImportToMap(namespace, name, alias, externalImports);
     }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.codegen.core.SymbolWriter;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -204,7 +205,11 @@ public final class PythonWriter extends SymbolWriter<PythonWriter, ImportDeclara
         public String apply(Object type, String indent) {
             if (type instanceof Symbol) {
                 Symbol typeSymbol = (Symbol) type;
-                addUseImports(typeSymbol);
+                // Check if the symbol is an operation - we shouldn't add imports for operations, since
+                //  they are methods of the service object and *can't* be imported
+                if (!isOperationSymbol(typeSymbol)) {
+                    addUseImports(typeSymbol);
+                }
                 return typeSymbol.getName();
             } else if (type instanceof SymbolReference) {
                 SymbolReference typeSymbol = (SymbolReference) type;
@@ -215,5 +220,9 @@ public final class PythonWriter extends SymbolWriter<PythonWriter, ImportDeclara
                         "Invalid type provided to $T. Expected a Symbol, but found `" + type + "`");
             }
         }
+    }
+
+    private Boolean isOperationSymbol(Symbol typeSymbol) {
+        return typeSymbol.getProperty("shape", Shape.class).map(Shape::isOperationShape).orElse(false);
     }
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
@@ -56,6 +56,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
+import software.amazon.smithy.model.traits.SparseTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.CaseUtils;
 import software.amazon.smithy.utils.MediaType;
@@ -175,7 +176,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol listShape(ListShape shape) {
         Symbol reference = toSymbol(shape.getMember());
-        var builder = createSymbolBuilder(shape, "list[" + reference.getName() + "]")
+        String type = String.format(shape.hasTrait(SparseTrait.class) ? "%s | None" : "%s", reference.getName());
+        var builder = createSymbolBuilder(shape, "list[" + type + "]")
                 .addReference(reference);
 
         if (needsDictHelpers(shape)) {
@@ -188,7 +190,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol mapShape(MapShape shape) {
         Symbol reference = toSymbol(shape.getValue());
-        var builder = createSymbolBuilder(shape, "dict[str, " + reference.getName() + "]")
+        String type = String.format(shape.hasTrait(SparseTrait.class) ? "%s | None" : "%s", reference.getName());
+        var builder = createSymbolBuilder(shape, "dict[str, " + type + "]")
                 .addReference(reference);
 
         if (needsDictHelpers(shape)) {


### PR DESCRIPTION
Creating a new PR for these changes on the base repository, so that CI will run - the previous PR is #80


*Description of changes:*
As part of these changes, some test skeletons are written. A basic implementation of a `NodeVisitor` is added, which is used to convert from node values to python values


*Testing:*
I run the the protocol tests generation for the restJson1, the generated code looks like this (snippets):

```python
async def test_rest_json_all_query_string_types_request_all_query_string_types() -> None:
    """Serializes query string parameters with all supported types"""
    client = RestJson()

    input_ = AllQueryStringTypesInput(
        query_string="Hello there",
        query_string_list=[
            "a",
            "b",
            "c",
        ],
        query_string_set=[
            "a",
            "b",
            "c",
        ],
        query_byte=1,
        query_short=2,
        query_integer=3,
        query_integer_list=[
            1,
            2,
            3,
        ],
        query_integer_set=[
            1,
            2,
            3,
        ],
        query_long=4,
        query_float=float(1.1),
        query_double=float(1.1),
        query_double_list=[
            float(1.1),
            float(2.1),
            float(3.1),
        ],
        query_boolean=True,
        query_boolean_list=[
            True,
            False,
            True,
        ],
        query_timestamp=datetime.fromtimestamp(1),
        query_timestamp_list=[
            datetime.fromtimestamp(1),
            datetime.fromtimestamp(2),
            datetime.fromtimestamp(3),
        ],
        query_enum="Foo",
        query_enum_list=[
            "Foo",
            "Baz",
            "Bar",
        ],
        query_integer_enum=1,
        query_integer_enum_list=[
            1,
            2,
            3,
        ],
    )

    actual = await client.all_query_string_types(input_)

    assert actual == actual

... 

@mark.skip()
async def test_document_output_response_document_type() -> None:
    """Serializes documents as part of the JSON response payload with no escaping."""
    client = RestJson()

    input_ = DocumentTypeInput()

    actual = client.document_type(input_)

    assert actual == actual

...
```

It's important to note that the imports are written as relative imports`..restjson.client`, `..restjson.models`, when it should probably be absolute. Also, it is importing the operation (i.e. `get_city`) when it shouldn't be (this PR address this).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
