### PR TITLE
Remove presence tracking

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -42,7 +42,6 @@ import software.amazon.smithy.model.knowledge.NullableIndex;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
@@ -90,30 +89,6 @@ public final class CodegenUtils {
                 .name("Plugin")
                 .namespace(format("%s.config", settings.getModuleName()), ".")
                 .definitionFile(format("./%s/config.py", settings.getModuleName()))
-                .build();
-    }
-
-    /**
-     * @param settings The client settings, used to account for module configuration.
-     * @return Returns the function that wraps and casts default values.
-     */
-    static Symbol getDefaultWrapperFunction(PythonSettings settings) {
-        return Symbol.builder()
-                .name("_default")
-                .namespace(format("%s.models", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/models.py", settings.getModuleName()))
-                .build();
-    }
-
-    /**
-     * @param settings The client settings, used to account for module configuration.
-     * @return Returns the symbol for the class that wraps default values.
-     */
-    static Symbol getDefaultWrapperClass(PythonSettings settings) {
-        return Symbol.builder()
-                .name("_DEFAULT")
-                .namespace(format("%s.models", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/models.py", settings.getModuleName()))
                 .build();
     }
 
@@ -391,17 +366,7 @@ public final class CodegenUtils {
         var shouldDedent = false;
         var isNullable = NullableIndex.of(context.model()).isMemberNullable(member);
         var memberName = context.symbolProvider().toMemberName(member);
-        if (member.getMemberTrait(context.model(), DefaultTrait.class).isPresent()) {
-            if (!accessFalsey) {
-                writer.write("if $1L._hasattr($2S) and $1L.$2L:", variableName, memberName);
-            } else if (isNullable) {
-                writer.write("if $1L._hasattr($2S) and $1L.$2L is not None:", variableName, memberName);
-            } else {
-                writer.write("if $L._hasattr($S):", variableName, memberName);
-            }
-            writer.indent();
-            shouldDedent = true;
-        } else if (!accessFalsey) {
+        if (!accessFalsey) {
             writer.write("if $L.$L:", variableName, memberName);
             writer.indent();
             shouldDedent = true;

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
@@ -107,7 +107,6 @@ final class DirectedPythonCodegen implements DirectedCodegen<GenerationContext, 
 
     @Override
     public void customizeBeforeShapeGeneration(CustomizeDirective<GenerationContext, PythonSettings> directive) {
-        generateDefaultWrapper(directive.settings(), directive.context().writerDelegator());
         generateServiceErrors(directive.settings(), directive.context().writerDelegator());
         addDefaultEndpointProvider(directive);
         new ConfigGenerator(directive.settings(), directive.context()).run();
@@ -167,63 +166,6 @@ final class DirectedPythonCodegen implements DirectedCodegen<GenerationContext, 
         protocolGenerator.generateResponseDeserializers(directive.context());
 
         protocolGenerator.generateProtocolTests(directive.context());
-    }
-
-    private void generateDefaultWrapper(PythonSettings settings, WriterDelegator<PythonWriter> writers) {
-        var wrapperClass = CodegenUtils.getDefaultWrapperClass(settings);
-        writers.useFileWriter(wrapperClass.getDefinitionFile(), wrapperClass.getNamespace(), writer -> {
-            writer.addStdlibImport("typing", "Any");
-            writer.write("""
-                    class _DEFAULT:
-                        def __init__(self, wrapped: Any):
-                            ""\"Wraps a value to signal it was provided by default.
-
-                            These values will be immediately unwrapped in the associated
-                            initializers so the values can be used as normal, the defaultedness
-                            will then be tracked separately.
-                            ""\"
-                            self._wrapped = wrapped
-
-                        @property
-                        def value(self) -> Any:
-                            # Prevent mutations from leaking by simply returning copies of mutable
-                            # defaults. We could also just make immutable subclasses.
-                            if isinstance(self._wrapped, list):
-                                return list(self._wrapped)
-                            if isinstance(self._wrapped, dict):
-                                return dict(self._wrapped)
-                            return self._wrapped
-
-                        def __repr__(self) -> str:
-                            return f"_DEFAULT({repr(self._wrapped)})"
-
-                        def __str__(self) -> str:
-                            return str(self._wrapped)
-                    """);
-        });
-
-        var wrapperFunction = CodegenUtils.getDefaultWrapperFunction(settings);
-        writers.useFileWriter(wrapperFunction.getDefinitionFile(), wrapperFunction.getNamespace(), writer -> {
-            writer.addStdlibImport("typing", "TypeVar");
-            writer.addStdlibImport("typing", "cast");
-            writer.write("""
-                        _D = TypeVar("_D")
-
-
-                        def _default(value: _D) -> _D:
-                            ""\"Wraps a value to signal it was provided by default.
-
-                            These values will be immediately unwrapped in the associated
-                            initializers so the values can be used as normal, the defaultedness
-                            will then be tracked separately.
-
-                            We use this wrapper function for brevity, but also because many completion
-                            tools will show the code of the default rather than the result, and
-                            `_default(7)` is a bit more clear than `cast(int, _DEFAULT(7))`.
-                            ""\"
-                            return cast(_D, $T(value))
-                        """, wrapperClass);
-        });
     }
 
     private void generateServiceErrors(PythonSettings settings, WriterDelegator<PythonWriter> writers) {

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeDeserVisitor.java
@@ -30,7 +30,6 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
-import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.SparseTrait;
 import software.amazon.smithy.model.traits.StringTrait;
@@ -204,9 +203,7 @@ public class JsonShapeDeserVisitor extends ShapeVisitor.Default<Void> {
 
             var target = context.model().expectShape(member.getTarget());
 
-            if (index.isMemberNullable(member) || member.hasTrait(DefaultTrait.class)) {
-                // Note that default values are handled by the constructor, so
-                // we don't need to do anything special here.
+            if (index.isMemberNullable(member)) {
                 var memberVisitor = getMemberVisitor(member, "_" + pythonName);
                 var memberDeserializer = target.accept(memberVisitor);
                 writer.write("""


### PR DESCRIPTION
Smithy guidance has changed to no longer require presense tracking for default values. This PR removes all code that facilitates that, instead opting to use a more typical python default value setup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
