### PR TITLE
Update aiohttp pin to support 3.9.x releases

### DIFF
--- a/python-packages/smithy-python/pyproject.toml
+++ b/python-packages/smithy-python/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "awscrt>=0.15,<1.0",
-    "aiohttp>=3.8.3,<3.9.0"
+    "aiohttp>=3.8.3,<3.10.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR will allow us to update to the latest minor version of aiohttp (currently 3.9.1).