### PR TITLE
Classify error types for retry

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -137,6 +137,7 @@ final class ClientGenerator implements Runnable {
         writer.write("""
                 def _classify_error(
                     self,
+                    *,
                     error: Exception,
                     context: InterceptorContext[Input, Output, $1T, $2T | None]
                 ) -> RetryErrorInfo:
@@ -294,7 +295,9 @@ final class ClientGenerator implements Runnable {
                                     retry_token = retry_strategy.refresh_retry_token_for_retry(
                                         token_to_renew=retry_token,
                                         error_info=self._classify_error(
-                                            context_with_response.response, context_with_response)
+                                            error=context_with_response.response,
+                                            context=context_with_response,
+                                        )
                                     )
                                 except SmithyRetryException:
                                     raise context_with_response.response

--- a/python-packages/smithy-core/smithy_core/interfaces/exceptions.py
+++ b/python-packages/smithy-core/smithy_core/interfaces/exceptions.py
@@ -1,8 +1,9 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from typing import Literal, Protocol
+from typing import Literal, Protocol, runtime_checkable
 
 
+@runtime_checkable
 class HasFault(Protocol):
     """A protocol for a modeled error.
 


### PR DESCRIPTION
Updates retry to actually classify error types so it can react reasonably.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
