### PR TITLE
Update Smithy version

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=[1.29.0,1.30.0[
+smithyVersion=[1.34.0,2.0)
 smithyGradleVersion=0.6.0

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
@@ -66,8 +66,10 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         "RestJsonEndpointTraitWithHostLabel",
         "RestJsonEndpointTrait",
 
-        // TODO: support parsing http dates with fractional seconds
-        "RestJsonHttpDateWithFractionalSeconds"
+        // TODO: support the request compression trait
+        // https://smithy.io/2.0/spec/behavior-traits.html#smithy-api-requestcompression-trait
+        "SDKAppliedContentEncoding_restJson1",
+        "SDKAppendedGzipAfterProvidedEncoding_restJson1"
     );
 
     @Override


### PR DESCRIPTION
The two new test skips are for a new trait that isn't supported. The removed one is because that test was removed from the source.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
