### PR TITLE
Deserialize status code

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
@@ -550,7 +550,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         OperationShape operation
     ) {
         writer.addStdlibImport("typing", "Any");
-        writer.write("args: dict[str, Any] = {}");
+        writer.write("kwargs: dict[str, Any] = {}");
         var bindingIndex = HttpBindingIndex.of(context.model());
 
         deserializeBody(context, writer, operation, bindingIndex);
@@ -559,7 +559,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         var outputShape = context.model().expectShape(operation.getOutputShape());
         var outputSymbol = context.symbolProvider().toSymbol(outputShape);
-        writer.write("return $T(**args)", outputSymbol);
+        writer.write("return $T(**kwargs)", outputSymbol);
     }
 
     /**


### PR DESCRIPTION
This adds deserialization for status codes.

Sample output:

```python
async def _deserialize_http_response_code(
    http_response: Response, config: Config
) -> HttpResponseCodeOutput:
    kwargs: dict[str, Any] = {}
    kwargs["status"] = http_response.status_code
    return HttpResponseCodeOutput(**kwargs)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
