### PR TITLE
Add length and repr to fields

### DIFF
--- a/python-packages/smithy-http/smithy_http/__init__.py
+++ b/python-packages/smithy-http/smithy_http/__init__.py
@@ -172,6 +172,12 @@ class Fields(interfaces.Fields):
     def __iter__(self) -> Iterator[interfaces.Field]:
         yield from self.entries.values()
 
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    def __repr__(self) -> str:
+        return f"Fields({self.entries})"
+
 
 def quote_and_escape_field_value(value: str) -> str:
     """Escapes and quotes a single :class:`Field` value if necessary.

--- a/python-packages/smithy-http/tests/unit/test_fields.py
+++ b/python-packages/smithy-http/tests/unit/test_fields.py
@@ -171,3 +171,17 @@ def test_fields_inequality(fs1: Fields, fs2: Fields) -> None:
 def test_repeated_initial_field_names(initial_fields: list[Field]) -> None:
     with pytest.raises(ValueError):
         Fields(initial_fields)
+
+
+@pytest.mark.parametrize(
+    "fields,expected_length",
+    [
+        (Fields(), 0),
+        (Fields([Field(name="fname1")]), 1),
+        (Fields(encoding="utf-1"), 0),
+        (Fields([Field(name="fname", values=["val2", "val1"])]), 1),
+        (Fields([Field(name="f1"), Field(name="f2")]), 2),
+    ],
+)
+def test_fields_length_value(fields: Fields, expected_length: int) -> None:
+    assert len(fields) == expected_length


### PR DESCRIPTION
This PR adds some minor usability dunders to the `Fields` class to allow us to verify the total number of `Field` entries in a `Fields` instance and represent those values in the `__repr__`.