### PR TITLE
Fill out javadoc

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -69,6 +69,10 @@ public final class CodegenUtils {
 
     private CodegenUtils() {}
 
+    /**
+     * @param settings The client settings, used to account for module configuration.
+     * @return Returns the client's configuration object symbol.
+     */
     public static Symbol getConfigSymbol(PythonSettings settings) {
         return Symbol.builder()
                 .name("Config")
@@ -77,7 +81,11 @@ public final class CodegenUtils {
                 .build();
     }
 
-    static Symbol getPluginSymbol(PythonSettings settings) {
+    /**
+     * @param settings The client settings, used to account for module configuration.
+     * @return Returns the client's plugin type hint symbol.
+     */
+    public static Symbol getPluginSymbol(PythonSettings settings) {
         return Symbol.builder()
                 .name("Plugin")
                 .namespace(format("%s.config", settings.getModuleName()), ".")
@@ -85,6 +93,10 @@ public final class CodegenUtils {
                 .build();
     }
 
+    /**
+     * @param settings The client settings, used to account for module configuration.
+     * @return Returns the function that wraps and casts default values.
+     */
     static Symbol getDefaultWrapperFunction(PythonSettings settings) {
         return Symbol.builder()
                 .name("_default")
@@ -93,6 +105,10 @@ public final class CodegenUtils {
                 .build();
     }
 
+    /**
+     * @param settings The client settings, used to account for module configuration.
+     * @return Returns the symbol for the class that wraps default values.
+     */
     static Symbol getDefaultWrapperClass(PythonSettings settings) {
         return Symbol.builder()
                 .name("_DEFAULT")
@@ -101,6 +117,17 @@ public final class CodegenUtils {
                 .build();
     }
 
+    /**
+     * Gets the service error symbol.
+     *
+     * <p>This error is the top-level error for the client. Every error surfaced by
+     * the client MUST be a subclass of this so that customers can reliably catch all
+     * exceptions it raises. The client implementation will wrap any errors that aren't
+     * already subclasses.
+     *
+     * @param settings The client settings, used to account for module configuration.
+     * @return Returns the symbol for the client's error class.
+     */
     public static Symbol getServiceError(PythonSettings settings) {
         return Symbol.builder()
                 .name("ServiceError")
@@ -109,6 +136,15 @@ public final class CodegenUtils {
                 .build();
     }
 
+    /**
+     * Gets the service API error symbol.
+     *
+     * <p>This error is the parent class for all errors returned over the wire by the
+     * service, including unknown errors.
+     *
+     * @param settings The client settings, used to account for module configuration.
+     * @return Returns the symbol for the client's API error class.
+     */
     public static Symbol getApiError(PythonSettings settings) {
         return Symbol.builder()
                 .name("ApiError")
@@ -117,6 +153,15 @@ public final class CodegenUtils {
                 .build();
     }
 
+    /**
+     * Gets the unknown API error symbol.
+     *
+     * <p> This error is the parent class for all errors returned over the wire by
+     * the service which aren't in the model.
+     *
+     * @param settings The client settings, used to account for module configuration.
+     * @return Returns the symbol for unknown API errors.
+     */
     public static Symbol getUnknownApiError(PythonSettings settings) {
         return Symbol.builder()
                 .name("UnknownApiError")
@@ -125,6 +170,10 @@ public final class CodegenUtils {
                 .build();
     }
 
+    /**
+     * @param settings The client settings, used to account for module configuration.
+     * @return Returns the symbol for the client-specific endpoint resolver.
+     */
     static Symbol getEndpointResolver(PythonSettings settings) {
         return Symbol.builder()
                 .name("EndpointResolver")
@@ -133,6 +182,10 @@ public final class CodegenUtils {
                 .build();
     }
 
+    /**
+     * @param settings The client settings, used to account for module configuration.
+     * @return Returns the symbol for the client-specific endpoint parameters.
+     */
     static Symbol getEndpointParams(PythonSettings settings) {
         return Symbol.builder()
                 .name("EndpointParams")
@@ -141,6 +194,13 @@ public final class CodegenUtils {
                 .build();
     }
 
+    /**
+     * Determines whether a given member is probably the main "message" of an error shape.
+     *
+     * @param model The whole service model.
+     * @param shape The member to check.
+     * @return Returns whether the member is probably the error message.
+     */
     static boolean isErrorMessage(Model model, MemberShape shape) {
         return ERROR_MESSAGE_MEMBER_NAMES.contains(shape.getMemberName().toLowerCase(Locale.US))
                 && model.expectShape(shape.getContainer()).hasTrait(ErrorTrait.class);

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -97,6 +97,14 @@ public final class HttpProtocolTestGenerator implements Runnable {
     private final GenerationContext context;
     private final BiPredicate<Shape, HttpMessageTestCase> testFilter;
 
+    /**
+     * Constructor.
+     *
+     * @param context The code generation context.
+     * @param protocol The protocol whose tests should be generated.
+     * @param writer The writer to write to.
+     * @param testFilter A filter that indicates tests which are expected to fail.
+     */
     public HttpProtocolTestGenerator(
             GenerationContext context,
             ShapeId protocol,
@@ -112,14 +120,6 @@ public final class HttpProtocolTestGenerator implements Runnable {
         this.testFilter = testFilter;
 
         writer.putFormatter('J', new JavaToPythonFormatter());
-    }
-
-    public HttpProtocolTestGenerator(
-        GenerationContext context,
-        ShapeId protocol,
-        PythonWriter writer
-    ) {
-        this(context, protocol, writer, (shape, testCase) -> false);
     }
 
     /**

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/MapGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/MapGenerator.java
@@ -25,7 +25,7 @@ import software.amazon.smithy.model.traits.SparseTrait;
 /**
  * Generates private helper methods for maps.
  */
-public class MapGenerator implements Runnable {
+final class MapGenerator implements Runnable {
 
     private final Model model;
     private final SymbolProvider symbolProvider;

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonCodegenPlugin.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonCodegenPlugin.java
@@ -19,10 +19,12 @@ import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.build.SmithyBuildPlugin;
 import software.amazon.smithy.codegen.core.directed.CodegenDirector;
 import software.amazon.smithy.python.codegen.integration.PythonIntegration;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Plugin to trigger Python code generation.
  */
+@SmithyUnstableApi
 public final class PythonCodegenPlugin implements SmithyBuildPlugin {
     @Override
     public String getName() {

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonDependency.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonDependency.java
@@ -19,10 +19,12 @@ import java.util.Collections;
 import java.util.List;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * A record of a python package dependency.
  */
+@SmithyUnstableApi
 public record PythonDependency(
         String packageName, String version, Type type, boolean isLink
 ) implements SymbolDependencyContainer {

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonSettings.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonSettings.java
@@ -24,11 +24,13 @@ import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Settings used by {@link PythonCodegenPlugin}.
  * TODO: make this immutable
  */
+@SmithyUnstableApi
 public final class PythonSettings {
 
     private static final String SERVICE = "service";

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonWriter.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.codegen.core.SymbolWriter;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -30,6 +31,7 @@ import software.amazon.smithy.utils.StringUtils;
  *
  * <p>Use the {@code $T} formatter to refer to {@link Symbol}s.
  */
+@SmithyUnstableApi
 public final class PythonWriter extends SymbolWriter<PythonWriter, ImportDeclarations> {
 
     private static final Logger LOGGER = Logger.getLogger(PythonWriter.class.getName());

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -18,10 +18,12 @@ package software.amazon.smithy.python.codegen;
 import java.util.List;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.python.codegen.PythonDependency.Type;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Dependencies used in the smithy python generator.
  */
+@SmithyUnstableApi
 public final class SmithyPythonDependency {
 
     /**

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/DocumentMemberSerVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/DocumentMemberSerVisitor.java
@@ -46,6 +46,7 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.PythonWriter;
 import software.amazon.smithy.python.codegen.SmithyPythonDependency;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Visitor to serialize member values for aggregate types into document bodies.
@@ -62,6 +63,7 @@ import software.amazon.smithy.python.codegen.SmithyPythonDependency;
  *   <li>All other types: unmodified.</li>
  * </ul>
  */
+@SmithyUnstableApi
 public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     private final GenerationContext context;
     private final PythonWriter writer;

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonMemberSerVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonMemberSerVisitor.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.PythonWriter;
 import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 
 /**
@@ -32,6 +33,7 @@ import software.amazon.smithy.utils.SetUtils;
  * <p>This does not delegate to serializers for lists or maps that would return them
  * unchanged. A list of booleans, for example, will never need any serialization changes.
  */
+@SmithyUnstableApi
 public class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
 
     private static final Set<ShapeType> NOOP_TARGETS = SetUtils.of(

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeDeserVisitor.java
@@ -49,6 +49,12 @@ public class JsonShapeDeserVisitor extends ShapeVisitor.Default<Void> {
     private final GenerationContext context;
     private final PythonWriter writer;
 
+    /**
+     * Constructor.
+     *
+     * @param context The code generation context.
+     * @param writer The writer that will be written to. Used here only to add dependencies.
+     */
     public JsonShapeDeserVisitor(GenerationContext context, PythonWriter writer) {
         this.context = context;
         this.writer = writer;
@@ -180,6 +186,15 @@ public class JsonShapeDeserVisitor extends ShapeVisitor.Default<Void> {
         return null;
     }
 
+    /**
+     * Generate deserializers for structure members.
+     *
+     * <p>The structure to deserialize must exist in the variable {@literal output}, and
+     * the results will be stored in a dict called {@literal kwargs}, which must also
+     * exist.
+     *
+     * @param members The members to generate serializers for.
+     */
     public void structureMembers(Collection<MemberShape> members) {
         var index = NullableIndex.of(context.model());
         var errorSymbol = CodegenUtils.getServiceError(context.settings());
@@ -212,6 +227,12 @@ public class JsonShapeDeserVisitor extends ShapeVisitor.Default<Void> {
         }
     }
 
+    /**
+     * Gets the JSON key that will be used for a given member.
+     *
+     * @param member The member to inspect.
+     * @return The string key that will be used for the member.
+     */
     protected String locationName(MemberShape member) {
         return member.getMemberTrait(context.model(), JsonNameTrait.class)
             .map(StringTrait::getValue)

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeSerVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeSerVisitor.java
@@ -35,23 +35,34 @@ import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.PythonWriter;
 import software.amazon.smithy.python.codegen.SmithyPythonDependency;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Visitor to generate serialization functions for shapes in JSON document bodies.
  */
+@SmithyUnstableApi
 public class JsonShapeSerVisitor extends ShapeVisitor.Default<Void> {
     private final GenerationContext context;
     private final PythonWriter writer;
 
     /**
-     * @param context The generation context.
-     * @param writer The writer being written to.
+     * Constructor.
+     *
+     * @param context The code generation context.
+     * @param writer The writer that will be written to. Used here only to add dependencies.
      */
     public JsonShapeSerVisitor(GenerationContext context, PythonWriter writer) {
         this.context = context;
         this.writer = writer;
     }
 
+    /**
+     * Gets the serialization visitor for a member.
+     *
+     * @param member The member to be serialized.
+     * @param dataSource The python variable / source containing the data to serialize.
+     * @return The serialization visitor for the member.
+     */
     protected DocumentMemberSerVisitor getMemberVisitor(MemberShape member, String dataSource) {
         return new JsonMemberSerVisitor(context, writer, member, dataSource, Format.EPOCH_SECONDS);
     }
@@ -176,6 +187,12 @@ public class JsonShapeSerVisitor extends ShapeVisitor.Default<Void> {
         }
     }
 
+    /**
+     * Gets the JSON key that will be used for a given member.
+     *
+     * @param member The member to inspect.
+     * @return The string key that will be used for the member.
+     */
     protected String locationName(MemberShape member) {
         return member.getMemberTrait(context.model(), JsonNameTrait.class)
             .map(StringTrait::getValue)

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonIntegration.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonIntegration.java
@@ -16,11 +16,13 @@
 package software.amazon.smithy.python.codegen.integration;
 
 import java.util.List;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Integration that registers {@link RestJsonProtocolGenerator}.
  */
-public class RestJsonIntegration implements PythonIntegration {
+@SmithyInternalApi
+public final class RestJsonIntegration implements PythonIntegration {
     @Override
     public List<ProtocolGenerator> getProtocolGenerators() {
         return List.of(new RestJsonProtocolGenerator());

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RuntimeClientPlugin.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RuntimeClientPlugin.java
@@ -54,6 +54,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         this.pythonPlugin = builder.pythonPlugin;
     }
 
+    /**
+     * Predicate that tests whether a plugin should be applied to an individual operation.
+     */
     @FunctionalInterface
     public interface OperationPredicate {
         /**

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/EndpointProviderSection.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/EndpointProviderSection.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.python.codegen.sections;
 
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * This section is responsible for generating an HTTP endpoint provider.
@@ -31,6 +32,7 @@ import software.amazon.smithy.utils.CodeSection;
  * @param endpointResolverSymbol The symbol representing the endpoint provider.
  * @param endpointParamsSymbol The symbol representing the parameter bag required by the endpoint provider.
  */
+@SmithyUnstableApi
 public record EndpointProviderSection(
         Symbol endpointResolverSymbol, Symbol endpointParamsSymbol) implements CodeSection {
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/PyprojectSection.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/PyprojectSection.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.python.codegen.sections;
 import java.util.Map;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * This section controls the entire pyproject.toml
@@ -30,5 +31,6 @@ import software.amazon.smithy.utils.CodeSection;
  *                     to a mapping of the package name to {@link SymbolDependency}.
  *                     This contains all the dependencies for the generated client.
  */
+@SmithyUnstableApi
 public record PyprojectSection(Map<String, Map<String, SymbolDependency>> dependencies) implements CodeSection {
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/ReadmeSection.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/ReadmeSection.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.python.codegen.sections;
 
 
 import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * This section controls the entire generated README.md
@@ -24,5 +25,6 @@ import software.amazon.smithy.utils.CodeSection;
  * <p>An integration may want to use this if they want to programmatically
  * overwrite the generated README.
  */
+@SmithyUnstableApi
 public record ReadmeSection() implements CodeSection {
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/ResolveEndpointSection.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/ResolveEndpointSection.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.python.codegen.sections;
 
 import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * This section resolves the service's endpoint and adds it to the transport
@@ -23,5 +24,6 @@ import software.amazon.smithy.utils.CodeSection;
  *
  * <p>This is implemented by default only for HTTP protocols.
  */
+@SmithyUnstableApi
 public record ResolveEndpointSection() implements CodeSection {
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/SendRequestSection.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/sections/SendRequestSection.java
@@ -16,11 +16,13 @@
 package software.amazon.smithy.python.codegen.sections;
 
 import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * This section is responsible for sending the client's request to the service.
  *
  * <p>This is implemented by default only for HTTP protocols.
  */
+@SmithyUnstableApi
 public record SendRequestSection() implements CodeSection {
 }


### PR DESCRIPTION
This fills out missing javadoc, including adding unstable notice annotations and fixing some visibility mistakes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
