### PR TITLE
Update explicit set/get/remove functions to use native dunder methods

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -153,7 +153,7 @@ final class ClientGenerator implements Runnable {
                 if context.transport_response:
                     if context.transport_response.status in [429, 503]:
                         retry_after = None
-                        retry_header = context.transport_response.fields.get_field("retry-after")
+                        retry_header = context.transport_response.fields["retry-after"]
                         if retry_header and retry_header.values:
                             retry_after = float(retry_header.values[0])
                         return RetryErrorInfo(error_type=RetryErrorType.THROTTLING, retry_after_hint=retry_after)

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -250,17 +250,17 @@ public final class HttpProtocolTestGenerator implements Runnable {
                         ${9C|}
                     ]
                     for expected_key, expected_val in expected_headers:
-                        assert expected_val in actual.fields.get_field(expected_key).values
+                        assert expected_val in actual.fields[expected_key].values
 
                     forbidden_headers: set[str] = set($10J)
                     for forbidden_key in forbidden_headers:
                         with raises(KeyError):
-                            actual.fields.get_field(forbidden_key)
+                            actual.fields[forbidden_key]
 
                     required_headers: list[str] = $11J
                     for required_key in required_headers:
-                        # Fields.remove_field() raises KeyError if key does not exist
-                        actual.fields.remove_field(required_key)
+                        # del Fields[required_key] raises KeyError if key does not exist
+                        del actual.fields[required_key]
 
                     ${12C|}
 

--- a/designs/http-interfaces.md
+++ b/designs/http-interfaces.md
@@ -215,14 +215,18 @@ class Fields(Protocol):
     encoding: str | None = "utf-8"
 
     def set_field(self, field: Field) -> None:
+        """Alias for __setitem__ to utilize the field.name for the entry key."""
+        ...
+
+    def __setitem__(self, name: str, field: Field) -> None:
         """Set entry for a Field name."""
         ...
 
-    def get_field(self, name: str) -> Field:
+    def __getitem__(self, name: str) -> Field:
         """Retrieve Field entry."""
         ...
 
-    def remove_field(self, name: str) -> None:
+    def __delitem__(self, name: str) -> None:
         """Delete entry from collection."""
         ...
 

--- a/python-packages/smithy-http/smithy_http/aio/aiohttp.py
+++ b/python-packages/smithy-http/smithy_http/aio/aiohttp.py
@@ -109,14 +109,12 @@ class AIOHTTPClient(HTTPClient):
         headers = Fields()
         for header_name, header_val in aiohttp_resp.headers.items():
             try:
-                headers.get_field(header_name).add(header_val)
+                headers[header_name].add(header_val)
             except KeyError:
-                headers.set_field(
-                    Field(
-                        name=header_name,
-                        values=[header_val],
-                        kind=FieldPosition.HEADER,
-                    )
+                headers[header_name] = Field(
+                    name=header_name,
+                    values=[header_val],
+                    kind=FieldPosition.HEADER,
                 )
 
         return HTTPResponse(

--- a/python-packages/smithy-http/smithy_http/aio/crt.py
+++ b/python-packages/smithy-http/smithy_http/aio/crt.py
@@ -75,14 +75,12 @@ class AWSCRTHTTPResponse(http_aio_interfaces.HTTPResponse):
         fields = Fields()
         for header_name, header_val in headers:
             try:
-                fields.get_field(header_name).add(header_val)
+                fields[header_name].add(header_val)
             except KeyError:
-                fields.set_field(
-                    Field(
-                        name=header_name,
-                        values=[header_val],
-                        kind=FieldPosition.HEADER,
-                    )
+                fields[header_name] = Field(
+                    name=header_name,
+                    values=[header_val],
+                    kind=FieldPosition.HEADER,
                 )
         self._status_code_future.set_result(status_code)
         self._headers_future.set_result(fields)

--- a/python-packages/smithy-http/smithy_http/interfaces/__init__.py
+++ b/python-packages/smithy-http/smithy_http/interfaces/__init__.py
@@ -75,15 +75,27 @@ class Fields(Protocol):
     encoding: str | None = "utf-8"
 
     def set_field(self, field: Field) -> None:
+        """Alias for __setitem__ to utilize the field.name for the entry key."""
+        ...
+
+    def __setitem__(self, name: str, field: Field) -> None:
         """Set entry for a Field name."""
         ...
 
-    def get_field(self, name: str) -> Field:
+    def __getitem__(self, name: str) -> Field:
         """Retrieve Field entry."""
         ...
 
-    def remove_field(self, name: str) -> None:
+    def __delitem__(self, name: str) -> None:
         """Delete entry from collection."""
+        ...
+
+    def __iter__(self) -> Iterator[Field]:
+        """Allow iteration over entries."""
+        ...
+
+    def __len__(self) -> int:
+        """Get total number of Field entries."""
         ...
 
     def get_by_type(self, kind: FieldPosition) -> list[Field]:
@@ -100,10 +112,6 @@ class Fields(Protocol):
         already exists in the current ``entries``, the values from ``other`` are
         appended. Otherwise, the ``Field`` is added to the list of ``entries``.
         """
-        ...
-
-    def __iter__(self) -> Iterator[Field]:
-        """Allow iteration over entries."""
         ...
 
 

--- a/python-packages/smithy-http/tests/unit/test_fields.py
+++ b/python-packages/smithy-http/tests/unit/test_fields.py
@@ -237,3 +237,84 @@ def test_fields_repr(fields: Field, expected_repr: str) -> None:
 )
 def test_fields_contains(fields: Fields, key: str, contained: bool) -> None:
     assert (key in fields) is contained
+
+
+@pytest.mark.parametrize(
+    "fields,key,expected",
+    [
+        (Fields(), "bad_key", None),
+        (Fields([Field(name="fname1")]), "FNAME1", Field(name="fname1")),
+        (Fields([Field(name="fname1")]), "fname1", Field(name="fname1")),
+        (Fields([Field(name="fname2")]), "fname1", None),
+        (Fields([Field(name="f1"), Field(name="f2")]), "f1", Field(name="f1")),
+        (Fields([Field(name="f1"), Field(name="f2")]), "f2", Field(name="f2")),
+        (Fields([Field(name="f1"), Field(name="f2")]), "f3", None),
+    ],
+)
+def test_fields_getitem(fields: Fields, key: str, expected: Field | None) -> None:
+    assert fields.get(key) == expected
+
+
+def test_fields_get_index() -> None:
+    fields = Fields([Field(name="f1"), Field(name="f2")])
+    assert fields["f1"] == Field(name="f1")
+
+
+def test_fields_get_missing_index() -> None:
+    fields = Fields([Field(name="fname1")])
+    with pytest.raises(KeyError):
+        fields["fname2"]
+
+
+@pytest.mark.parametrize(
+    "fields,field",
+    [
+        (Fields(), Field(name="fname1")),
+        (Fields([Field(name="fname1", values=["1", "2"])]), Field(name="fname1")),
+        (Fields([Field(name="f1"), Field(name="f2")]), Field(name="f3")),
+    ],
+)
+def test_fields_setitem(fields: Fields, field: Field) -> None:
+    fields[field.name] = field
+    assert field.name in fields
+    assert fields[field.name] == field
+
+
+@pytest.mark.parametrize(
+    "fields,field",
+    [
+        (Fields(), Field(name="fname1")),
+        (Fields([Field(name="fname1", values=["1", "2"])]), Field(name="fname1")),
+        (Fields([Field(name="f1"), Field(name="f2")]), Field(name="f3")),
+    ],
+)
+def test_fields_set_field(fields: Fields, field: Field) -> None:
+    fields.set_field(field)
+    assert field.name in fields
+    assert fields[field.name] == field
+
+
+@pytest.mark.parametrize(
+    "fields,field_name,expected_keys",
+    [
+        (Fields([Field(name="fname1", values=["1", "2"])]), "fname1", []),
+        (Fields([Field(name="f1"), Field(name="f2")]), "f2", ["f1"]),
+    ],
+)
+def test_fields_delitem(
+    fields: Fields, field_name: str, expected_keys: list[str]
+) -> None:
+    assert field_name in fields
+    del fields[field_name]
+    assert field_name not in fields
+
+    # Ensure we don't delete anything unexpected
+    assert len(fields) == len(expected_keys)
+    for key in expected_keys:
+        assert key in fields
+
+
+def test_fields_delitem_missing() -> None:
+    fields = Fields([Field(name="fname1")])
+    with pytest.raises(KeyError):
+        del fields["fname2"]


### PR DESCRIPTION
This PR proposes simplifying our `Fields` interface to use more idiomatic methods for accessing, setting, and removing `Field` entries. The original implementation was strictly following the Cross-SDK specification but creates an unintuitive user experience for Python developers. We could also keep the existing methods and alias them to the dunder implementations, but it seems like clutter and confusing imo.