### PR TITLE
Migrate settings to immutable record

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -75,8 +75,8 @@ public final class CodegenUtils {
     public static Symbol getConfigSymbol(PythonSettings settings) {
         return Symbol.builder()
                 .name("Config")
-                .namespace(format("%s.config", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/config.py", settings.getModuleName()))
+                .namespace(format("%s.config", settings.moduleName()), ".")
+                .definitionFile(format("./%s/config.py", settings.moduleName()))
                 .build();
     }
 
@@ -87,8 +87,8 @@ public final class CodegenUtils {
     public static Symbol getPluginSymbol(PythonSettings settings) {
         return Symbol.builder()
                 .name("Plugin")
-                .namespace(format("%s.config", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/config.py", settings.getModuleName()))
+                .namespace(format("%s.config", settings.moduleName()), ".")
+                .definitionFile(format("./%s/config.py", settings.moduleName()))
                 .build();
     }
 
@@ -106,8 +106,8 @@ public final class CodegenUtils {
     public static Symbol getServiceError(PythonSettings settings) {
         return Symbol.builder()
                 .name("ServiceError")
-                .namespace(format("%s.errors", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/errors.py", settings.getModuleName()))
+                .namespace(format("%s.errors", settings.moduleName()), ".")
+                .definitionFile(format("./%s/errors.py", settings.moduleName()))
                 .build();
     }
 
@@ -123,8 +123,8 @@ public final class CodegenUtils {
     public static Symbol getApiError(PythonSettings settings) {
         return Symbol.builder()
                 .name("ApiError")
-                .namespace(format("%s.errors", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/errors.py", settings.getModuleName()))
+                .namespace(format("%s.errors", settings.moduleName()), ".")
+                .definitionFile(format("./%s/errors.py", settings.moduleName()))
                 .build();
     }
 
@@ -140,8 +140,8 @@ public final class CodegenUtils {
     public static Symbol getUnknownApiError(PythonSettings settings) {
         return Symbol.builder()
                 .name("UnknownApiError")
-                .namespace(format("%s.errors", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/errors.py", settings.getModuleName()))
+                .namespace(format("%s.errors", settings.moduleName()), ".")
+                .definitionFile(format("./%s/errors.py", settings.moduleName()))
                 .build();
     }
 
@@ -154,8 +154,8 @@ public final class CodegenUtils {
     public static Symbol getHttpAuthParamsSymbol(PythonSettings settings) {
         return Symbol.builder()
             .name("HTTPAuthParams")
-            .namespace(format("%s.auth", settings.getModuleName()), ".")
-            .definitionFile(format("./%s/auth.py", settings.getModuleName()))
+            .namespace(format("%s.auth", settings.moduleName()), ".")
+            .definitionFile(format("./%s/auth.py", settings.moduleName()))
             .build();
     }
 
@@ -168,8 +168,8 @@ public final class CodegenUtils {
     public static Symbol getHttpAuthSchemeResolverSymbol(PythonSettings settings) {
         return Symbol.builder()
             .name("HTTPAuthSchemeResolver")
-            .namespace(format("%s.auth", settings.getModuleName()), ".")
-            .definitionFile(format("./%s/auth.py", settings.getModuleName()))
+            .namespace(format("%s.auth", settings.moduleName()), ".")
+            .definitionFile(format("./%s/auth.py", settings.moduleName()))
             .build();
     }
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ConfigGenerator.java
@@ -171,7 +171,7 @@ final class ConfigGenerator implements Runnable {
 
     private static void writeDefaultHttpAuthSchemes(GenerationContext context, PythonWriter writer) {
         var supportedAuthSchemes = new LinkedHashMap<String, Symbol>();
-        var service = context.settings().getService(context.model());
+        var service = context.settings().service(context.model());
         for (PythonIntegration integration : context.integrations()) {
             for (RuntimeClientPlugin plugin : integration.getClientPlugins()) {
                 if (plugin.matchesService(context.model(), service)
@@ -217,7 +217,7 @@ final class ConfigGenerator implements Runnable {
     private void writeInterceptorsType(PythonWriter writer) {
         var symbolProvider = context.symbolProvider();
         var operationShapes = TopDownIndex.of(context.model())
-                .getContainedOperations(settings.getService());
+                .getContainedOperations(settings.service());
 
         writer.addStdlibImport("typing", "Union");
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
@@ -255,14 +255,14 @@ final class ConfigGenerator implements Runnable {
         var serviceIndex = ServiceIndex.of(context.model());
         if (context.applicationProtocol().isHttpProtocol()) {
             properties.addAll(HTTP_PROPERTIES);
-            if (!serviceIndex.getAuthSchemes(settings.getService()).isEmpty()) {
+            if (!serviceIndex.getAuthSchemes(settings.service()).isEmpty()) {
                 properties.addAll(getHttpAuthProperties(context));
                 writer.onSection(new AddAuthHelper());
             }
         }
 
         var model = context.model();
-        var service = context.settings().getService(model);
+        var service = context.settings().service(model);
 
         // Add any relevant config properties from plugins.
         for (PythonIntegration integration : context.integrations()) {
@@ -293,7 +293,7 @@ final class ConfigGenerator implements Runnable {
                     ${C|}
                     \"""
                     ${C|}
-            """, symbol.getName(), context.settings().getService().getName(),
+            """, symbol.getName(), context.settings().service().getName(),
             writer.consumer(w -> writePropertyDeclarations(w, finalProperties)),
             writer.consumer(w -> writeInitParams(w, finalProperties)),
             writer.consumer(w -> documentProperties(w, finalProperties)),

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpAuthGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpAuthGenerator.java
@@ -41,7 +41,7 @@ final class HttpAuthGenerator implements Runnable {
     public void run() {
         var supportedAuthSchemes = new HashMap<ShapeId, AuthScheme>();
         var properties = new ArrayList<DerivedProperty>();
-        var service = context.settings().getService(context.model());
+        var service = context.settings().service(context.model());
         for (PythonIntegration integration : context.integrations()) {
             for (RuntimeClientPlugin plugin : integration.getClientPlugins()) {
                 if (plugin.matchesService(context.model(), service)
@@ -90,7 +90,7 @@ final class HttpAuthGenerator implements Runnable {
         Map<ShapeId, AuthScheme> supportedAuthSchemes
     ) {
         var resolvedAuthSchemes = ServiceIndex.of(context.model())
-            .getEffectiveAuthSchemes(settings.getService()).keySet().stream()
+            .getEffectiveAuthSchemes(settings.service()).keySet().stream()
             .filter(supportedAuthSchemes::containsKey)
             .map(supportedAuthSchemes::get)
             .toList();
@@ -114,7 +114,7 @@ final class HttpAuthGenerator implements Runnable {
     }
 
     private void writeOperationAuthOptions(PythonWriter writer, Map<ShapeId, AuthScheme> supportedAuthSchemes) {
-        var operations = TopDownIndex.of(context.model()).getContainedOperations(settings.getService());
+        var operations = TopDownIndex.of(context.model()).getContainedOperations(settings.service());
         var serviceIndex = ServiceIndex.of(context.model());
         for (OperationShape operation : operations) {
             if (!operation.hasTrait(AuthTrait.class)) {
@@ -122,7 +122,7 @@ final class HttpAuthGenerator implements Runnable {
             }
 
             var operationAuthSchemes = serviceIndex
-                .getEffectiveAuthSchemes(settings.getService(), operation).keySet().stream()
+                .getEffectiveAuthSchemes(settings.service(), operation).keySet().stream()
                 .filter(supportedAuthSchemes::containsKey)
                 .map(supportedAuthSchemes::get)
                 .toList();

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -115,7 +115,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
         this.settings = context.settings();
         this.model = context.model();
         this.protocol = protocol;
-        this.service = settings.getService(model);
+        this.service = settings.service(model);
         this.writer = writer;
         this.context = context;
         this.testFilter = testFilter;

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ImportDeclarations.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ImportDeclarations.java
@@ -56,7 +56,7 @@ final class ImportDeclarations implements ImportContainer {
 
     ImportDeclarations addImport(String namespace, String name, String alias) {
         var isTestModule = this.localNamespace.startsWith("tests");
-        if (namespace.startsWith(settings.getModuleName())) {
+        if (namespace.startsWith(settings.moduleName())) {
             // if the module is for tests, we shouldn't relativize the imports
             //  as python will complain that the imports are beyond the top-level package
             var ns = isTestModule ? namespace : relativize(namespace);

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonClientCodegenPlugin.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonClientCodegenPlugin.java
@@ -36,11 +36,11 @@ public final class PythonClientCodegenPlugin implements SmithyBuildPlugin {
         CodegenDirector<PythonWriter, PythonIntegration, GenerationContext, PythonSettings> runner
                 = new CodegenDirector<>();
 
-        PythonSettings settings = PythonSettings.from(context.getSettings());
+        PythonSettings settings = PythonSettings.fromNode(context.getSettings());
         runner.settings(settings);
         runner.directedCodegen(new DirectedPythonCodegen());
         runner.fileManifest(context.getFileManifest());
-        runner.service(settings.getService());
+        runner.service(settings.service());
         runner.model(context.getModel());
         runner.integrationClass(PythonIntegration.class);
         runner.performDefaultCodegenTransforms();

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonSettings.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonSettings.java
@@ -17,60 +17,58 @@ package software.amazon.smithy.python.codegen;
 
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Set;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.StringUtils;
+import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * Settings used by {@link PythonClientCodegenPlugin}.
- * TODO: make this immutable
+ *
+ * @param service The id of the service that is being generated.
+ * @param moduleName The name of the module to generate.
+ * @param moduleVersion The version of the module to generate.
+ * @param moduleDescription The optional module description for the module that will be generated.
  */
 @SmithyUnstableApi
-public final class PythonSettings {
+public record PythonSettings(
+        ShapeId service,
+        String moduleName,
+        String moduleVersion,
+        String moduleDescription
+    ) implements ToSmithyBuilder<PythonSettings> {
 
     private static final String SERVICE = "service";
     private static final String MODULE_NAME = "module";
     private static final String MODULE_DESCRIPTION = "moduleDescription";
     private static final String MODULE_VERSION = "moduleVersion";
 
-    private ShapeId service;
-    private String moduleName;
-    private String moduleVersion;
-    private String moduleDescription = "";
-    private ShapeId protocol;
-
-    /**
-     * Create a settings object from a configuration object node.
-     *
-     * @param config Config object to load.
-     * @return Returns the extracted settings.
-     */
-    public static PythonSettings from(ObjectNode config) {
-        PythonSettings settings = new PythonSettings();
-        config.warnIfAdditionalProperties(Arrays.asList(SERVICE, MODULE_NAME, MODULE_DESCRIPTION, MODULE_VERSION));
-
-        settings.setService(config.expectStringMember(SERVICE).expectShapeId());
-        settings.setModuleName(config.expectStringMember(MODULE_NAME).getValue());
-        settings.setModuleVersion(config.expectStringMember(MODULE_VERSION).getValue());
-        settings.setModuleDescription(config.getStringMemberOrDefault(
-                MODULE_DESCRIPTION, settings.getModuleName() + " client"));
-
-        return settings;
+    public PythonSettings {
+        Objects.requireNonNull(service);
+        Objects.requireNonNull(moduleName);
+        Objects.requireNonNull(moduleDescription);
+        Objects.requireNonNull(moduleVersion);
+        if (!moduleName.matches("[a-z_\\d]+")) {
+            throw new CodegenException(
+                    "Python package names may only consist of lowercase letters, numbers, and underscores.");
+        }
     }
 
-    /**
-     * Gets the id of the service that is being generated.
-     *
-     * @return Returns the service id.
-     * @throws NullPointerException if the service has not been set.
-     */
-    public ShapeId getService() {
-        return Objects.requireNonNull(service, SERVICE + " not set");
+    public PythonSettings(Builder builder) {
+        this(
+                builder.service,
+                builder.moduleName,
+                builder.moduleVersion,
+                StringUtils.isBlank(builder.moduleDescription)
+                        ? builder.moduleName + " client"
+                        : builder.moduleDescription
+        );
     }
 
     /**
@@ -81,133 +79,78 @@ public final class PythonSettings {
      * @throws NullPointerException if the service has not been set.
      * @throws CodegenException if the service is invalid or not found.
      */
-    public ServiceShape getService(Model model) {
+    public ServiceShape service(Model model) {
         return model
-                .getShape(getService())
-                .orElseThrow(() -> new CodegenException("Service shape not found: " + getService()))
+                .getShape(service())
+                .orElseThrow(() -> new CodegenException("Service shape not found: " + service()))
                 .asServiceShape()
-                .orElseThrow(() -> new CodegenException("Shape is not a Service: " + getService()));
+                .orElseThrow(() -> new CodegenException("Shape is not a Service: " + service()));
     }
 
     /**
-     * Sets the service to generate.
+     * Create a settings object from a configuration object node.
      *
-     * @param service The service to generate.
+     * @param config Config object to load.
+     * @return Returns the extracted settings.
      */
-    public void setService(ShapeId service) {
-        this.service = Objects.requireNonNull(service);
+    public static PythonSettings fromNode(ObjectNode config) {
+        config.warnIfAdditionalProperties(Arrays.asList(SERVICE, MODULE_NAME, MODULE_DESCRIPTION, MODULE_VERSION));
+
+        String moduleName = config.expectStringMember(MODULE_NAME).getValue();
+        Builder builder = builder()
+                .service(config.expectStringMember(SERVICE).expectShapeId())
+                .moduleName(moduleName)
+                .moduleVersion(config.expectStringMember(MODULE_VERSION).getValue());
+        config.getStringMember(MODULE_DESCRIPTION).map(StringNode::getValue).ifPresent(builder::moduleDescription);
+        return builder.build();
     }
 
-    /**
-     * Gets the required module name for the module that will be generated.
-     *
-     * @return Returns the module name.
-     * @throws NullPointerException if the module name has not been set.
-     */
-    public String getModuleName() {
-        return Objects.requireNonNull(moduleName, MODULE_NAME + " not set");
+    @Override
+    public SmithyBuilder<PythonSettings> toBuilder() {
+        return builder()
+                .service(service)
+                .moduleName(moduleName)
+                .moduleVersion(moduleVersion)
+                .moduleDescription(moduleDescription);
     }
 
-    /**
-     * Sets the name of the module to generate.
-     *
-     * @param moduleName The name of the module to generate.
-     */
-    public void setModuleName(String moduleName) {
-        if (moduleName != null && !moduleName.matches("[a-z_\\d]+")) {
-            throw new CodegenException(
-                    "Python package names may only consist of lowercase letters, numbers, and underscores.");
-        }
-        this.moduleName = Objects.requireNonNull(moduleName);
+    public static Builder builder() {
+        return new Builder();
     }
 
-    /**
-     * Gets the required module version for the module that will be generated.
-     *
-     * @return The version of the module that will be generated.
-     * @throws NullPointerException if the module version has not been set.
-     */
-    public String getModuleVersion() {
-        return Objects.requireNonNull(moduleVersion, MODULE_VERSION + " not set");
-    }
+    public static class Builder implements SmithyBuilder<PythonSettings> {
 
-    /**
-     * Sets the required module version for the module that will be generated.
-     *
-     * @param moduleVersion The version of the module that will be generated.
-     */
-    public void setModuleVersion(String moduleVersion) {
-        this.moduleVersion = Objects.requireNonNull(moduleVersion);
-    }
+        private ShapeId service;
+        private String moduleName;
+        private String moduleVersion;
+        private String moduleDescription;
 
-    /**
-     * Gets the optional module description for the module that will be generated.
-     *
-     * @return Returns the module description.
-     */
-    public String getModuleDescription() {
-        return moduleDescription;
-    }
-
-    /**
-     * Sets the description of the module to generate.
-     *
-     * @param moduleDescription The description of the module to generate.
-     */
-    public void setModuleDescription(String moduleDescription) {
-        this.moduleDescription = Objects.requireNonNull(moduleDescription);
-    }
-
-    /**
-     * Gets the configured protocol to generate.
-     *
-     * @return Returns the configured protocol.
-     */
-    public ShapeId getProtocol() {
-        return protocol;
-    }
-
-    /**
-     * Resolves the highest priority protocol from a service shape that is
-     * supported by the generator.
-     *
-     * @param model Model to enable finding protocols on the service.
-     * @param service Service to get the protocols from if "protocols" is not set.
-     * @param supportedProtocols The set of protocol names supported by the generator.
-     * @return Returns the resolved protocol name.
-     * @throws CodegenException if no protocol could be resolved.
-     */
-    public ShapeId resolveServiceProtocol(Model model, ServiceShape service, Set<ShapeId> supportedProtocols) {
-        if (protocol != null) {
-            return protocol;
+        @Override
+        public PythonSettings build() {
+            SmithyBuilder.requiredState("service", service);
+            SmithyBuilder.requiredState("moduleName", moduleName);
+            SmithyBuilder.requiredState("moduleVersion", moduleVersion);
+            return new PythonSettings(this);
         }
 
-        ServiceIndex serviceIndex = ServiceIndex.of(model);
-        Set<ShapeId> resolvedProtocols = serviceIndex.getProtocols(service).keySet();
-        if (resolvedProtocols.isEmpty()) {
-            throw new CodegenException(
-                    "Unable to derive the protocol setting of the service `" + service.getId() + "` because no "
-                            + "protocol definition traits were present. You need to set an explicit `protocol` to "
-                            + "generate in smithy-build.json to generate this service.");
+        public Builder service(ShapeId service) {
+            this.service = service;
+            return this;
         }
 
-        protocol = resolvedProtocols.stream()
-                .filter(supportedProtocols::contains)
-                .findFirst()
-                .orElseThrow(() -> new CodegenException(String.format(
-                        "The %s service supports the following unsupported protocols %s. The following protocol "
-                                + "generators were found on the class path: %s",
-                        service.getId(), resolvedProtocols, supportedProtocols)));
+        public Builder moduleName(String moduleName) {
+            this.moduleName = moduleName;
+            return this;
+        }
 
-        return protocol;
-    }
+        public Builder moduleVersion(String moduleVersion) {
+            this.moduleVersion = moduleVersion;
+            return this;
+        }
 
-    /**
-     * Sets the protocol to generate.
-     *
-     * @param protocol Protocols to generate.
-     */
-    public void setProtocol(ShapeId protocol) {
-        this.protocol = Objects.requireNonNull(protocol);
+        public Builder moduleDescription(String moduleDescription) {
+            this.moduleDescription = moduleDescription;
+            return this;
+        }
     }
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SetupGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SetupGenerator.java
@@ -89,7 +89,7 @@ final class SetupGenerator {
                         "Programming Language :: Python :: 3 :: Only",
                         "Programming Language :: Python :: 3.12"
                     ]
-                    """, settings.getModuleName(), settings.getModuleVersion(), settings.getModuleDescription());
+                    """, settings.moduleName(), settings.moduleVersion(), settings.moduleDescription());
 
             Optional.ofNullable(dependencies.get(Type.DEPENDENCY.getType())).ifPresent(deps -> {
                 writer.openBlock("dependencies = [", "]", () -> writeDependencyList(writer, deps.values()));
@@ -164,16 +164,16 @@ final class SetupGenerator {
             PythonSettings settings,
             GenerationContext context
     ) {
-        var service = context.model().expectShape(settings.getService());
+        var service = context.model().expectShape(settings.service());
 
         // see: https://smithy.io/2.0/spec/documentation-traits.html#smithy-api-title-trait
         var title = service.getTrait(TitleTrait.class)
                 .map(StringTrait::getValue)
-                .orElse(StringUtils.capitalize(settings.getModuleName()));
+                .orElse(StringUtils.capitalize(settings.moduleName()));
 
-        var description = StringUtils.isBlank(settings.getModuleDescription())
+        var description = StringUtils.isBlank(settings.moduleDescription())
                 ? "Generated service client for " + title
-                : StringUtils.wrap(settings.getModuleDescription(), 80);
+                : StringUtils.wrap(settings.moduleDescription(), 80);
 
         context.writerDelegator().useFileWriter("README.md", writer -> {
             writer.pushState(new ReadmeSection());

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
@@ -81,7 +81,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     SymbolVisitor(Model model, PythonSettings settings) {
         this.model = model;
         this.settings = settings;
-        this.service = model.expectShape(settings.getService(), ServiceShape.class);
+        this.service = model.expectShape(settings.service(), ServiceShape.class);
 
         // Load reserved words from new-line delimited files.
         var reservedClassNames = new ReservedWordsBuilder()
@@ -236,16 +236,16 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     private Symbol createAsDictFunctionSymbol(Shape shape) {
         return Symbol.builder()
                 .name(String.format("_%s_as_dict", CaseUtils.toSnakeCase(shape.getId().getName())))
-                .namespace(format("%s.models", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/models.py", settings.getModuleName()))
+                .namespace(format("%s.models", settings.moduleName()), ".")
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .build();
     }
 
     private Symbol createFromDictFunctionSymbol(Shape shape) {
         return Symbol.builder()
                 .name(String.format("_%s_from_dict", CaseUtils.toSnakeCase(shape.getId().getName())))
-                .namespace(format("%s.models", settings.getModuleName()), ".")
-                .definitionFile(format("./%s/models.py", settings.getModuleName()))
+                .namespace(format("%s.models", settings.moduleName()), ".")
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .build();
     }
 
@@ -302,8 +302,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         // Operation names are escaped like members because ultimately they're
         // properties on an object too.
         var name = escaper.escapeMemberName(CaseUtils.toSnakeCase(shape.getId().getName(service)));
-        return createSymbolBuilder(shape, name, format("%s.client", settings.getModuleName()))
-                .definitionFile(format("./%s/client.py", settings.getModuleName()))
+        return createSymbolBuilder(shape, name, format("%s.client", settings.moduleName()))
+                .definitionFile(format("./%s/client.py", settings.moduleName()))
                 .build();
     }
 
@@ -316,8 +316,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol serviceShape(ServiceShape shape) {
         var name = getDefaultShapeName(shape);
-        return createSymbolBuilder(shape, name, format("%s.client", settings.getModuleName()))
-                .definitionFile(format("./%s/client.py", settings.getModuleName()))
+        return createSymbolBuilder(shape, name, format("%s.client", settings.moduleName()))
+                .definitionFile(format("./%s/client.py", settings.moduleName()))
                 .build();
     }
 
@@ -344,8 +344,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     public Symbol enumShape(EnumShape shape) {
         var builder = createSymbolBuilder(shape, "str");
         String name = getDefaultShapeName(shape);
-        Symbol enumSymbol = createSymbolBuilder(shape, name, format("%s.models", settings.getModuleName()))
-                .definitionFile(format("./%s/models.py", settings.getModuleName()))
+        Symbol enumSymbol = createSymbolBuilder(shape, name, format("%s.models", settings.moduleName()))
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .build();
 
         // We add this enum symbol as a property on a generic string symbol
@@ -361,8 +361,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     public Symbol intEnumShape(IntEnumShape shape) {
         var builder = createSymbolBuilder(shape, "int");
         String name = getDefaultShapeName(shape);
-        Symbol enumSymbol = createSymbolBuilder(shape, name, format("%s.models", settings.getModuleName()))
-                .definitionFile(format("./%s/models.py", settings.getModuleName()))
+        Symbol enumSymbol = createSymbolBuilder(shape, name, format("%s.models", settings.moduleName()))
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .build();
 
         // Like string enums, int enums are plain ints when used as members.
@@ -374,12 +374,12 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     public Symbol structureShape(StructureShape shape) {
         String name = getDefaultShapeName(shape);
         if (shape.hasTrait(ErrorTrait.class)) {
-            return createSymbolBuilder(shape, name, format("%s.errors", settings.getModuleName()))
-                    .definitionFile(format("./%s/errors.py", settings.getModuleName()))
+            return createSymbolBuilder(shape, name, format("%s.errors", settings.moduleName()))
+                    .definitionFile(format("./%s/errors.py", settings.moduleName()))
                     .build();
         }
-        return createSymbolBuilder(shape, name, format("%s.models", settings.getModuleName()))
-                .definitionFile(format("./%s/models.py", settings.getModuleName()))
+        return createSymbolBuilder(shape, name, format("%s.models", settings.moduleName()))
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .build();
     }
 
@@ -388,12 +388,12 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         String name = getDefaultShapeName(shape);
 
         var unknownName = name + "Unknown";
-        var unknownSymbol = createSymbolBuilder(shape, unknownName, format("%s.models", settings.getModuleName()))
-            .definitionFile(format("./%s/models.py", settings.getModuleName()))
+        var unknownSymbol = createSymbolBuilder(shape, unknownName, format("%s.models", settings.moduleName()))
+            .definitionFile(format("./%s/models.py", settings.moduleName()))
             .build();
 
-        return createSymbolBuilder(shape, name, format("%s.models", settings.getModuleName()))
-                .definitionFile(format("./%s/models.py", settings.getModuleName()))
+        return createSymbolBuilder(shape, name, format("%s.models", settings.moduleName()))
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .putProperty("fromDict", createFromDictFunctionSymbol(shape))
                 .putProperty("unknown", unknownSymbol)
                 .build();
@@ -406,8 +406,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
             // Union members, unlike other shape members, have types generated for them.
             var containerSymbol = container.accept(this);
             var name = containerSymbol.getName() + StringUtils.capitalize(shape.getMemberName());
-            return createSymbolBuilder(shape, name, format("%s.models", settings.getModuleName()))
-                .definitionFile(format("./%s/models.py", settings.getModuleName()))
+            return createSymbolBuilder(shape, name, format("%s.models", settings.moduleName()))
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .build();
         }
         Shape targetShape = model.getShape(shape.getTarget())

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpApiKeyAuth.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpApiKeyAuth.java
@@ -60,7 +60,7 @@ public final class HttpApiKeyAuth implements PythonIntegration {
         if (!hasApiKeyAuth(context)) {
             return;
         }
-        var trait = context.settings().getService(context.model()).expectTrait(HttpApiKeyAuthTrait.class);
+        var trait = context.settings().service(context.model()).expectTrait(HttpApiKeyAuthTrait.class);
         var params = CodegenUtils.getHttpAuthParamsSymbol(context.settings());
         var resolver = CodegenUtils.getHttpAuthSchemeResolverSymbol(context.settings());
 
@@ -97,7 +97,7 @@ public final class HttpApiKeyAuth implements PythonIntegration {
     }
 
     private boolean hasApiKeyAuth(GenerationContext context) {
-        var service = context.settings().getService(context.model());
+        var service = context.settings().service(context.model());
         return service.hasTrait(HttpApiKeyAuthTrait.class);
     }
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
@@ -123,7 +123,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         var configSymbol = CodegenUtils.getConfigSymbol(context.settings());
         var transportRequest = context.applicationProtocol().requestType();
 
-        for (OperationShape operation : topDownIndex.getContainedOperations(context.settings().getService())) {
+        for (OperationShape operation : topDownIndex.getContainedOperations(context.settings().service())) {
             var serFunction = getSerializationFunction(context, operation);
             var input = context.model().expectShape(operation.getInputShape());
             var inputSymbol = context.symbolProvider().toSymbol(input);
@@ -758,9 +758,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     @Override
     public void generateResponseDeserializers(GenerationContext context) {
         var topDownIndex = TopDownIndex.of(context.model());
-        var service = context.settings().getService(context.model());
+        var service = context.settings().service(context.model());
         var deserializingErrorShapes = new TreeSet<ShapeId>();
-        for (OperationShape operation : topDownIndex.getContainedOperations(context.settings().getService())) {
+        for (OperationShape operation : topDownIndex.getContainedOperations(context.settings().service())) {
             generateOperationResponseDeserializer(context, operation);
             deserializingErrorShapes.addAll(operation.getErrors(service));
         }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -192,7 +192,7 @@ public final class HttpProtocolGeneratorUtils {
         OperationShape operation,
         Function<StructureShape, String> errorShapeToCode
     ) {
-        var errorIds = operation.getErrors(context.settings().getService(context.model()));
+        var errorIds = operation.getErrors(context.settings().service(context.model()));
         for (ShapeId errorId : errorIds) {
             var error = context.model().expectShape(errorId, StructureShape.class);
             var code = errorShapeToCode.apply(error).toLowerCase(Locale.US);

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/ProtocolGenerator.java
@@ -65,7 +65,7 @@ public interface ProtocolGenerator {
      * @return Returns the generated function name.
      */
     default String getSerializationFunctionName(GenerationContext context, ToShapeId shapeId) {
-        var name = context.settings().getService(context.model()).getContextualName(shapeId);
+        var name = context.settings().service(context.model()).getContextualName(shapeId);
         return "_serialize_" + CaseUtils.toSnakeCase(name);
     }
 
@@ -79,8 +79,8 @@ public interface ProtocolGenerator {
     default Symbol getSerializationFunction(GenerationContext context, ToShapeId shapeId) {
         return Symbol.builder()
                 .name(getSerializationFunctionName(context, shapeId))
-                .namespace(format("%s.serialize", context.settings().getModuleName()), "")
-                .definitionFile(format("./%s/serialize.py", context.settings().getModuleName()))
+                .namespace(format("%s.serialize", context.settings().moduleName()), "")
+                .definitionFile(format("./%s/serialize.py", context.settings().moduleName()))
                 .build();
     }
 
@@ -92,7 +92,7 @@ public interface ProtocolGenerator {
      * @return Returns the generated function name.
      */
     default String getDeserializationFunctionName(GenerationContext context, ToShapeId shapeId) {
-        var name = context.settings().getService(context.model()).getContextualName(shapeId);
+        var name = context.settings().service(context.model()).getContextualName(shapeId);
         return "_deserialize_" + CaseUtils.toSnakeCase(name);
     }
 
@@ -106,8 +106,8 @@ public interface ProtocolGenerator {
     default Symbol getDeserializationFunction(GenerationContext context, ToShapeId shapeId) {
         return Symbol.builder()
                 .name(getDeserializationFunctionName(context, shapeId))
-                .namespace(format("%s.deserialize", context.settings().getModuleName()), "")
-                .definitionFile(format("./%s/deserialize.py", context.settings().getModuleName()))
+                .namespace(format("%s.deserialize", context.settings().moduleName()), "")
+                .definitionFile(format("./%s/deserialize.py", context.settings().moduleName()))
                 .build();
     }
 
@@ -120,11 +120,11 @@ public interface ProtocolGenerator {
      * @return Returns the generated symbol.
      */
     default Symbol getErrorDeserializationFunction(GenerationContext context, ToShapeId shapeId) {
-        var name = context.settings().getService(context.model()).getContextualName(shapeId);
+        var name = context.settings().service(context.model()).getContextualName(shapeId);
         return Symbol.builder()
             .name("_deserialize_error_" + CaseUtils.toSnakeCase(name))
-            .namespace(format("%s.deserialize", context.settings().getModuleName()), "")
-            .definitionFile(format("./%s/deserialize.py", context.settings().getModuleName()))
+            .namespace(format("%s.deserialize", context.settings().moduleName()), "")
+            .definitionFile(format("./%s/deserialize.py", context.settings().moduleName()))
             .build();
     }
 


### PR DESCRIPTION
This migrates the settings object to be an immutable record (same thing as a python dataclass), reducing any risk from passing it around.

This also removes the protocol setting. It was never actually possible to set since the `fromNode` method didn't check for it. But also, it's just as easy to strip out the protocols you don't want via projection transforms.

Resolving the protocol was dramatically simplified and bundled in to the protocol generator resolver.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
