### PR TITLE
Put default http config directly on the config object

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigGenerator.java
@@ -51,7 +51,6 @@ final class ConfigGenerator implements Runnable {
     }
 
     private static List<ConfigField> getHttpFields(PythonSettings settings) {
-        var endpointParams = CodegenUtils.getEndpointParams(settings);
         var endpointResolver = CodegenUtils.getEndpointResolver(settings);
         return Arrays.asList(
                 new ConfigField(
@@ -73,12 +72,17 @@ final class ConfigGenerator implements Runnable {
                         configuration."""
                 ),
                 new ConfigField(
-                    "endpoint_params",
-                    endpointParams,
+                    "endpoint_url",
+                    Symbol.builder()
+                        .name("str | URL")
+                        .addReference(Symbol.builder()
+                            .name("URL")
+                            .namespace("smithy_python.interfaces.http", ".")
+                            .addDependency(SmithyPythonDependency.SMITHY_PYTHON)
+                            .build())
+                        .build(),
                     true,
-                    """
-                        The endpoint resolver used to resolve the final endpoint per-operation based on the \
-                        configuration."""
+                    "A static URL to route requests to."
                 )
         );
     }


### PR DESCRIPTION
This removes the indirection of the endpoint params. This lets us be compliant with the more complex endpoint resolution rules without actually implementing it yet (or requiring customers to buy in). At operation generation time we can just manually wire this up. If the more advanced traits are present, we can upgrade.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
