### PR TITLE
Upgrade pants and add security linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,10 @@ for all its packages, so you will need that too to work on it.
 Pants provides a number of python commands it calls goals, documente [here]
 (https://www.pantsbuild.org/docs/python-goals). In short:
 
-* `./pants fmt ::` - This will run our formatters on all of the python library
-  code. Use this before you make a commit.
+* `./pants fmt ::` - This will run some of our formatters on all of the python
+  library code. Use this before you make a commit.
+* `./pants fix ::` - This will run the rest of the formatters on python library
+  code. Also use this before commits.
 * `./pants lint ::` - This will run our linters on all of the python library
   code. You should also use this before you make a commit, and particularly
   before you make a pull request.

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.15.0"
+pants_version = "2.16.0"
 
 backend_packages = [
     "pants.backend.python",

--- a/pants.toml
+++ b/pants.toml
@@ -9,6 +9,7 @@ backend_packages = [
     "pants.backend.python.typecheck.mypy",
     "pants.backend.python.lint.pyupgrade",
     "pants.backend.python.lint.docformatter",
+    "pants.backend.python.lint.bandit",
 ]
 
 [source]
@@ -63,6 +64,9 @@ version = "docformatter==1.5.1"
 args = ["--wrap-summaries 88", "--wrap-descriptions 88"]
 lockfile = "lockfiles/docformatter"
 interpreter_constraints = [">=3.11"]
+
+[bandit]
+args = ["-x tests"]
 
 [anonymous-telemetry]
 enabled = false

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.14.0"
+pants_version = "2.15.0"
 
 backend_packages = [
     "pants.backend.python",
@@ -7,7 +7,7 @@ backend_packages = [
     "pants.backend.python.lint.isort",
     "pants.backend.python.lint.flake8",
     "pants.backend.python.typecheck.mypy",
-    "pants.backend.experimental.python.lint.pyupgrade",
+    "pants.backend.python.lint.pyupgrade",
     "pants.backend.python.lint.docformatter",
 ]
 
@@ -62,9 +62,6 @@ interpreter_constraints = [">=3.11"]
 version = "docformatter==1.5.1"
 args = ["--wrap-summaries 88", "--wrap-descriptions 88"]
 lockfile = "lockfiles/docformatter"
-interpreter_constraints = [">=3.11"]
-
-[poetry]
 interpreter_constraints = [">=3.11"]
 
 [anonymous-telemetry]

--- a/python-packages/smithy-python/smithy_python/_private/http/crt.py
+++ b/python-packages/smithy-python/smithy_python/_private/http/crt.py
@@ -13,11 +13,11 @@
 
 
 import asyncio
-from collections.abc import AsyncIterable
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable
 from concurrent.futures import Future
 from io import BytesIO
 from threading import Lock
-from typing import Any, AsyncGenerator, Awaitable
+from typing import Any
 
 from awscrt import http as crt_http
 from awscrt import io as crt_io

--- a/python-packages/smithy-python/smithy_python/_private/retries/__init__.py
+++ b/python-packages/smithy-python/smithy_python/_private/retries/__init__.py
@@ -12,9 +12,9 @@
 # language governing permissions and limitations under the License.
 
 import random
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable
 
 from ...exceptions import SmithyRetryException
 from ...interfaces import retries as retries_interface

--- a/python-packages/smithy-python/smithy_python/interfaces/blobs.py
+++ b/python-packages/smithy-python/smithy_python/interfaces/blobs.py
@@ -1,16 +1,7 @@
 from asyncio import iscoroutinefunction
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from io import BytesIO
-from typing import (
-    AsyncIterable,
-    AsyncIterator,
-    Awaitable,
-    Callable,
-    Protocol,
-    Self,
-    Union,
-    cast,
-    runtime_checkable,
-)
+from typing import Protocol, Self, Union, cast, runtime_checkable
 
 # The default chunk size for iterating streams.
 _DEFAULT_CHUNK_SIZE = 1024

--- a/python-packages/smithy-python/smithy_python/types.py
+++ b/python-packages/smithy-python/smithy_python/types.py
@@ -1,4 +1,5 @@
-from typing import Mapping, Sequence, TypeAlias
+from collections.abc import Mapping, Sequence
+from typing import TypeAlias
 
 Document: TypeAlias = (
     Mapping[str, "Document"] | Sequence["Document"] | str | int | float | bool | None

--- a/python-packages/smithy-python/tests/integration/http_clients/conftest.py
+++ b/python-packages/smithy-python/tests/integration/http_clients/conftest.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 
 import pytest
-
 from smithy_python._private import URI, Field, Fields
 from smithy_python._private.http import HTTPRequest
 from smithy_python.async_utils import async_list

--- a/python-packages/smithy-python/tests/unit/test_api_key_auth.py
+++ b/python-packages/smithy-python/tests/unit/test_api_key_auth.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import AsyncIterable, AsyncIterator
 
 import pytest
-
 from smithy_python._private import URI, Field, Fields
 from smithy_python._private.api_key_auth import (
     ApiKeyAuthScheme,

--- a/python-packages/smithy-python/tests/unit/test_api_key_auth.py
+++ b/python-packages/smithy-python/tests/unit/test_api_key_auth.py
@@ -1,5 +1,5 @@
+from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass
-from typing import AsyncIterable, AsyncIterator
 
 import pytest
 from smithy_python._private import URI, Field, Fields

--- a/python-packages/smithy-python/tests/unit/test_blobs.py
+++ b/python-packages/smithy-python/tests/unit/test_blobs.py
@@ -2,7 +2,6 @@ from io import BytesIO
 from typing import Self
 
 import pytest
-
 from smithy_python.interfaces.blobs import AsyncBytesReader, SeekableAsyncBytesReader
 
 

--- a/python-packages/smithy-python/tests/unit/test_http.py
+++ b/python-packages/smithy-python/tests/unit/test_http.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 
 import pytest
-
 from smithy_python._private import URI, Field, Fields, HostType
 from smithy_python._private.http import (
     HTTPRequest,

--- a/python-packages/smithy-python/tests/unit/test_http_fields.py
+++ b/python-packages/smithy-python/tests/unit/test_http_fields.py
@@ -15,7 +15,6 @@
 # mypy: allow-incomplete-defs
 
 import pytest
-
 from smithy_python._private import Field, FieldPosition, Fields
 
 

--- a/python-packages/smithy-python/tests/unit/test_http_utils.py
+++ b/python-packages/smithy-python/tests/unit/test_http_utils.py
@@ -13,7 +13,6 @@
 
 
 import pytest
-
 from smithy_python.exceptions import SmithyException
 from smithy_python.httputils import join_query_params, split_header
 

--- a/python-packages/smithy-python/tests/unit/test_identity.py
+++ b/python-packages/smithy-python/tests/unit/test_identity.py
@@ -15,7 +15,6 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from freezegun import freeze_time
-
 from smithy_python._private.identity import Identity
 
 

--- a/python-packages/smithy-python/tests/unit/test_protocolutils.py
+++ b/python-packages/smithy-python/tests/unit/test_protocolutils.py
@@ -15,7 +15,6 @@ import json
 from collections.abc import AsyncIterator
 
 import pytest
-
 from smithy_python._private import tuples_to_fields
 from smithy_python._private.http import HTTPResponse
 from smithy_python.async_utils import async_list

--- a/python-packages/smithy-python/tests/unit/test_retries.py
+++ b/python-packages/smithy-python/tests/unit/test_retries.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 
 import pytest
-
 from smithy_python._private.retries import ExponentialBackoffJitterType as EBJT
 from smithy_python._private.retries import (
     ExponentialRetryBackoffStrategy,

--- a/python-packages/smithy-python/tests/unit/test_utils.py
+++ b/python-packages/smithy-python/tests/unit/test_utils.py
@@ -21,7 +21,6 @@ from typing import Any, NamedTuple
 from unittest.mock import Mock
 
 import pytest
-
 from smithy_python.exceptions import ExpectationNotMetException
 from smithy_python.utils import (
     ensure_utc,


### PR DESCRIPTION
This upgrades pants to the latest stable version and adds a new linter - bandit, which is a security linter. Note that there's a `pants fix` command that runs isort and some of the other code formatters. I'm not entirely sure where the distinction is to be honest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
