### PR TITLE
Fix type signature for deepcopy

### DIFF
--- a/python-packages/smithy-python/smithy_python/_private/http/aiohttp_client.py
+++ b/python-packages/smithy-python/smithy_python/_private/http/aiohttp_client.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from copy import copy, deepcopy
 from itertools import chain
+from typing import Any
 from urllib.parse import parse_qs, urlunparse
 
 import aiohttp
@@ -105,7 +106,7 @@ class AIOHTTPClient(interfaces.http.HTTPClient):
             reason=aiohttp_resp.reason,
         )
 
-    def __deepcopy__(self) -> "AIOHTTPClient":
+    def __deepcopy__(self, memo: Any) -> "AIOHTTPClient":
         return AIOHTTPClient(
             client_config=deepcopy(self._config),
             _session=copy(self._session),


### PR DESCRIPTION
We really need some integ tests to protect from idiots like me. But also, why is the documentation for these so bad? I'm assuming that this [stdlib entry from the typeshed repo](https://github.com/python/typeshed/blob/852882b8bfe9e1792448b94809351a392e83ce9e/stdlib/weakref.pyi#L67) is correct.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
