### PR TITLE
Properly handle unions in from_dict

### DIFF
--- a/codegen/smithy-python-codegen-test/model/main.smithy
+++ b/codegen/smithy-python-codegen-test/model/main.smithy
@@ -15,7 +15,7 @@ use aws.protocols#restJson1
 service Weather {
     version: "2006-03-01"
     resources: [City]
-    operations: [GetCurrentTime]
+    operations: [GetCurrentTime, TestUnionListOperation]
 }
 
 resource City {
@@ -24,6 +24,25 @@ resource City {
     list: ListCities
     resources: [Forecast, CityImage]
     operations: [GetCityAnnouncements]
+}
+
+@http(code: 200, method: "POST", uri: "/test-union-list")
+operation TestUnionListOperation {
+    input := {
+        inputList: UnionList
+    }
+    output := {
+        response: String
+    }
+}
+
+list UnionList {
+    member: UnionListMember
+}
+
+union UnionListMember {
+    field1: String
+    field2: Integer
 }
 
 resource Forecast {

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CollectionGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CollectionGenerator.java
@@ -89,9 +89,9 @@ final class CollectionGenerator implements Runnable {
         writer.addStdlibImport("typing", "List");
         writer.addStdlibImport("typing", "Any");
         writer.openBlock("def $L(given: List[Any]) -> $T:", "", fromDictSymbol.getName(), symbol, () -> {
-            if (target.isUnionShape() || target.isStructureShape()) {
+            if (target.isStructureShape()) {
                 writer.write("return [$T.from_dict(v)$L for v in given]", targetSymbol, sparseGuard);
-            } else if (target.isMapShape() || target instanceof CollectionShape) {
+            } else if (target.isUnionShape() || target.isMapShape() || target instanceof CollectionShape) {
                 var targetFromDictSymbol = targetSymbol.expectProperty("fromDict", Symbol.class);
                 writer.write("return [$T(v)$L for v in given]", targetFromDictSymbol, sparseGuard);
             } else {


### PR DESCRIPTION
*Issue #, if available:*

Fixes #184

*Description of changes:*

When calling from_dict, unions need to use their special global method. This was already being generated, just never called.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
