### PR TITLE
vend ``rfc3986`` package

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -1,6 +1,5 @@
 [GLOBAL]
 pants_version = "2.14.0"
-pants_ignore = "/python-packages/smithy-python/smithy_python/_private/rfc3986"
 
 backend_packages = [
     "pants.backend.python",

--- a/python-packages/smithy-python/smithy_python/BUILD
+++ b/python-packages/smithy-python/smithy_python/BUILD
@@ -4,4 +4,7 @@ python_sources(
     name="source",
     dependencies=[":pytyped"],
     sources=["**/*.py"],
+    overrides={
+        "_private/rfc3986/*.py": {"skip_mypy": True}
+    }
 )

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/__init__.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/__init__.py
@@ -11,21 +11,22 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-An implementation of semantics and validations described in RFC 3986.
+"""An implementation of semantics and validations described in RFC 3986.
 
 See http://rfc3986.readthedocs.io/ for detailed documentation.
 
 :copyright: (c) 2014 Rackspace
 :license: Apache v2.0, see LICENSE for details
 """
-from .api import iri_reference
-from .api import IRIReference
-from .api import is_valid_uri
-from .api import normalize_uri
-from .api import uri_reference
-from .api import URIReference
-from .api import urlparse
+from .api import (
+    IRIReference,
+    URIReference,
+    iri_reference,
+    is_valid_uri,
+    normalize_uri,
+    uri_reference,
+    urlparse,
+)
 from .parseresult import ParseResult
 
 __title__ = "rfc3986"

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/_mixin.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/_mixin.py
@@ -2,9 +2,7 @@
 import warnings
 
 from . import exceptions as exc
-from . import misc
-from . import normalizers
-from . import validators
+from . import misc, normalizers, validators
 
 
 class URIMixin:

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/abnf_regexp.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/abnf_regexp.py
@@ -109,9 +109,7 @@ variations = [
 
 IPv6_RE = "(({})|({})|({})|({})|({})|({})|({})|({})|({}))".format(*variations)
 
-IPv_FUTURE_RE = r"v[0-9A-Fa-f]+\.[%s]+" % (
-    UNRESERVED_RE + SUB_DELIMITERS_RE + ":"
-)
+IPv_FUTURE_RE = r"v[0-9A-Fa-f]+\.[%s]+" % (UNRESERVED_RE + SUB_DELIMITERS_RE + ":")
 
 # RFC 6874 Zone ID ABNF
 ZONE_ID = "(?:[" + UNRESERVED_RE + "]|" + PCT_ENCODED + ")+"
@@ -130,9 +128,7 @@ HOST_RE = HOST_PATTERN = "({}|{}|{})".format(
     IPv4_RE,
     IP_LITERAL_RE,
 )
-USERINFO_RE = (
-    "^([" + UNRESERVED_RE + SUB_DELIMITERS_RE + ":]|%s)+" % (PCT_ENCODED)
-)
+USERINFO_RE = "^([" + UNRESERVED_RE + SUB_DELIMITERS_RE + ":]|%s)+" % (PCT_ENCODED)
 PORT_RE = "[0-9]{1,5}"
 
 # ####################
@@ -243,9 +239,7 @@ IHOST_RE = IHOST_PATTERN = "({}|{}|{})".format(
     IP_LITERAL_RE,
 )
 
-IUSERINFO_RE = (
-    "^(?:[" + IUNRESERVED_RE + SUB_DELIMITERS_RE + ":]|%s)+" % (PCT_ENCODED)
-)
+IUSERINFO_RE = "^(?:[" + IUNRESERVED_RE + SUB_DELIMITERS_RE + ":]|%s)+" % (PCT_ENCODED)
 
 IFRAGMENT_RE = (
     "^(?:[/?:@" + IUNRESERVED_RE + SUB_DELIMITERS_RE + "]|%s)*$" % PCT_ENCODED

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/api.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/api.py
@@ -11,11 +11,10 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Module containing the simple and functional API for rfc3986.
+"""Module containing the simple and functional API for rfc3986.
 
-This module defines functions and provides access to the public attributes
-and classes of rfc3986.
+This module defines functions and provides access to the public attributes and classes
+of rfc3986.
 """
 from .iri import IRIReference
 from .parseresult import ParseResult

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/builder.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/builder.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module containing the logic for the URIBuilder object."""
-from . import compat
-from . import normalizers
-from . import uri
-from . import uri_reference
+from . import compat, normalizers, uri, uri_reference
 
 
 class URIBuilder:
@@ -26,7 +23,6 @@ class URIBuilder:
         This object should be instantiated by the user, but it's recommended
         that it is not provided with arguments. Instead, use the available
         method to populate the fields.
-
     """
 
     def __init__(
@@ -77,9 +73,9 @@ class URIBuilder:
     def from_uri(cls, reference):
         """Initialize the URI builder from another URI.
 
-        Takes the given URI reference and creates a new URI builder instance
-        populated with the values from the reference. If given a string it will
-        try to convert it to a reference before constructing the builder.
+        Takes the given URI reference and creates a new URI builder instance populated
+        with the values from the reference. If given a string it will try to convert it
+        to a reference before constructing the builder.
         """
         if not isinstance(reference, uri.URIReference):
             reference = uri_reference(reference)
@@ -104,7 +100,6 @@ class URIBuilder:
             >>> URIBuilder().add_scheme('HTTPS')
             URIBuilder(scheme='https', userinfo=None, host=None, port=None,
                     path=None, query=None, fragment=None)
-
         """
         scheme = normalizers.normalize_scheme(scheme)
         return URIBuilder(
@@ -158,7 +153,6 @@ class URIBuilder:
             >>> URIBuilder().add_host('google.com')
             URIBuilder(scheme=None, userinfo=None, host='google.com',
                     port=None, path=None, query=None, fragment=None)
-
         """
         return URIBuilder(
             scheme=self.scheme,
@@ -182,7 +176,6 @@ class URIBuilder:
             >>> URIBuilder().add_port(443)
             URIBuilder(scheme=None, userinfo=None, host=None, port='443',
                     path=None, query=None, fragment=None)
-
         """
         port_int = int(port)
         if port_int < 0:
@@ -221,7 +214,6 @@ class URIBuilder:
             >>> URIBuilder().add_path('/checkout.php')
             URIBuilder(scheme=None, userinfo=None, host=None, port=None,
                     path='/checkout.php', query=None, fragment=None)
-
         """
         if not path.startswith("/"):
             path = f"/{path}"
@@ -258,7 +250,6 @@ class URIBuilder:
             >>> URIBuilder(path="/users").extend_path("sigmavirus24")
             URIBuilder(scheme=None, userinfo=None, host=None, port=None,
                     path='/users/sigmavirus24', query=None, fragment=None)
-
         """
         existing_path = self.path or ""
         path = "{}/{}".format(existing_path.rstrip("/"), path.lstrip("/"))
@@ -277,7 +268,6 @@ class URIBuilder:
             >>> URIBuilder().add_query_from([('a', 'b c')])
             URIBuilder(scheme=None, userinfo=None, host=None, port=None,
                     path=None, query='a=b+c', fragment=None)
-
         """
         query = normalizers.normalize_query(compat.urlencode(query_items))
 
@@ -320,7 +310,6 @@ class URIBuilder:
             >>> URIBuilder().add_query('a=b&c=d')
             URIBuilder(scheme=None, userinfo=None, host=None, port=None,
                     path=None, query='a=b&c=d', fragment=None)
-
         """
         return URIBuilder(
             scheme=self.scheme,
@@ -340,7 +329,6 @@ class URIBuilder:
             >>> URIBuilder().add_fragment('section-2.6.1')
             URIBuilder(scheme=None, userinfo=None, host=None, port=None,
                     path=None, query=None, fragment='section-2.6.1')
-
         """
         return URIBuilder(
             scheme=self.scheme,
@@ -365,13 +353,10 @@ class URIBuilder:
             ...     ).add_path('sigmavirus24/rfc3986').add_credentials(
             ...     'sigmavirus24', 'not-re@l').finalize().unsplit()
             'https://sigmavirus24:not-re%40l@github.com/sigmavirus24/rfc3986'
-
         """
         return uri.URIReference(
             self.scheme,
-            normalizers.normalize_authority(
-                (self.userinfo, self.host, self.port)
-            ),
+            normalizers.normalize_authority((self.userinfo, self.host, self.port)),
             self.path,
             self.query,
             self.fragment,

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/exceptions.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/exceptions.py
@@ -13,9 +13,7 @@ class InvalidAuthority(RFC3986Exception):
 
     def __init__(self, authority):
         """Initialize the exception with the invalid authority."""
-        super().__init__(
-            f"The authority ({compat.to_str(authority)}) is not valid."
-        )
+        super().__init__(f"The authority ({compat.to_str(authority)}) is not valid.")
 
 
 class InvalidPort(RFC3986Exception):
@@ -32,9 +30,7 @@ class ResolutionError(RFC3986Exception):
     def __init__(self, uri):
         """Initialize the error with the failed URI."""
         super().__init__(
-            "{} does not meet the requirements for resolution.".format(
-                uri.unsplit()
-            )
+            f"{uri.unsplit()} does not meet the requirements for resolution."
         )
 
 
@@ -90,9 +86,7 @@ class PasswordForbidden(ValidationError):
         """Initialize the error with the URI that failed validation."""
         unsplit = getattr(uri, "unsplit", lambda: uri)
         super().__init__(
-            '"{}" contained a password when validation forbade it'.format(
-                unsplit()
-            )
+            f'"{unsplit()}" contained a password when validation forbade it'
         )
         self.uri = uri
 

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/iri.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/iri.py
@@ -15,12 +15,7 @@
 # limitations under the License.
 from collections import namedtuple
 
-from . import compat
-from . import exceptions
-from . import misc
-from . import normalizers
-from . import uri
-
+from . import compat, exceptions, misc, normalizers, uri
 
 try:
     import idna
@@ -28,9 +23,7 @@ except ImportError:  # pragma: no cover
     idna = None
 
 
-class IRIReference(
-    namedtuple("IRIReference", misc.URI_COMPONENTS), uri.URIMixin
-):
+class IRIReference(namedtuple("IRIReference", misc.URI_COMPONENTS), uri.URIMixin):
     """Immutable object representing a parsed IRI Reference.
 
     Can be encoded into an URIReference object via the procedure
@@ -43,9 +36,7 @@ class IRIReference(
 
     slots = ()
 
-    def __new__(
-        cls, scheme, authority, path, query, fragment, encoding="utf-8"
-    ):
+    def __new__(cls, scheme, authority, path, query, fragment, encoding="utf-8"):
         """Create a new IRIReference."""
         ref = super().__new__(
             cls,
@@ -135,10 +126,7 @@ class IRIReference(
             authority = ""
             if self.host:
                 authority = ".".join(
-                    [
-                        compat.to_str(idna_encoder(part))
-                        for part in self.host.split(".")
-                    ]
+                    [compat.to_str(idna_encoder(part)) for part in self.host.split(".")]
                 )
 
             if self.userinfo is not None:

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/misc.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/misc.py
@@ -11,11 +11,10 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Module containing compiled regular expressions and constants.
+"""Module containing compiled regular expressions and constants.
 
-This module contains important constants, patterns, and compiled regular
-expressions for parsing and validating URIs and their components.
+This module contains important constants, patterns, and compiled regular expressions for
+parsing and validating URIs and their components.
 """
 import re
 
@@ -52,9 +51,7 @@ SUBAUTHORITY_MATCHER = re.compile(
         "^(?:(?P<userinfo>{})@)?"  # userinfo
         "(?P<host>{})"  # host
         ":?(?P<port>{})?$"  # port
-    ).format(
-        abnf_regexp.USERINFO_RE, abnf_regexp.HOST_PATTERN, abnf_regexp.PORT_RE
-    )
+    ).format(abnf_regexp.USERINFO_RE, abnf_regexp.HOST_PATTERN, abnf_regexp.PORT_RE)
 )
 
 
@@ -110,9 +107,7 @@ ISUBAUTHORITY_MATCHER = re.compile(
         "^(?:(?P<userinfo>{})@)?"  # iuserinfo
         "(?P<host>{})"  # ihost
         ":?(?P<port>{})?$"  # port
-    ).format(
-        abnf_regexp.IUSERINFO_RE, abnf_regexp.IHOST_RE, abnf_regexp.PORT_RE
-    ),
+    ).format(abnf_regexp.IUSERINFO_RE, abnf_regexp.IHOST_RE, abnf_regexp.PORT_RE),
     re.UNICODE,
 )
 

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/normalizers.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/normalizers.py
@@ -14,8 +14,7 @@
 """Module with functions to normalize components."""
 import re
 
-from . import compat
-from . import misc
+from . import compat, misc
 
 
 def normalize_scheme(scheme):

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/parseresult.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/parseresult.py
@@ -14,11 +14,7 @@
 """Module containing the urlparse compatibility logic."""
 from collections import namedtuple
 
-from . import compat
-from . import exceptions
-from . import misc
-from . import normalizers
-from . import uri
+from . import compat, exceptions, misc, normalizers, uri
 
 __all__ = ("ParseResult", "ParseResultBytes")
 
@@ -37,9 +33,7 @@ class ParseResultMixin:
     def _generate_authority(self, attributes):
         # I swear I did not align the comparisons below. That's just how they
         # happened to align based on pep8 and attribute lengths.
-        userinfo, host, port = (
-            attributes[p] for p in ("userinfo", "host", "port")
-        )
+        userinfo, host, port = (attributes[p] for p in ("userinfo", "host", "port"))
         if self.userinfo != userinfo or self.host != host or self.port != port:
             if port:
                 port = f"{port}"
@@ -74,9 +68,7 @@ class ParseResultMixin:
         return self.query
 
 
-class ParseResult(
-    namedtuple("ParseResult", PARSED_COMPONENTS), ParseResultMixin
-):
+class ParseResult(namedtuple("ParseResult", PARSED_COMPONENTS), ParseResultMixin):
     """Implementation of urlparse compatibility class.
 
     This uses the URIReference logic to handle compatibility with the
@@ -230,9 +222,7 @@ class ParseResult(
                 ),
             )
         )
-        return ParseResultBytes(
-            uri_ref=self.reference, encoding=encoding, **attrs
-        )
+        return ParseResultBytes(uri_ref=self.reference, encoding=encoding, **attrs)
 
     def unsplit(self, use_idna=False):
         """Create a URI string from the components.

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/uri.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/uri.py
@@ -15,9 +15,7 @@
 # limitations under the License.
 from collections import namedtuple
 
-from . import compat
-from . import misc
-from . import normalizers
+from . import compat, misc, normalizers
 from ._mixin import URIMixin
 
 
@@ -81,9 +79,7 @@ class URIReference(namedtuple("URIReference", misc.URI_COMPONENTS), URIMixin):
 
     slots = ()
 
-    def __new__(
-        cls, scheme, authority, path, query, fragment, encoding="utf-8"
-    ):
+    def __new__(cls, scheme, authority, path, query, fragment, encoding="utf-8"):
         """Create a new URIReference."""
         ref = super().__new__(
             cls,
@@ -130,9 +126,7 @@ class URIReference(namedtuple("URIReference", misc.URI_COMPONENTS), URIMixin):
         # this method.
         return URIReference(
             normalizers.normalize_scheme(self.scheme or ""),
-            normalizers.normalize_authority(
-                (self.userinfo, self.host, self.port)
-            ),
+            normalizers.normalize_authority((self.userinfo, self.host, self.port)),
             normalizers.normalize_path(self.path or ""),
             normalizers.normalize_query(self.query),
             normalizers.normalize_fragment(self.fragment),

--- a/python-packages/smithy-python/smithy_python/_private/rfc3986/validators.py
+++ b/python-packages/smithy-python/smithy_python/_private/rfc3986/validators.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module containing the validation logic for rfc3986."""
-from . import exceptions
-from . import misc
-from . import normalizers
+from . import exceptions, misc, normalizers
 
 
 class Validator:
@@ -41,7 +39,6 @@ class Validator:
          rfc3986.exceptions.MissingComponentError: ('path was required but
          missing', URIReference(scheme=u'imap', authority=u'mail.google.com',
          path=None, query=None, fragment=None), ['path'])
-
     """
 
     COMPONENT_NAMES = frozenset(
@@ -159,9 +156,7 @@ class Validator:
         for component in components:
             if component not in self.COMPONENT_NAMES:
                 raise ValueError(f'"{component}" is not a valid component')
-        self.validated_components.update(
-            {component: True for component in components}
-        )
+        self.validated_components.update({component: True for component in components})
         return self
 
     def require_presence_of(self, *components):
@@ -182,9 +177,7 @@ class Validator:
         for component in components:
             if component not in self.COMPONENT_NAMES:
                 raise ValueError(f'"{component}" is not a valid component')
-        self.required_components.update(
-            {component: True for component in components}
-        )
+        self.required_components.update({component: True for component in components})
         return self
 
     def validate(self, uri):


### PR DESCRIPTION
*Description of changes:*
Per a conversation that was started here: https://github.com/awslabs/smithy-python/pull/143#discussion_r1116884691
and continue offline, it was determined that, in order to properly validate URI components, we should vend the entire `rfc3986` package. Since it is an independent package that we are simply vending/copying, it will be excluded from our build system pants.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
