### PR TITLE
Skip `RestJsonDeserializeIgnoreType` test, fix READMEs

### DIFF
--- a/codegen/smithy-aws-python-codegen/README.md
+++ b/codegen/smithy-aws-python-codegen/README.md
@@ -3,7 +3,7 @@
 This package implements AWS-specific code generation plugins to the python generator.
 Anything that is specific to AWS MUST be implemented here. Examples include most [AWS
 protocols](https://smithy.io/2.0/aws/protocols/index.html)(*),
-[sigv4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html),
+[SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html),
 and AWS service customizations. Conversely, any features that are
 NOT specific to AWS MUST NOT be implemented here.
 
@@ -12,7 +12,7 @@ included in the generic generator for now to provide a default supported protoco
 
 One very important thing to keep in mind when implementing features and integrations
 here is that they MUST NOT be coupled wherever possible. For example, a user
-MUST be able to use sigv4 even if they aren't using an AWS protocol or even the
+MUST be able to use SigV4 even if they aren't using an AWS protocol or even the
 [service trait](https://smithy.io/2.0/aws/aws-core.html#aws-api-service-trait).
 
 ### Why separate AWS components from the core package and each other?

--- a/codegen/smithy-python-codegen-test/README.md
+++ b/codegen/smithy-python-codegen-test/README.md
@@ -1,10 +1,10 @@
 ## Smithy Python Codegen Test
 
-This package is a hand-written Smithy package that generates a python client. The
+This package is a handwritten Smithy package that generates a python client. The
 shapes in this package are intended to exercise as many parts of the generator as
 possible to ensure they generate valid code that passes mypy checks. For
 example, there are cases that ensure that we're properly escaping shape names that
-would collide with built in types (e.g. a shape called `Exception` would collide with
+would collide with built-in types (e.g. a shape called `Exception` would collide with
 the builtin of the same name if it weren't escaped).
 
 This package does not contain any actual unit tests. Mypy passing and python not

--- a/codegen/smithy-python-codegen/README.md
+++ b/codegen/smithy-python-codegen/README.md
@@ -10,7 +10,7 @@ not limited to, the following capabilities:
   generation.
 
 This package MUST NOT include any components that are only applicable to a particular
-organization. For example, [sigv4
+organization. For example, [SigV4
 ](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html)
 (an AWS HTTP authorization mechanism) support MUST NOT be implemented in this package
 since it isn't generally applicable outside of AWS.

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
@@ -69,7 +69,10 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         // TODO: support the request compression trait
         // https://smithy.io/2.0/spec/behavior-traits.html#smithy-api-requestcompression-trait
         "SDKAppliedContentEncoding_restJson1",
-        "SDKAppendedGzipAfterProvidedEncoding_restJson1"
+        "SDKAppendedGzipAfterProvidedEncoding_restJson1",
+
+        // TODO: update union deserialization to ignore `__type` for JSON protocols
+        "RestJsonDeserializeIgnoreType"
     );
 
     @Override


### PR DESCRIPTION
*Description of changes:*
- New restJson1 protocol test was added for unions with `__type` [here](https://github.com/smithy-lang/smithy/pull/1945)
- We should specifically ignore this field (`__type`) for JSON based protocols instead of throwing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
