### PR TITLE
remove enable_recursive_aliases setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,6 @@
 strict = true
 warn_unused_configs = true
 
-# This should be removable after mypy 0.990, it's needed to allow the document
-# alias to successfully be checked.
-enable_recursive_aliases = true
-
 [[tool.mypy.overrides]]
 module = ["awscrt", "pytest"]
 ignore_missing_imports = true


### PR DESCRIPTION
Remove the `enable_recursive_aliases` setting since it is enabled by default as of mypy 1.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
