### PR TITLE
Implement __repr__ and __eq__ on generated classes

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/UnionGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/UnionGenerator.java
@@ -112,11 +112,15 @@ final class UnionGenerator implements Runnable {
                         if not isinstance(other, $1L):
                             return False
                         return self.value == other.value
-                    """);
+                    """, memberSymbol.getName());
             });
             writer.write("");
         }
 
+        // Note that the unknown variant doesn't implement __eq__. This is because
+        // the default implementation does exactly what we want: an instance check.
+        // Since the underlying value is unknown and un-comparable, that is the only
+        // realistic implementation.
         var unknownSymbol = symbolProvider.toSymbol(shape).expectProperty("unknown", Symbol.class);
         writer.write("""
                 class $1L():
@@ -142,7 +146,6 @@ final class UnionGenerator implements Runnable {
 
                     def __repr__(self) -> str:
                         return f"$1L(tag={self.tag})"
-
                 """, unknownSymbol.getName());
         memberNames.add(unknownSymbol.getName());
 


### PR DESCRIPTION
This adds generated `__repr__` and `__eq__` methods to the generated classes. `__eq__` is needed to make tests work at all and `__repr__` is needed to make sense of failures. Example generated:

```python
class GreetingStruct:
    hi: Optional[str]

    [...]

    def __repr__(self) -> str:
        result = "GreetingStruct("
        if self._has["hi"]:
            result += f"hi={repr(self.hi)}"

        return result + ")"

    def __eq__(self, other: Any) -> bool:
        if not isinstance(other, GreetingStruct):
            return False
        attributes: list[str] = [
            "hi",
        ]
        return all(
            self._hasattr(a) == other._hasattr(a) and getattr(self, a) == getattr(other, a)
            for a in attributes
        )


# Structure with no members
class AllQueryStringTypesOutput:
    [...]

    def __repr__(self) -> str:
        result = "AllQueryStringTypesOutput("

        return result + ")"

    def __eq__(self, other: Any) -> bool:
        return isinstance(other, AllQueryStringTypesOutput)


# Exception
class ComplexError(ApiError[Literal["ComplexError"]]):
    code: Literal["ComplexError"] = "ComplexError"
    message: str
    header: Optional[str]
    top_level: Optional[str]
    nested: Optional[ComplexNestedErrorData]

    [...]

    def __repr__(self) -> str:
        result = "ComplexError("
        result += f"message={self.message},"
        if self._has["header"]:
            result += f"header={repr(self.header)}, "

        if self._has["top_level"]:
            result += f"top_level={repr(self.top_level)}, "

        if self._has["nested"]:
            result += f"nested={repr(self.nested)}"

        return result + ")"

    def __eq__(self, other: Any) -> bool:
        if not isinstance(other, ComplexError):
            return False
        attributes: list[str] = [
            "message",
            "header",
            "top_level",
            "nested",
        ]
        return all(
            self._hasattr(a) == other._hasattr(a) and getattr(self, a) == getattr(other, a)
            for a in attributes
        )
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
