### PR TITLE
Write command execution for requests/response/error-response protocol tests

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -190,5 +191,22 @@ public final class CodegenUtils {
             return packageName;
         }
         return packageName.substring(packageName.lastIndexOf('/') + 1);
+    }
+
+    /**
+     * Convert a map of k,v to a list of pairwise arrays.
+     *
+     * <p>For example:
+     *
+     * <pre>{@code
+     * Map.of("a", 1, "b", 2) -> List.of({"a", 1}, {"b", 2})
+     * }</pre>
+     *
+     * @param map The map to be converted
+     * @return The list of arrays
+     */
+    public static List<Object[]> toTuples(Map<?, ?> map) {
+        return map.entrySet().stream().map((entry) ->
+                List.of(entry.getKey(), entry.getValue()).toArray()).toList();
     }
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.python.codegen;
 
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -200,6 +201,37 @@ public final class PythonWriter extends SymbolWriter<PythonWriter, ImportDeclara
      */
     public PythonWriter addImport(String namespace, String name, String alias) {
         getImportContainer().addImport(namespace, name, alias);
+        return this;
+    }
+
+    /**
+     * Imports a set of types from a module only if necessary.
+     *
+     * @param namespace Module to import the type from.
+     * @param names Set of types to import.
+     * @return Returns the writer.
+     */
+    public PythonWriter addImports(String namespace, Set<String> names) {
+        names.forEach((name) -> getImportContainer().addImport(namespace, name, name));
+        return this;
+    }
+
+    /**
+     * Conditionally write text.
+     *
+     * <p>Useful for short-handing a conditional write when
+     * you aren't able to use the built-in conditional
+     * formatting functionality.
+     *
+     * @param shouldWrite Whether to write the text or not.
+     * @param content Content to write.
+     * @param args String arguments to use for formatting.
+     * @return Returns self.
+     */
+    public PythonWriter maybeWrite(boolean shouldWrite, Object content, Object... args) {
+        if (shouldWrite) {
+            write(content, args);
+        }
         return this;
     }
 

--- a/codegen/smithy-python-codegen/src/main/resources/software/amazon/smithy/python/codegen/reserved-member-names.txt
+++ b/codegen/smithy-python-codegen/src/main/resources/software/amazon/smithy/python/codegen/reserved-member-names.txt
@@ -72,3 +72,8 @@ float
 int
 list
 str
+
+# For the exact same reason as above, these are names of common types
+# that are likely imported in the generated code (e.g. datetime)
+# We only escape the types we use.
+datetime

--- a/python-packages/smithy-python/pyproject.toml
+++ b/python-packages/smithy-python/pyproject.toml
@@ -45,3 +45,6 @@ exclude=["tests*", "codegen", "designs"]
 profile = "black"
 honor_noqa = true
 src_paths = ["smithy_python", "tests"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a custom formatter for formatting certain java objects as python, which is useful in protocol tests for formatting the headers. Adds basic assertion logic and utility classes for easily constructing them.

Adds protocol-test utils to `smithy-python` - these classes and methods are extensively used within the generated protocol tests. `pyproject.toml` updated to correctly execute async tests, and linter was run.

*Testing*
Below are snippets of generated code:

#### Request
```python
async def test_rest_json_http_payload_traits_with_blob_request_http_payload_traits() -> None:
    """Serializes a blob in the HTTP payload"""
    client = RestJson(config=Config(http_client=RequestTestAsyncHttpClient()))

    input_ = HttpPayloadTraitsInput(
        foo="Foo",
        blob=b"blobby blob blob",
    )

    try:
        await client.http_payload_traits(input_)
        fail("Expected 'TestHttpServiceError' exception to be thrown!")
    except TestHttpServiceError as err:
        actual = err.request

        assert actual.method == "POST"
        assert actual.url.path == "/HttpPayloadTraits"
        assert actual.url.host == ""
        assert {h[0] for h in actual.headers} >= {"Content-Length"}
    except Exception as err:
        fail(
            f"Expected 'TestHttpServiceError' exception to be thrown, but received {type(err).__name__}"
        )
```

#### Response
```python
async def test_rest_json_http_payload_traits_with_media_type_with_blob_response_http_payload_traits_with_media_type() -> None:
    """Serializes a blob in the HTTP payload with a content-type"""
    client = RestJson(
        config=Config(
            http_client=ResponseTestAsyncHttpClient(
                status_code=200,
                headers=[("Content-Type", "text/plain"), ("X-Foo", "Foo")],
                body="blobby blob blob",
            )
        )
    )

    input_ = HttpPayloadTraitsWithMediaTypeInput()

    try:
        actual = await client.http_payload_traits_with_media_type(input_)
    except Exception as err:
        fail(f"Expected a valid response, but received: {type(err).__name__}")
    else:
        expected = HttpPayloadTraitsWithMediaTypeOutput(
            foo="Foo",
            blob=b"blobby blob blob",
        )

        assert actual == expected
```

#### Error
```python
async def test_rest_json_foo_error_using_x_amzn_error_type_error_greeting_with_errors() -> None:
    """Serializes the X-Amzn-ErrorType header. For an example service, see Amazon EKS."""
    client = RestJson(
        config=Config(
            http_client=ResponseTestAsyncHttpClient(
                status_code=500,
                headers=[("X-Amzn-Errortype", "FooError")],
                body=None,
            )
        )
    )

    input_ = GreetingWithErrorsInput()

    try:
        await client.greeting_with_errors(input_)
        fail("Expected 'FooError' exception to be thrown!")
    except Exception as err:
        if type(err).__name__ != "FooError":
            fail(
                f"Expected 'FooError' exception to be thrown, but received {type(err).__name__}"
            )
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
