### PR TITLE
Add AWS Java package

### DIFF
--- a/codegen/settings.gradle.kts
+++ b/codegen/settings.gradle.kts
@@ -15,6 +15,7 @@
 
 rootProject.name = "smithy-python"
 include(":smithy-python-codegen")
+include(":smithy-aws-python-codegen")
 include(":smithy-python-codegen-test")
 include(":smithy-python-protocol-test")
 

--- a/codegen/smithy-aws-python-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-python-codegen/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+description = "Generates AWS Python code from Smithy models"
+extra["displayName"] = "Smithy :: AWS :: Python :: Codegen"
+extra["moduleName"] = "software.amazon.smithy.aws.python.codegen"
+
+val smithyVersion: String by project
+
+buildscript {
+    val smithyVersion: String by project
+
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
+    }
+}
+
+dependencies {
+    implementation(project(":smithy-python-codegen"))
+    implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
+}

--- a/codegen/smithy-aws-python-codegen/src/main/java/software/amazon/smithy/aws/python/codegen/AwsAuthIntegration.java
+++ b/codegen/smithy-aws-python-codegen/src/main/java/software/amazon/smithy/aws/python/codegen/AwsAuthIntegration.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.python.codegen;
+
+import software.amazon.smithy.python.codegen.integration.PythonIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds support for AWS auth traits.
+ */
+@SmithyInternalApi
+public class AwsAuthIntegration implements PythonIntegration {
+}

--- a/codegen/smithy-aws-python-codegen/src/main/java/software/amazon/smithy/aws/python/codegen/AwsProtocolsIntegration.java
+++ b/codegen/smithy-aws-python-codegen/src/main/java/software/amazon/smithy/aws/python/codegen/AwsProtocolsIntegration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.python.codegen;
+
+import java.util.List;
+import software.amazon.smithy.python.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.python.codegen.integration.PythonIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds AWS protocols to the generator's list of supported protocols.
+ */
+@SmithyInternalApi
+public class AwsProtocolsIntegration implements PythonIntegration {
+    @Override
+    public List<ProtocolGenerator> getProtocolGenerators() {
+        return List.of();
+    }
+}

--- a/codegen/smithy-aws-python-codegen/src/main/resources/META-INF/services/software.amazon.smithy.python.codegen.integration.PythonIntegration
+++ b/codegen/smithy-aws-python-codegen/src/main/resources/META-INF/services/software.amazon.smithy.python.codegen.integration.PythonIntegration
@@ -1,0 +1,7 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+software.amazon.smithy.aws.python.codegen.AwsAuthIntegration
+software.amazon.smithy.aws.python.codegen.AwsProtocolsIntegration


### PR DESCRIPTION
This adds the Java package for AWS specific integrations.

~~Note that checkstyle will fail on the license headers until #142 is merged.~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
