### PR TITLE
Add basic schema and shape classes

### DIFF
--- a/python-packages/smithy-core/smithy_core/schemas.py
+++ b/python-packages/smithy-core/smithy_core/schemas.py
@@ -1,0 +1,195 @@
+from dataclasses import dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    NotRequired,
+    Protocol,
+    Required,
+    Self,
+    TypedDict,
+    runtime_checkable,
+)
+
+from .exceptions import ExpectationNotMetException, SmithyException
+from .shapes import ShapeID, ShapeType
+
+if TYPE_CHECKING:
+    from .traits import Trait
+
+
+@dataclass(kw_only=True, frozen=True, init=False)
+class Schema:
+    """Describes a shape, its traits, and its members."""
+
+    id: ShapeID
+    type: ShapeType
+    traits: dict[ShapeID, "Trait"] = field(default_factory=dict)
+    members: dict[str, "Schema"] = field(default_factory=dict)
+    member_target: "Schema | HasSchema | None" = None
+    member_index: int | None = None
+
+    def __init__(
+        self,
+        *,
+        id: ShapeID,
+        type: ShapeType,
+        traits: list["Trait"] | dict[ShapeID, "Trait"] | None = None,
+        members: list["Schema"] | dict[str, "Schema"] | None = None,
+        member_target: "Schema | HasSchema | None" = None,
+        member_index: int | None = None,
+    ) -> None:
+        """Initialize a schema.
+
+        :param id: The ID of the shape.
+        :param type: The type of the shape.
+        :param traits: Traits applied to the shape, which describe additional metadata.
+        :param members: Members of the shape. These correspond to list contents,
+            dataclass properties, map keys/values, and union variants.
+        :param member_target: The schema that the member points to, if the shape is the
+            MEMBER type.
+        :param member_index: The index of the member, if the shape is the MEMBER type.
+            This is used for faster match checks when all members of a shape are known.
+        """
+        _member_props = [
+            id.member is not None,
+            member_target is not None,
+            member_index is not None,
+        ]
+        if any(_member_props) and not all(_member_props):
+            raise SmithyException(
+                "If any member property is set, all member properties must be set. "
+                f"member_name: {repr(id.member)}, member_target: "
+                f"{repr(member_target)}, member_index: {repr(member_index)}"
+            )
+
+        # setattr is required because the class is frozen
+        object.__setattr__(self, "id", id)
+        object.__setattr__(self, "type", type)
+
+        if traits:
+            if isinstance(traits, list):
+                traits = {t.id: t for t in traits}
+        else:
+            traits = {}
+        object.__setattr__(self, "traits", traits)
+
+        if members:
+            if isinstance(members, list):
+                m: dict[str, "Schema"] = {}
+                for member in members:
+                    m[member.expect_member_name()] = member
+                members = m
+        else:
+            members = {}
+        object.__setattr__(self, "members", members)
+
+        if member_target is not None:
+            object.__setattr__(self, "member_target", member_target)
+
+        if member_index is not None:
+            object.__setattr__(self, "member_index", member_index)
+
+    @property
+    def member_name(self) -> str | None:
+        """The name of the member, if the shape is the MEMBER type."""
+        return self.id.member
+
+    def expect_member_name(self) -> str:
+        """Assert the schema is a member schema and return its member name.
+
+        :raises ExpectationNotMetException: If member_name wasn't set.
+        :returns: Returns the member name.
+        """
+        return self.id.expect_member()
+
+    def expect_member_target(self) -> "Schema":
+        """Assert the schema is a member schema and return its target.
+
+        If the target is a class containing a schema, the schema is extracted and
+        returned.
+
+        :raises ExpectationNotMetException: If member_target wasn't set.
+        :returns: Returns the target schema.
+        """
+        match self.member_target:
+            case None:
+                raise ExpectationNotMetException(
+                    "Expected member_target to be set, but was None."
+                )
+            case HasSchema():
+                return self.member_target.SCHEMA
+            case _:
+                return self.member_target
+
+    def expect_member_index(self) -> int:
+        """Assert the schema is a member schema and return its member index.
+
+        :raises ExpectationNotMetException: If member_index wasn't set.
+        :returns: Returns the member index.
+        """
+        if self.member_index is None:
+            raise ExpectationNotMetException(
+                "Expected member_index to be set, but was None."
+            )
+        return self.member_index
+
+    @classmethod
+    def collection(
+        cls,
+        *,
+        id: ShapeID,
+        type: ShapeType = ShapeType.STRUCTURE,
+        traits: list["Trait"] | None = None,
+        members: dict[str, "MemberSchema"] | None = None,
+    ) -> Self:
+        """Create a schema for a collection shape.
+
+        :param id: The ID of the shape.
+        :param type: The type of the shape. Defaults to STRUCTURE.
+        :param traits: Traits applied to the shape, which describe additional metadata.
+        :param members: Members of the shape. These correspond to list contents, dataclass
+            properties, map keys/values, and union variants. In contrast to the main
+            constructor, this is a dict of member names to a simplified dict containing
+            only ``traits`` and a ``target``. Member schemas will be generated from this.
+        """
+        struct_members: dict[str, "Schema"] = {}
+        if members:
+            for i, k in enumerate(members.keys()):
+                member_traits = members[k].get("traits")
+                struct_members[k] = cls(
+                    id=id.with_member(k),
+                    type=ShapeType.MEMBER,
+                    traits=member_traits,
+                    member_target=members[k]["target"],
+                    member_index=i,
+                )
+        result = cls(
+            id=id,
+            type=type,
+            traits=traits,
+            members=struct_members,
+        )
+        print(repr(result))
+        return result
+
+
+class MemberSchema(TypedDict):
+    """A simplified schema for members.
+
+    This is only used for :ref:`Schema.collection`.
+
+    :param target: The target of the member.
+    :param traits: An optional list of traits for the member.
+    """
+
+    target: Required["Schema | HasSchema"]
+    traits: NotRequired[list["Trait"]]
+
+
+@runtime_checkable
+class HasSchema(Protocol):
+    """Protocol for classes that contain schemas.
+
+    Generated classes will contain these schemas.
+    """
+
+    SCHEMA: Schema

--- a/python-packages/smithy-core/smithy_core/schemas.py
+++ b/python-packages/smithy-core/smithy_core/schemas.py
@@ -168,7 +168,6 @@ class Schema:
             traits=traits,
             members=struct_members,
         )
-        print(repr(result))
         return result
 
 

--- a/python-packages/smithy-core/smithy_core/shapes.py
+++ b/python-packages/smithy-core/smithy_core/shapes.py
@@ -1,0 +1,128 @@
+from enum import Enum
+from typing import Self
+
+from .exceptions import ExpectationNotMetException, SmithyException
+
+
+class ShapeID:
+    """An identifier for a Smithy shape."""
+
+    _id: str
+    _namespace: str
+    _name: str
+    _member: str | None = None
+
+    def __init__(self, id: str) -> None:
+        """Initialize a ShapeID.
+
+        :param id: The string representation of the ID.
+        """
+        self._id = id
+        if "#" not in id:
+            raise SmithyException(f"Invalid shape id: {id}")
+        self._namespace, self._name = id.split("#", 1)
+        if not self.namespace or not self._name:
+            raise SmithyException(f"Invalid shape id: {id}")
+
+        if len(split_name := self._name.split("$", 1)) > 1:
+            self._name, self._member = split_name
+            if not self._name or not self._member:
+                raise SmithyException(f"Invalid shape id: {id}")
+
+    @property
+    def namespace(self) -> str:
+        """The namespace of the shape."""
+        return self._namespace
+
+    @property
+    def name(self) -> str:
+        """The name of the shape, or the name of the containing shape if the shape is a
+        member."""
+        return self._name
+
+    @property
+    def member(self) -> str | None:
+        """The member name of the shape.
+
+        This is only set for member shapes.
+        """
+        return self._member
+
+    def expect_member(self) -> str:
+        """Assert the member name is set and get it.
+
+        :raises ExpectationNotMetException: If member wasn't set.
+        :returns: Returns the member name.
+        """
+        if self.member is None:
+            raise ExpectationNotMetException("Expected member to be set, but was None.")
+        return self.member
+
+    def with_member(self, member: str) -> "ShapeID":
+        """Create a new shape id from the current id with the given member name.
+
+        :param member: The member name to use on the new shape id.
+        """
+        return ShapeID.from_parts(
+            namespace=self.namespace,
+            name=self.name,
+            member=member,
+        )
+
+    def __str__(self) -> str:
+        return self._id
+
+    def __repr__(self) -> str:
+        return f"ShapeId({self._id})"
+
+    def __eq__(self, other: object) -> bool:
+        return self._id == str(other)
+
+    def __hash__(self) -> int:
+        return hash(self._id)
+
+    @classmethod
+    def from_parts(
+        cls, *, namespace: str, name: str, member: str | None = None
+    ) -> Self:
+        """Initialize a ShapeID from component parts instead of a string whole.
+
+        :param namesapce: The shape's namespace.
+        :param name: The shape's individual name.
+        :param member: The shape member's name. Only set for member shapes.
+        """
+        if member is not None:
+            return cls(f"{namespace}#{name}${member}")
+        return cls(f"{namespace}#{name}")
+
+
+class ShapeType(Enum):
+    """The type of data that a shape represents."""
+
+    BLOB = 1
+    BOOLEAN = 2
+    STRING = 3
+    TIMESTAMP = 4
+    BYTE = 5
+    SHORT = 6
+    INTEGER = 7
+    LONG = 8
+    FLOAT = 9
+    DOUBLE = 10
+    BIG_INTEGER = 11
+    BIG_DECIMAL = 12
+    DOCUMENT = 13
+    ENUM = 14
+    INT_ENUM = 15
+
+    LIST = 16
+    MAP = 17
+    STRUCTURE = 18
+    UNION = 19
+
+    MEMBER = 20
+
+    # We won't acutally be using these, probably
+    # SERVICE = 21
+    # RESOURCE = 22
+    # OPERATION = 23

--- a/python-packages/smithy-core/smithy_core/traits.py
+++ b/python-packages/smithy-core/smithy_core/traits.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .shapes import ShapeID
+    from .types import Document
+
+
+@dataclass(kw_only=True, frozen=True)
+class Trait:
+    """A component that can be attached to a schema to describe additional information
+    about it.
+
+    :param id: The ID of the trait.
+    :param value: The document value of the trait.
+    """
+
+    id: "ShapeID"
+    value: "Document"

--- a/python-packages/smithy-http/tests/unit/test_schemas.py
+++ b/python-packages/smithy-http/tests/unit/test_schemas.py
@@ -1,0 +1,77 @@
+from typing import Final
+
+import pytest
+from smithy_core.exceptions import ExpectationNotMetException
+from smithy_core.schemas import HasSchema, Schema
+from smithy_core.shapes import ShapeID, ShapeType
+from smithy_core.traits import Trait
+
+ID: ShapeID = ShapeID("ns.foo#bar")
+STRING = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
+
+
+def test_traits_list():
+    trait_id = ShapeID("smithy.api#internal")
+    trait = Trait(id=trait_id, value=True)
+    schema = Schema(id=ID, type=ShapeType.STRUCTURE, traits=[trait])
+    assert schema.traits == {trait_id: trait}
+
+
+def test_members_list():
+    member_name = "baz"
+    member = Schema(
+        id=ID.with_member(member_name),
+        type=ShapeType.MEMBER,
+        member_target=STRING,
+        member_index=0,
+    )
+    schema = Schema(id=ID, type=ShapeType.STRUCTURE, members=[member])
+    assert schema.members == {"baz": member}
+
+
+def test_expect_member_schema():
+    member_schema = Schema(
+        id=ID.with_member("baz"),
+        type=ShapeType.MEMBER,
+        member_target=STRING,
+        member_index=0,
+    )
+    assert member_schema.expect_member_name() == "baz"
+    assert member_schema.member_name == "baz"
+
+    assert member_schema.expect_member_target() == STRING
+    assert member_schema.member_target == STRING
+
+    assert member_schema.expect_member_index() == 0
+    assert member_schema.member_index == 0
+
+
+def test_member_expectations_raise_on_non_members():
+    with pytest.raises(ExpectationNotMetException):
+        STRING.expect_member_name()
+
+    with pytest.raises(ExpectationNotMetException):
+        STRING.expect_member_target()
+
+    with pytest.raises(ExpectationNotMetException):
+        STRING.expect_member_index()
+
+
+def test_collection_constructor():
+    member_name = "baz"
+    member = Schema(
+        id=ID.with_member(member_name),
+        type=ShapeType.MEMBER,
+        member_target=STRING,
+        member_index=0,
+    )
+    schema = Schema.collection(id=ID, members={member_name: {"target": STRING}})
+    assert schema.members == {member_name: member}
+
+
+class TestSchemaBearer:
+    SCHEMA: Final[Schema] = Schema.collection(id=ID)
+
+
+def test_has_schema():
+    assert isinstance(TestSchemaBearer, HasSchema)

--- a/python-packages/smithy-http/tests/unit/test_shapes.py
+++ b/python-packages/smithy-http/tests/unit/test_shapes.py
@@ -1,0 +1,45 @@
+import pytest
+from smithy_core.exceptions import ExpectationNotMetException, SmithyException
+from smithy_core.shapes import ShapeID
+
+
+@pytest.mark.parametrize(
+    "id,namespace,name,member",
+    [
+        ("ns.foo#bar", "ns.foo", "bar", None),
+        ("ns.foo#bar$baz", "ns.foo", "bar", "baz"),
+    ],
+)
+def test_valid_shape_id(id: str, namespace: str, name: str, member: str | None):
+    shape_id = ShapeID(id)
+
+    assert str(shape_id) == id
+    assert shape_id.namespace == namespace
+    assert shape_id.name == name
+    assert shape_id.member == member
+
+
+@pytest.mark.parametrize(
+    "id", ["foo", "#", "ns.foo#", "#foo", "ns.foo#bar$", "ns.foo#$baz", "#$"]
+)
+def test_invalid_shape_id(id: str):
+    with pytest.raises(SmithyException):
+        ShapeID(id)
+
+
+def test_expect_member():
+    assert ShapeID("ns.foo#bar$baz").expect_member() == "baz"
+    with pytest.raises(ExpectationNotMetException):
+        assert ShapeID("ns.foo#bar").expect_member()
+
+
+def test_from_parts():
+    assert ShapeID("ns.foo#bar") == ShapeID.from_parts(namespace="ns.foo", name="bar")
+    assert ShapeID("ns.foo#bar$baz") == ShapeID.from_parts(
+        namespace="ns.foo", name="bar", member="baz"
+    )
+
+
+def test_with_member():
+    assert ShapeID("ns.foo#bar").with_member("baz") == ShapeID("ns.foo#bar$baz")
+    assert ShapeID("ns.foo#bar$cleared").with_member("baz") == ShapeID("ns.foo#bar$baz")


### PR DESCRIPTION
This adds the schema class, which will be used to provide some information from the model at runtime. It additionally adds in some shape / trait classes that are needed to fill it out.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
