### PR TITLE
Docs: Remove left-behind reference to SeekableByteStream

### DIFF
--- a/designs/shapes.md
+++ b/designs/shapes.md
@@ -154,9 +154,9 @@ Additionally, it will support passing in a `ByteStream` which is any class that
 implements a `read` method that accepts a `size` param and returns bytes.
 It will also accept an async variant of that same type or an `AsyncIterable`.
 
-Both `ByteStream`, `SeekableByteStream`, and `AsyncByteStream` will be
-implemented as [Protocols](https://www.python.org/dev/peps/pep-0544/),
-which are a way of defining structural subtyping in Python.
+Both `ByteStream` and `AsyncByteStream` will be implemented as [Protocols
+](https://www.python.org/dev/peps/pep-0544/), which are a way of defining
+structural subtyping in Python.
 
 ```python
 @runtime_checkable


### PR DESCRIPTION
One mention of `SeekableByteStream` was left behind when all others were deleted in https://github.com/awslabs/smithy-python/pull/154. This PR removes the straggler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
