### PR TITLE
add html coverage report

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -36,7 +36,10 @@ lockfile = "lockfiles/pytest"
 
 [coverage-py]
 interpreter_constraints = [">=3.11"]
-report = "xml"
+report = [
+    "xml",
+    "html"
+]
 
 [mypy]
 version = "mypy==1.0.0"


### PR DESCRIPTION
*Description of changes:*
This adds an html coverage report when running `./pants test` with the `--test-use-coverage` flag. This will make it easier for us to ensure our code is as covered as possible while running tests within the pants build system rather than running `coverage` separately.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
