### PR TITLE
Tolerate empty JSON bodies

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
@@ -125,7 +125,7 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
         writer.write("""
             body = await http_response.body.read()
-            output = json_loads(body)
+            output = json_loads(body) if body else {}
 
             """);
 


### PR DESCRIPTION
If the HTTP response body is empty, don't try to parse it, just set the output to an empty dict.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
