### PR TITLE
add seekable async iterable interface

### DIFF
--- a/python-packages/smithy-python/smithy_python/async_utils.py
+++ b/python-packages/smithy-python/smithy_python/async_utils.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from asyncio import sleep
-from collections.abc import AsyncIterable, Iterable
+from collections.abc import AsyncGenerator, AsyncIterable, Iterable
 from typing import TypeVar
 
 _ListEl = TypeVar("_ListEl")
@@ -23,3 +23,105 @@ async def async_list(lst: Iterable[_ListEl]) -> AsyncIterable[_ListEl]:
     for x in lst:
         await sleep(0)
         yield x
+
+
+class SeekableAsyncIterable(AsyncIterable[bytes]):
+    """An AsyncIterable constructed from a list of bytes that can be moved forward or
+    backward to a specific offset."""
+
+    def __init__(self, values: list[bytes]) -> None:
+        self._values = values
+        self._position: int = 0
+        self._chunk_offset: int = 0
+        self._tell: int = 0
+
+    def __aiter__(self) -> AsyncGenerator[bytes, None]:
+        return self._async_generator()
+
+    async def __anext__(self) -> bytes:
+        try:
+            value = self._values[self._position]
+        except IndexError:
+            raise StopAsyncIteration()
+        else:
+            self._move_pos(len(value))
+            return value
+
+    async def _async_generator(self) -> AsyncGenerator[bytes, None]:
+        for i, value in enumerate(self._values[self._position :]):
+            if i == 0:
+                value = value[self._chunk_offset :]
+            await sleep(0)
+            yield value
+            self._move_pos(len(value))
+
+    def _move_pos(self, offset: int) -> None:
+        self._tell += offset
+        self._position += 1
+
+    async def seek(self, offset: int, whence: int = 0) -> None:
+        """Seek to a specific offset in the iterable.
+
+        :param offset: The offset to seek to.
+        :param whence: The reference point to seek from in the stream. 0 will seek
+        from the beginning, 1 will seek from the current position, and 2 will seek
+        from the end.
+        """
+        if whence == 0 and offset < 0:
+            raise ValueError(
+                "Cannot seek to a negative offset when seeking from the beginning "
+                "of the stream."
+            )
+
+        if offset == self.tell():
+            return
+        # TODO: Support seeking from the current position and end of the stream.
+        # AKA whence = 1 or 2.
+
+        self._reset()
+        total_offset = 0
+        async for chunk in self:
+            chunk_size = len(chunk)
+            if total_offset + chunk_size > offset:
+                self._offset_chunk(offset - total_offset)
+                return
+            total_offset += chunk_size
+
+        # Ensure that tell is set to the provided offset rather than the position
+        # at the end of the stream.
+        self._tell = offset
+
+    def _reset(self) -> None:
+        self._tell = 0
+        self._chunk_offset = 0
+        self._position = 0
+
+    def tell(self) -> int:
+        """Return the current offset."""
+        return self._tell
+
+    async def read(self, size: int = -1) -> bytes:
+        """Read a chunk of bytes from the iterable.
+
+        :param size: The number of bytes to read. If less than zero,
+        read the entire remaining contents of the iterable.
+        """
+        data = b""
+        if size < 0:
+            async for chunk in self:
+                data += chunk
+        elif size > 0:
+            total_size = 0
+            async for chunk in self:
+                chunk_size = len(chunk)
+                if total_size + chunk_size > size:
+                    data += chunk[: size - total_size]
+                    self._offset_chunk(size - total_size)
+                    break
+                total_size += chunk_size
+                data += chunk
+        return data
+
+    def _offset_chunk(self, offset: int) -> None:
+        self._chunk_offset = offset
+        self._tell += self._chunk_offset

--- a/python-packages/smithy-python/tests/unit/test_async_utils.py
+++ b/python-packages/smithy-python/tests/unit/test_async_utils.py
@@ -1,0 +1,83 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import pytest
+
+from smithy_python.async_utils import SeekableAsyncIterable
+
+
+@pytest.fixture(scope="function")
+def seekable_async_iterable() -> SeekableAsyncIterable:
+    return SeekableAsyncIterable([b"a" * 10, b"b" * 10, b"c" * 10])
+
+
+@pytest.mark.asyncio
+async def test_seekable_async_iterable_stop_iteration(
+    seekable_async_iterable: SeekableAsyncIterable,
+) -> None:
+    with pytest.raises(StopAsyncIteration):
+        while True:
+            await anext(seekable_async_iterable)
+
+
+@pytest.mark.asyncio
+async def test_seekable_async_iterable_anext(
+    seekable_async_iterable: SeekableAsyncIterable,
+) -> None:
+    assert await anext(seekable_async_iterable) == b"a" * 10
+    assert seekable_async_iterable.tell() == 10
+    assert await anext(seekable_async_iterable) == b"b" * 10
+    assert seekable_async_iterable.tell() == 20
+    assert await anext(seekable_async_iterable) == b"c" * 10
+    assert seekable_async_iterable.tell() == 30
+
+
+@pytest.mark.parametrize(
+    "offset, expected_result",
+    [
+        (0, b"a" * 10 + b"b" * 10 + b"c" * 10),
+        (5, b"a" * 5 + b"b" * 10 + b"c" * 10),
+        (10, b"b" * 10 + b"c" * 10),
+        (11, b"b" * 9 + b"c" * 10),
+        (20, b"c" * 10),
+        (29, b"c"),
+        (50, b""),
+    ],
+)
+@pytest.mark.asyncio
+async def test_seek(
+    seekable_async_iterable: SeekableAsyncIterable,
+    offset: int,
+    expected_result: bytes,
+) -> None:
+    await seekable_async_iterable.seek(offset)
+    assert seekable_async_iterable.tell() == offset
+    assert await seekable_async_iterable.read() == expected_result
+
+
+@pytest.mark.asyncio
+async def test_negative_seek_raises(
+    seekable_async_iterable: SeekableAsyncIterable,
+) -> None:
+    with pytest.raises(ValueError):
+        await seekable_async_iterable.seek(-1)
+
+
+@pytest.mark.parametrize(
+    "size, expected_result",
+    [(0, b""), (5, b"a" * 5), (10, b"a" * 10), (-1, b"a" * 10 + b"b" * 10 + b"c" * 10)],
+)
+@pytest.mark.asyncio
+async def test_read(
+    seekable_async_iterable: SeekableAsyncIterable, size: int, expected_result: bytes
+) -> None:
+    assert await seekable_async_iterable.read(size) == expected_result


### PR DESCRIPTION
*Description of changes:*
This implements a new interface `SeekableAsyncIterable`. It is an asynchronous iterable that is capable of seeking, meaning the exact byte position can be set at any given time. It only accepts a list of bytes and the public APIs are specifically meant to consume a stream of chunked bytes. Similar to other i/o objects in Python, it implements `seek`, `tell` and `read`.

This should unblock https://github.com/awslabs/smithy-python/pull/136 which needed this implementation for processing request payloads that can be rewound.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
