### PR TITLE
Fix parsing epoch second timestamps

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
@@ -968,7 +968,13 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         public String timestampShape(TimestampShape shape) {
             HttpBindingIndex httpIndex = HttpBindingIndex.of(context.model());
             Format format = httpIndex.determineTimestampFormat(member, bindingType, defaultTimestampFormat);
-            return HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, dataSource, member, format);
+            var source = dataSource;
+            if (format == Format.EPOCH_SECONDS) {
+                writer.addDependency(SmithyPythonDependency.SMITHY_PYTHON);
+                writer.addImport("smithy_python.utils", "strict_parse_float");
+                source = "strict_parse_float(" + dataSource + ")";
+            }
+            return HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, source, member, format);
         }
 
         @Override

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -92,7 +92,7 @@ public final class HttpProtocolGeneratorUtils {
                 writer.addStdlibImport("datetime", "datetime");
                 writer.addStdlibImport("datetime", "timezone");
                 writer.addImport("smithy_python.utils", "expect_type");
-                return "datetime.fromtimestamp(expect_type(int, " + dataSource + "), timezone.utc)";
+                return "datetime.fromtimestamp(expect_type(int | float, " + dataSource + "), timezone.utc)";
             case HTTP_DATE:
                 writer.addImport("smithy_python.utils", "ensure_utc");
                 writer.addStdlibImport("email.utils", "parsedate_to_datetime");

--- a/python-packages/smithy-python/smithy_python/utils.py
+++ b/python-packages/smithy-python/smithy_python/utils.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime, timezone
-from typing import Any, TypeVar
+from types import UnionType
+from typing import Any, TypeVar, overload
 
 from .exceptions import ExpectationNotMetException
 
@@ -45,7 +46,21 @@ def limited_parse_float(value: Any) -> float:
 _T = TypeVar("_T")
 
 
+@overload
 def expect_type(typ: type[_T], value: Any) -> _T:
+    ...
+
+
+# For some reason, mypy and other type checkers don't treat Union like a full type
+# despite it being checkable with isinstance and other methods. This essentially means
+# we can't pass back the given type when we're given a union. So instead we have to
+# return Any.
+@overload
+def expect_type(typ: UnionType, value: Any) -> Any:
+    ...
+
+
+def expect_type(typ: UnionType | type, value: Any) -> Any:
     """Asserts a value is of the given type and returns it as that type.
 
     This is essentially typing.cast, but with a runtime assertion. If the runtime

--- a/python-packages/smithy-python/tests/unit/test_utils.py
+++ b/python-packages/smithy-python/tests/unit/test_utils.py
@@ -39,6 +39,8 @@ def test_ensure_utc(given: datetime, expected: datetime) -> None:
         (str, ""),
         (int, 1),
         (bool, True),
+        (float | int, 1),
+        (float | int, 1.1),
     ],
 )
 def test_expect_type(typ: Any, value: Any) -> None:
@@ -53,6 +55,7 @@ def test_expect_type(typ: Any, value: Any) -> None:
         (int, 1.0),
         (bool, 0),
         (bool, ""),
+        (float | int, "1"),
     ],
 )
 def test_expect_type_raises(typ: Any, value: Any) -> None:


### PR DESCRIPTION
This fixes parsing epoch second timestamps in headers, where they're strings, by properly casting them. It also fixes some a typing issue allowing such timestamps to be either ints or floats, both of which fromtimestamp handles just fine.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
