### PR TITLE
Strip prefix from prefix headers

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
@@ -683,9 +683,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 if _key_lowercase.startswith($1S):
                     if $2S not in kwargs:
                         kwargs[$2S] = {}
-                    kwargs[$2S][key] = $3L
+                    kwargs[$2S][key[$3L:]] = $4L
 
-                """, locationName, memberName, mapTarget.accept(deserVisitor));
+                """, locationName, memberName, locationName.length(), mapTarget.accept(deserVisitor));
         }
     }
 


### PR DESCRIPTION
The prefixes of prefix headers need to be stripped from the map keys.

So, for example, if the prefix was `x-amz-` and the headers `x-amz-foo` and `x-amz-bar` were present, the resultant map would have the keys `foo` and `bar`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
