### PR TITLE
[bug] Fix codgen bug where port number was ignored

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -375,6 +375,7 @@ final class ClientGenerator implements Runnable {
                             scheme=endpoint.uri.scheme,
                             host=context.transport_request.destination.host + endpoint.uri.host,
                             path=path,
+                            port=endpoint.uri.port,
                             query=context.transport_request.destination.query,
                         )
                         context._transport_request.fields.extend(endpoint.headers)


### PR DESCRIPTION
*Issue #196 *

*Description of changes:*

This change passes through the port from the parsed endpoint uri when creating a URI object. Prior to this change the port field of the URI was always None which in turn uses the default port for the protocol which is an issue as pointed out in #196.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
