### PR TITLE
Add Makefile for development snippets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+help: ## Show this help.
+	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)
+
+
+install-deps: ## Builds and installs the python packages.
+	./pants package ::
+	python3 -m pip install dist/*.whl --force-reinstall
+
+
+smithy-build: ## Builds the Java code generation packages.
+	cd codegen && ./gradlew clean build
+
+
+generate-protocol-tests: ## Generates the protocol tests, rebuilding necessary Java packages.
+	cd codegen && ./gradlew clean :smithy-python-protocol-test:build
+
+
+run-protocol-tests: ## Runs already-generated protocol tests
+	cd codegen/smithy-python-protocol-test/build/smithyprojections/smithy-python-protocol-test/rest-json-1/python-codegen && \
+	python3 -m pip install '.[tests]' && \
+	python3 -m pytest tests
+
+
+test-protocols: install-deps generate-protocol-tests run-protocol-tests ## Generates and runs protocol tests.


### PR DESCRIPTION
This adds in a Makefile to store common development snippets to do things like install the local python packages or run the protocol tests.

To build and run the protocol tests, for example, you could simply use `make test-protocols`

I did this instead of some python script because it's much more concise and we really don't need that much.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
