### PR TITLE
Use uri.netloc() instead of uri.host when sending HTTP requests

### DIFF
--- a/python-packages/smithy-python/smithy_python/_private/http/aiohttp_client.py
+++ b/python-packages/smithy-python/smithy_python/_private/http/aiohttp_client.py
@@ -78,7 +78,7 @@ class AIOHTTPClient(interfaces.http.HTTPClient):
 
     def _serialize_uri_without_query(self, uri: interfaces.URI) -> str:
         """Serialize all parts of the URI up to and including the path."""
-        components = (uri.scheme, uri.netloc(), uri.path or "", "", "", "")
+        components = (uri.scheme, uri.netloc, uri.path or "", "", "", "")
         return urlunparse(components)
 
     async def _marshal_response(

--- a/python-packages/smithy-python/smithy_python/_private/http/aiohttp_client.py
+++ b/python-packages/smithy-python/smithy_python/_private/http/aiohttp_client.py
@@ -78,7 +78,7 @@ class AIOHTTPClient(interfaces.http.HTTPClient):
 
     def _serialize_uri_without_query(self, uri: interfaces.URI) -> str:
         """Serialize all parts of the URI up to and including the path."""
-        components = (uri.scheme, uri.host, uri.path or "", "", "", "")
+        components = (uri.scheme, uri.netloc(), uri.path or "", "", "", "")
         return urlunparse(components)
 
     async def _marshal_response(


### PR DESCRIPTION
When `send`ing a request using `AIOHTTPClient` the endpoint URI is split into URL and query string. The URL resulting from calling `_serialize_uri_without_query` is missing parts of the URI (user, password and port), which causes issues when using non-standard ports.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
