### PR TITLE
Add __contains__ support to Fields

### DIFF
--- a/python-packages/smithy-http/smithy_http/__init__.py
+++ b/python-packages/smithy-http/smithy_http/__init__.py
@@ -178,6 +178,9 @@ class Fields(interfaces.Fields):
     def __repr__(self) -> str:
         return f"Fields({self.entries})"
 
+    def __contains__(self, key: str) -> bool:
+        return key in self.entries
+
 
 def quote_and_escape_field_value(value: str) -> str:
     """Escapes and quotes a single :class:`Field` value if necessary.

--- a/python-packages/smithy-http/smithy_http/__init__.py
+++ b/python-packages/smithy-http/smithy_http/__init__.py
@@ -179,7 +179,7 @@ class Fields(interfaces.Fields):
         return f"Fields({self.entries})"
 
     def __contains__(self, key: str) -> bool:
-        return key in self.entries
+        return self._normalize_field_name(key) in self.entries
 
 
 def quote_and_escape_field_value(value: str) -> str:

--- a/python-packages/smithy-http/tests/unit/test_fields.py
+++ b/python-packages/smithy-http/tests/unit/test_fields.py
@@ -228,6 +228,7 @@ def test_fields_repr(fields: Field, expected_repr: str) -> None:
     "fields,key,contained",
     [
         (Fields(), "bad_key", False),
+        (Fields([Field(name="fname1")]), "FNAME1", True),
         (Fields([Field(name="fname1")]), "fname1", True),
         (Fields([Field(name="fname2")]), "fname1", False),
         (Fields([Field(name="f1"), Field(name="f2")]), "f1", True),

--- a/python-packages/smithy-http/tests/unit/test_fields.py
+++ b/python-packages/smithy-http/tests/unit/test_fields.py
@@ -222,3 +222,17 @@ def test_fields_length_value(fields: Fields, expected_length: int) -> None:
 )
 def test_fields_repr(fields: Field, expected_repr: str) -> None:
     assert repr(fields) == expected_repr
+
+
+@pytest.mark.parametrize(
+    "fields,key,contained",
+    [
+        (Fields(), "bad_key", False),
+        (Fields([Field(name="fname1")]), "fname1", True),
+        (Fields([Field(name="fname2")]), "fname1", False),
+        (Fields([Field(name="f1"), Field(name="f2")]), "f1", True),
+        (Fields([Field(name="f1"), Field(name="f2")]), "f3", False),
+    ],
+)
+def test_fields_contains(fields: Fields, key: str, contained: bool) -> None:
+    assert (key in fields) is contained


### PR DESCRIPTION
Add `__contains__` to Fields to properly support the `in` Python keyword when searching the collection.