### PR TITLE
Implement api key auth

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpApiKeyAuth.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpApiKeyAuth.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.python.codegen.integration;
+
+import java.util.List;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
+import software.amazon.smithy.python.codegen.ApplicationProtocol;
+import software.amazon.smithy.python.codegen.CodegenUtils;
+import software.amazon.smithy.python.codegen.ConfigProperty;
+import software.amazon.smithy.python.codegen.GenerationContext;
+import software.amazon.smithy.python.codegen.SmithyPythonDependency;
+
+/**
+ * Adds support for the http api key auth.
+ * {@see https://smithy.io/2.0/spec/authentication-traits.html#smithy-api-httpapikeyauth-trait}
+ */
+public final class HttpApiKeyAuth implements PythonIntegration {
+    private static final String OPTION_GENERATOR_NAME = "_generate_api_key_option";
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return List.of(
+            RuntimeClientPlugin.builder()
+                .servicePredicate((model, service) -> service.hasTrait(HttpApiKeyAuthTrait.class))
+                .addConfigProperty(ConfigProperty.builder()
+                    .name("api_key_identity_resolver")
+                    .documentation("Resolves the API key. Required for operations that use API key auth.")
+                    .type(Symbol.builder()
+                        .name("IdentityResolver[ApiKeyIdentity, IdentityProperties]")
+                        .addReference(Symbol.builder()
+                            .addDependency(SmithyPythonDependency.SMITHY_PYTHON)
+                            .name("IdentityResolver")
+                            .namespace("smithy_python.interfaces.identity", ".")
+                            .build())
+                        .addReference(Symbol.builder()
+                            .addDependency(SmithyPythonDependency.SMITHY_PYTHON)
+                            .name("ApiKeyIdentity")
+                            .namespace("smithy_python._private.api_key_auth", ".")
+                            .build())
+                        .addReference(Symbol.builder()
+                            .addDependency(SmithyPythonDependency.SMITHY_PYTHON)
+                            .name("IdentityProperties")
+                            .namespace("smithy_python.interfaces.identity", ".")
+                            .build())
+                        .build())
+                    .nullable(true)
+                    .build())
+                .authScheme(new ApiKeyAuthScheme())
+                .build()
+        );
+    }
+
+    @Override
+    public void customize(GenerationContext context) {
+        if (!hasApiKeyAuth(context)) {
+            return;
+        }
+        var trait = context.settings().getService(context.model()).expectTrait(HttpApiKeyAuthTrait.class);
+        var params = CodegenUtils.getHttpAuthParamsSymbol(context.settings());
+        var resolver = CodegenUtils.getHttpAuthSchemeResolverSymbol(context.settings());
+
+        // Add a function that generates the http auth option for api key auth.
+        // This needs to be generated because there's modeled parameters that
+        // must be accounted for.
+        context.writerDelegator().useFileWriter(resolver.getDefinitionFile(), resolver.getNamespace(), writer -> {
+            writer.addDependency(SmithyPythonDependency.SMITHY_PYTHON);
+            writer.addImport("smithy_python.interfaces.auth", "HTTPAuthOption");
+            writer.addImport("smithy_python._private.api_key_auth", "ApiKeyLocation");
+            writer.pushState();
+
+            // Push the scheme into the context to allow for conditionally adding
+            // it to the properties dict.
+            writer.putContext("scheme", trait.getScheme().orElse(null));
+            writer.write("""
+                def $1L(auth_params: $2T) -> HTTPAuthOption:
+                    return HTTPAuthOption(
+                        scheme_id=$3S,
+                        identity_properties={},
+                        signer_properties={
+                            "name": $4S,
+                            "location": ApiKeyLocation($5S),
+                            ${?scheme}
+                            "scheme": ${scheme:S},
+                            ${/scheme}
+                        }
+                    )
+                """, OPTION_GENERATOR_NAME, params, HttpApiKeyAuthTrait.ID.toString(),
+                trait.getName(), trait.getIn().toString());
+            writer.popState();
+        });
+    }
+
+    private boolean hasApiKeyAuth(GenerationContext context) {
+        var service = context.settings().getService(context.model());
+        return service.hasTrait(HttpApiKeyAuthTrait.class);
+    }
+
+    /**
+     * The AuthScheme representing api key auth.
+     */
+    private static final class ApiKeyAuthScheme implements AuthScheme {
+
+        @Override
+        public ShapeId getAuthTrait() {
+            return HttpApiKeyAuthTrait.ID;
+        }
+
+        @Override
+        public ApplicationProtocol getApplicationProtocol() {
+            return ApplicationProtocol.createDefaultHttpApplicationProtocol();
+        }
+
+        @Override
+        public Symbol getAuthOptionGenerator(GenerationContext context) {
+            var resolver = CodegenUtils.getHttpAuthSchemeResolverSymbol(context.settings());
+            return Symbol.builder()
+                .name(OPTION_GENERATOR_NAME)
+                .namespace(resolver.getNamespace(), ".")
+                .definitionFile(resolver.getDefinitionFile())
+                .build();
+        }
+
+        @Override
+        public Symbol getAuthSchemeSymbol(GenerationContext context) {
+            return Symbol.builder()
+                .name("ApiKeyAuthScheme")
+                .namespace("smithy_python._private.api_key_auth", ".")
+                .addDependency(SmithyPythonDependency.SMITHY_PYTHON)
+                .build();
+        }
+    }
+}

--- a/codegen/smithy-python-codegen/src/main/resources/META-INF/services/software.amazon.smithy.python.codegen.integration.PythonIntegration
+++ b/codegen/smithy-python-codegen/src/main/resources/META-INF/services/software.amazon.smithy.python.codegen.integration.PythonIntegration
@@ -4,3 +4,4 @@
 #
 
 software.amazon.smithy.python.codegen.integration.RestJsonIntegration
+software.amazon.smithy.python.codegen.integration.HttpApiKeyAuth

--- a/python-packages/smithy-python/smithy_python/_private/api_key_auth.py
+++ b/python-packages/smithy-python/smithy_python/_private/api_key_auth.py
@@ -1,0 +1,145 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import NotRequired, Protocol, TypedDict
+
+from ..exceptions import SmithyIdentityException
+from ..interfaces.auth import HTTPAuthScheme, HTTPSigner
+from ..interfaces.http import HTTPRequest
+from ..interfaces.identity import IdentityProperties, IdentityResolver
+from . import URI, Field
+from .identity import Identity
+
+
+class ApiKeyIdentity(Identity):
+    """The identity for auth that uses an api key."""
+
+    def __init__(self, *, api_key: str) -> None:
+        super().__init__(expiration=None)
+        self.api_key = api_key
+
+
+class ApiKeyIdentityResolver(IdentityResolver[ApiKeyIdentity, IdentityProperties]):
+    """Loads the api key identity from the configuration."""
+
+    def __init__(self, *, api_key: str | ApiKeyIdentity) -> None:
+        """
+        :param api_key: The API key to authenticate with.
+        """
+        match api_key:
+            case str():
+                self._identity = ApiKeyIdentity(api_key=api_key)
+            case ApiKeyIdentity():
+                self._identity = api_key
+
+    async def get_identity(
+        self, *, identity_properties: IdentityProperties
+    ) -> ApiKeyIdentity:
+        """Load the user's api key identity from this resolver.
+
+        :param identity_properties: Properties used to help determine the
+        identity to return.
+        :returns: The api key identity.
+        """
+        return self._identity
+
+
+class ApiKeyLocation(Enum):
+    """The locations that the api key could be placed in the signed request."""
+
+    HEADER = "header"
+    QUERY = "query"
+
+
+class ApiKeySigningProperties(TypedDict):
+    """The properties needed to sign a request with api key auth.
+
+    seealso:: The `Smithy API Key auth trait docs <https://smithy.io/2.0/spec/authentication-traits.html#smithy-api-httpapikeyauth-trait>`_
+    , which have more details on these properties, including examples.
+    """
+
+    name: str
+    """The name of the HTTP header or query string parameter containing the key."""
+
+    scheme: NotRequired[str]
+    """The :rfc:`9110#section-11.4` scheme to prefix a header value with."""
+
+    location: ApiKeyLocation
+    """Where the key is serialized."""
+
+
+class ApiKeyConfig(Protocol):
+    api_key_identity_resolver: IdentityResolver[
+        ApiKeyIdentity, IdentityProperties
+    ] | None
+
+
+@dataclass(init=False)
+class ApiKeyAuthScheme(
+    HTTPAuthScheme[
+        ApiKeyIdentity, ApiKeyConfig, IdentityProperties, ApiKeySigningProperties
+    ]
+):
+    """An auth scheme containing necessary data and tools for api key auth."""
+
+    scheme_id: str
+    signer: HTTPSigner[ApiKeyIdentity, ApiKeySigningProperties]
+
+    def __init__(
+        self,
+        *,
+        signer: HTTPSigner[ApiKeyIdentity, ApiKeySigningProperties] | None = None,
+    ) -> None:
+        """Constructor.
+
+        :param identity_resolver: The identity resolver to extract the api key identity.
+        :param signer: The signer used to sign the request.
+        """
+        self.scheme_id = "smithy.api#httpApiKeyAuth"
+        self.signer = signer or ApiKeySigner()
+
+    def identity_resolver(
+        self, *, config: ApiKeyConfig
+    ) -> IdentityResolver[ApiKeyIdentity, IdentityProperties]:
+        if not config.api_key_identity_resolver:
+            raise SmithyIdentityException(
+                "Attempted to use API key auth, but api_key_identity_resolver was not"
+                "set on the config."
+            )
+        return config.api_key_identity_resolver
+
+
+class ApiKeySigner(HTTPSigner[ApiKeyIdentity, ApiKeySigningProperties]):
+    """A signer that signs http requests with an api key."""
+
+    async def sign(
+        self,
+        *,
+        http_request: HTTPRequest,
+        identity: ApiKeyIdentity,
+        signing_properties: ApiKeySigningProperties,
+    ) -> HTTPRequest:
+        match signing_properties["location"]:
+            case ApiKeyLocation.QUERY:
+                query = http_request.destination.query or ""
+                if query:
+                    query += "&"
+                query += f"{signing_properties['name']}={identity.api_key}"
+                http_request.destination = URI(
+                    scheme=http_request.destination.scheme,
+                    username=http_request.destination.username,
+                    password=http_request.destination.password,
+                    host=http_request.destination.host,
+                    port=http_request.destination.port,
+                    path=http_request.destination.password,
+                    query=query,
+                    fragment=http_request.destination.fragment,
+                )
+            case ApiKeyLocation.HEADER:
+                value = identity.api_key
+                if "scheme" in signing_properties and signing_properties["scheme"]:
+                    value = f"{signing_properties['scheme']} {value}"
+                http_request.fields.set_field(
+                    Field(name=signing_properties["name"], values=[value])
+                )
+
+        return http_request

--- a/python-packages/smithy-python/tests/unit/test_api_key_auth.py
+++ b/python-packages/smithy-python/tests/unit/test_api_key_auth.py
@@ -1,0 +1,157 @@
+from dataclasses import dataclass
+from typing import AsyncIterable, AsyncIterator
+
+import pytest
+
+from smithy_python._private import URI, Field, Fields
+from smithy_python._private.api_key_auth import (
+    ApiKeyAuthScheme,
+    ApiKeyIdentity,
+    ApiKeyIdentityResolver,
+    ApiKeyLocation,
+    ApiKeySigner,
+    ApiKeySigningProperties,
+)
+from smithy_python._private.http import HTTPRequest
+from smithy_python.exceptions import SmithyIdentityException
+from smithy_python.interfaces.identity import IdentityProperties, IdentityResolver
+
+
+@pytest.fixture
+def signer() -> ApiKeySigner:
+    return ApiKeySigner()
+
+
+class _FakeBody(AsyncIterable[bytes]):
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        return self
+
+    async def __anext__(self) -> bytes:
+        return b"spam"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeBody)
+
+
+def request(query: str | None = None, fields: Fields | None = None) -> HTTPRequest:
+    return HTTPRequest(
+        destination=URI(host="example.com", query=query),
+        body=_FakeBody(),
+        method="POST",
+        fields=fields or Fields(),
+    )
+
+
+async def test_identity_resolver() -> None:
+    api_key = "spam"
+    resolver = ApiKeyIdentityResolver(api_key=api_key)
+    identity = await resolver.get_identity(identity_properties={})
+
+    assert identity.api_key == api_key
+
+    resolver = ApiKeyIdentityResolver(api_key=ApiKeyIdentity(api_key=api_key))
+    identity = await resolver.get_identity(identity_properties={})
+
+    assert identity.api_key == api_key
+
+
+async def test_sign_empty_query(signer: ApiKeySigner) -> None:
+    api_key = "spam"
+    identity = ApiKeyIdentity(api_key=api_key)
+    properties: ApiKeySigningProperties = {
+        "name": "eggs",
+        "location": ApiKeyLocation.QUERY,
+    }
+
+    given = request()
+    expected = request(query="eggs=spam")
+
+    actual = await signer.sign(
+        http_request=given,
+        identity=identity,
+        signing_properties=properties,
+    )
+
+    assert actual == expected
+
+
+async def test_sign_non_empty_query(signer: ApiKeySigner) -> None:
+    api_key = "spam"
+    identity = ApiKeyIdentity(api_key=api_key)
+    properties: ApiKeySigningProperties = {
+        "name": "eggs",
+        "location": ApiKeyLocation.QUERY,
+    }
+
+    given = request(query="spam=eggs")
+    expected = request(query="spam=eggs&eggs=spam")
+
+    actual = await signer.sign(
+        http_request=given,
+        identity=identity,
+        signing_properties=properties,
+    )
+
+    assert actual == expected
+
+
+async def test_sign_header(signer: ApiKeySigner) -> None:
+    api_key = "spam"
+    identity = ApiKeyIdentity(api_key=api_key)
+    properties: ApiKeySigningProperties = {
+        "name": "eggs",
+        "location": ApiKeyLocation.HEADER,
+    }
+
+    given = request()
+    expected = request(fields=Fields([Field(name="eggs", values=["spam"])]))
+
+    actual = await signer.sign(
+        http_request=given,
+        identity=identity,
+        signing_properties=properties,
+    )
+
+    assert actual == expected
+
+
+async def test_sign_header_with_scheme(signer: ApiKeySigner) -> None:
+    api_key = "spam"
+    identity = ApiKeyIdentity(api_key=api_key)
+    properties: ApiKeySigningProperties = {
+        "name": "eggs",
+        "location": ApiKeyLocation.HEADER,
+        "scheme": "Bearer",
+    }
+
+    given = request()
+    expected = request(fields=Fields([Field(name="eggs", values=["Bearer spam"])]))
+
+    actual = await signer.sign(
+        http_request=given,
+        identity=identity,
+        signing_properties=properties,
+    )
+
+    assert actual == expected
+
+
+@dataclass
+class ApiKeyConfig:
+    api_key_identity_resolver: IdentityResolver[
+        ApiKeyIdentity, IdentityProperties
+    ] | None = None
+
+
+async def test_auth_scheme_gets_resolver() -> None:
+    scheme = ApiKeyAuthScheme()
+    resolver = ApiKeyIdentityResolver(api_key="spam")
+    config = ApiKeyConfig(api_key_identity_resolver=resolver)
+
+    assert resolver == scheme.identity_resolver(config=config)
+
+
+async def test_auth_scheme_missing_resolver() -> None:
+    scheme = ApiKeyAuthScheme()
+    with pytest.raises(SmithyIdentityException):
+        scheme.identity_resolver(config=ApiKeyConfig())


### PR DESCRIPTION
This adds support for [api key auth](https://smithy.io/2.0/spec/authentication-traits.html#smithy-api-httpapikeyauth-trait).


Here's the relevant parts of the config, including new entries and newly populated defaults:

```python
@dataclass(init=False)
class Config:
    """Configuration for Weather."""

    interceptors: list[_ServiceInterceptor]
    retry_strategy: RetryStrategy
    http_client: HTTPClient
    http_request_config: HTTPRequestConfiguration | None
    endpoint_resolver: EndpointResolver[Any]
    endpoint_uri: str | URI | None
    http_auth_schemes: dict[str, HTTPAuthScheme[Any, Any, Any, Any]]
    http_auth_scheme_resolver: HTTPAuthSchemeResolver
    api_key_identity_resolver: IdentityResolver[
        ApiKeyIdentity, IdentityProperties
    ] | None

    def __init__(
        self,
        *,
        interceptors: list[_ServiceInterceptor] | None = None,
        retry_strategy: RetryStrategy | None = None,
        http_client: HTTPClient | None = None,
        http_request_config: HTTPRequestConfiguration | None = None,
        endpoint_resolver: EndpointResolver[Any] | None = None,
        endpoint_uri: str | URI | None = None,
        http_auth_schemes: dict[str, HTTPAuthScheme[Any, Any, Any, Any]] | None = None,
        http_auth_scheme_resolver: HTTPAuthSchemeResolver | None = None,
        api_key_identity_resolver: IdentityResolver[ApiKeyIdentity, IdentityProperties]
        | None = None,
    ):
        self.interceptors = interceptors or []
        self.retry_strategy = retry_strategy or SimpleRetryStrategy()
        self.http_client = http_client or AIOHTTPClient()
        self.http_request_config = http_request_config
        self.endpoint_resolver = endpoint_resolver or StaticEndpointResolver()
        self.endpoint_uri = endpoint_uri
        self.http_auth_schemes = http_auth_schemes or {
            "smithy.api#httpApiKeyAuth": ApiKeyAuthScheme(),
        }

        self.http_auth_scheme_resolver = (
            http_auth_scheme_resolver or HTTPAuthSchemeResolver()
        )
        self.api_key_identity_resolver = api_key_identity_resolver

    def set_http_auth_scheme(self, scheme: HTTPAuthScheme[Any, Any, Any, Any]) -> None:
        """Sets the implementation of an auth scheme.

        Using this method ensures the correct key is used.

        :param scheme: The auth scheme to add.
        """
        self.http_auth_schemes[scheme.scheme_id] = scheme

```

The following is the new auth resolver:

```python
@dataclass
class HTTPAuthParams:
    operation: str


class HTTPAuthSchemeResolver:
    def resolve_auth_scheme(
        self, auth_parameters: HTTPAuthParams
    ) -> list[HTTPAuthOption]:
        auth_options: list[HTTPAuthOption] = []

        # This is an example of an operation that is unauthed. Operations that have a subset
        # of auth will also be special cased in this way inside this function, all from model
        # derived information.
        if auth_parameters.operation == "GetCurrentTime":
            return auth_options

        if (option := _generate_api_key_option(auth_parameters)) is not None:
            auth_options.append(option)

        return auth_options


def _generate_api_key_option(auth_params: HTTPAuthParams) -> HTTPAuthOption:
    return HTTPAuthOption(
        scheme_id="smithy.api#httpApiKeyAuth",
        identity_properties={},
        signer_properties={
            "name": "weather-auth",
            "location": ApiKeyLocation("header"),
        },
    )
```

An api key client might be constructed like so:

```python
api_key = "spam"
config = Config(api_key_identity_resolver=ApiKeyIdentityResolver(api_key=api_key))
client = Weather(config=config)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
