### PR TITLE
Documents

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
@@ -226,7 +226,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol documentShape(DocumentShape shape) {
         return createSymbolBuilder(shape, "Document")
-                .namespace("smithy_core.types", ".")
+                .namespace("smithy_core.documents", ".")
                 .addDependency(SmithyPythonDependency.SMITHY_CORE)
                 .build();
     }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/DocumentMemberDeserVisitor.java
@@ -285,7 +285,8 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public final String documentShape(DocumentShape shape) {
-        return dataSource();
+        writer.addImport("smithy_core.documents", "Document");
+        return String.format("Document(%s)", dataSource());
     }
 
     @Override

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/DocumentMemberSerVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/DocumentMemberSerVisitor.java
@@ -180,7 +180,7 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
 
     @Override
     public String documentShape(DocumentShape documentShape) {
-        return dataSource();
+        return String.format("%s.as_value()", dataSource());
     }
 
     @Override

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
@@ -841,11 +841,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         delegator.useFileWriter(deserFunction.getDefinitionFile(), deserFunction.getNamespace(), writer -> {
             writer.pushState(new ErrorDeserializerSection(error));
             writer.addStdlibImport("typing", "Any");
+            writer.addImport("smithy_core.documents", "DocumentValue");
             writer.write("""
                 async def $L(
                     http_response: $T,
                     config: $T,
-                    parsed_body: dict[str, Document] | None,
+                    parsed_body: dict[str, DocumentValue] | None,
                     default_message: str,
                 ) -> $T:
                     kwargs: dict[str, Any] = {"message": default_message}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonMemberSerVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonMemberSerVisitor.java
@@ -37,7 +37,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
 
     private static final Set<ShapeType> NOOP_TARGETS = SetUtils.of(
-        ShapeType.STRING, ShapeType.ENUM, ShapeType.BOOLEAN, ShapeType.DOCUMENT, ShapeType.BYTE, ShapeType.SHORT,
+        ShapeType.STRING, ShapeType.ENUM, ShapeType.BOOLEAN, ShapeType.BYTE, ShapeType.SHORT,
         ShapeType.INTEGER, ShapeType.INT_ENUM, ShapeType.LONG, ShapeType.FLOAT, ShapeType.DOUBLE
     );
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeDeserVisitor.java
@@ -98,7 +98,7 @@ public class JsonShapeDeserVisitor extends ShapeVisitor.Default<Void> {
         var symbol = context.symbolProvider().toSymbol(shape);
         var errorSymbol = CodegenUtils.getServiceError(context.settings());
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document", "Document");
+        writer.addImport("smithy_core.documents", "DocumentValue");
 
         var target = context.model().expectShape(shape.getMember().getTarget());
         var memberVisitor = getMemberVisitor(shape.getMember(), "e");
@@ -111,7 +111,7 @@ public class JsonShapeDeserVisitor extends ShapeVisitor.Default<Void> {
         }
 
         writer.write("""
-            def $1L(output: Document, config: $2T) -> $3T:
+            def $1L(output: DocumentValue, config: $2T) -> $3T:
                 if not isinstance(output, list):
                     raise $5T(f"Expected list, found {type(output)}")
                 return [$4L$6L for e in output]
@@ -126,14 +126,14 @@ public class JsonShapeDeserVisitor extends ShapeVisitor.Default<Void> {
         var symbol = context.symbolProvider().toSymbol(shape);
         var errorSymbol = CodegenUtils.getServiceError(context.settings());
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document", "Document");
+        writer.addImport("smithy_core.documents", "DocumentValue");
 
         var valueShape = context.model().expectShape(shape.getValue().getTarget());
         var valueVisitor = getMemberVisitor(shape.getValue(), "v");
         var valueDeserializer = valueShape.accept(valueVisitor);
 
         writer.write("""
-            def $1L(output: Document, config: $2T) -> $3T:
+            def $1L(output: DocumentValue, config: $2T) -> $3T:
                 if not isinstance(output, dict):
                     raise $4T(f"Expected dict, found { type(output) }")
             """, functionName, config, symbol, errorSymbol);
@@ -156,9 +156,9 @@ public class JsonShapeDeserVisitor extends ShapeVisitor.Default<Void> {
         var symbol = context.symbolProvider().toSymbol(shape);
         var errorSymbol = CodegenUtils.getServiceError(context.settings());
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document", "Document");
+        writer.addImport("smithy_core.documents", "DocumentValue");
         writer.write("""
-            def $1L(output: Document, config: $2T) -> $3T:
+            def $1L(output: DocumentValue, config: $2T) -> $3T:
                 if not isinstance(output, dict):
                     raise $4T(f"Expected dict, found {type(output)}")
 
@@ -232,9 +232,9 @@ public class JsonShapeDeserVisitor extends ShapeVisitor.Default<Void> {
         var unknownSymbol = symbol.expectProperty(SymbolProperties.UNION_UNKNOWN);
 
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document", "Document");
+        writer.addImport("smithy_core.documents", "DocumentValue");
         writer.write("""
-            def $1L(output: Document, config: $2T) -> $3T:
+            def $1L(output: DocumentValue, config: $2T) -> $3T:
                 if not isinstance(output, dict):
                     raise $5T(f"Expected dict, found {type(output)}")
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeSerVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/JsonShapeSerVisitor.java
@@ -109,9 +109,9 @@ public class JsonShapeSerVisitor extends ShapeVisitor.Default<Void> {
         }
 
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document");
+        writer.addImport("smithy_core.documents", "DocumentValue");
         writer.write("""
-            def $1L(input: $2T, config: $3T) -> list[Document]:
+            def $1L(input: $2T, config: $3T) -> list[DocumentValue]:
                 return [$4L$5L for e in input]
             """, functionName, listSymbol, config, memberSerializer, sparseTrailer);
         return null;
@@ -139,9 +139,9 @@ public class JsonShapeSerVisitor extends ShapeVisitor.Default<Void> {
         }
 
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document");
+        writer.addImport("smithy_core.documents", "DocumentValue");
         writer.write("""
-            def $1L(input: $2T, config: $3T) -> dict[str, Document]:
+            def $1L(input: $2T, config: $3T) -> dict[str, DocumentValue]:
                 return {k: $4L$5L for k, v in input.items()}
             """, functionName, mapSymbol, config, valueSerializer, sparseTrailer);
         return null;
@@ -153,11 +153,11 @@ public class JsonShapeSerVisitor extends ShapeVisitor.Default<Void> {
         var config = CodegenUtils.getConfigSymbol(context.settings());
         var structureSymbol = context.symbolProvider().toSymbol(shape);
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document");
+        writer.addImport("smithy_core.documents", "DocumentValue");
 
         writer.write("""
-            def $1L(input: $2T, config: $3T) -> dict[str, Document]:
-                result: dict[str, Document] = {}
+            def $1L(input: $2T, config: $3T) -> dict[str, DocumentValue]:
+                result: dict[str, DocumentValue] = {}
 
                 ${4C|}
                 return result
@@ -209,10 +209,10 @@ public class JsonShapeSerVisitor extends ShapeVisitor.Default<Void> {
         var unionSymbol = context.symbolProvider().toSymbol(shape);
         var errorSymbol = CodegenUtils.getServiceError(context.settings());
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document");
+        writer.addImport("smithy_core.documents", "DocumentValue");
 
         writer.write("""
-            def $1L(input: $2T, config: $3T) -> dict[str, Document]:
+            def $1L(input: $2T, config: $3T) -> dict[str, DocumentValue]:
                 match input:
                     ${5C|}
                     case _:

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
@@ -113,8 +113,8 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         List<HttpBinding> documentBindings
     ) {
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document");
-        writer.write("result: dict[str, Document] = {}\n");
+        writer.addImport("smithy_core.documents", "DocumentValue");
+        writer.write("result: dict[str, DocumentValue] = {}\n");
 
         var bodyMembers = documentBindings.stream()
             .map(HttpBinding::getMember)
@@ -244,12 +244,12 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         List<HttpBinding> documentBindings
     ) {
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImport("smithy_core.types", "Document");
+        writer.addImport("smithy_core.documents", "DocumentValue");
         writer.addStdlibImport("json");
 
         if (operationOrError.isOperationShape()) {
             writer.write("""
-                output: dict[str, Document] = {}
+                output: dict[str, DocumentValue] = {}
                 if (body := await http_response.consume_body_async()):
                     output = json.loads(body)
 
@@ -263,7 +263,7 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                 if (parsed_body is None) and (body := await http_response.consume_body_async()):
                     parsed_body = json.loads(body)
 
-                output: dict[str, Document] = parsed_body if parsed_body is not None else {}
+                output: dict[str, DocumentValue] = parsed_body if parsed_body is not None else {}
                 """);
         }
 

--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -1,0 +1,286 @@
+import datetime
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from typing import TypeGuard
+
+from .exceptions import ExpectationNotMetException
+from .schemas import Schema
+from .shapes import ShapeID, ShapeType
+from .utils import expect_type
+
+_DOCUMENT = Schema(id=ShapeID("smithy.api#Document"), type=ShapeType.DOCUMENT)
+
+
+type DocumentValue = (
+    Mapping[str, DocumentValue]
+    | Sequence[DocumentValue]
+    | str
+    | int
+    | float
+    | Decimal
+    | bool
+    | None
+    | bytes
+    | datetime.datetime
+)
+"""Protocol-agnostic open content."""
+
+
+type _InnerDocumentValue = (
+    dict[str, "Document"]
+    | list["Document"]
+    | str
+    | int
+    | float
+    | Decimal
+    | bool
+    | None
+    | bytes
+    | datetime.datetime
+)
+"""The inner value for a Document.
+
+Collections in these inner values are restricted to having Document values and may only
+be lists or dicts.
+"""
+
+
+class Document:
+    """Wrapped protocol-agnostic open content.
+
+    This wrapping class facilitates serialization and deserialiazation and may contain a
+    schema to enable serializing and deserializing protocol-specific documents into a
+    protocol-agnostic form.
+    """
+
+    _value: _InnerDocumentValue = None
+    _raw_value: Mapping[str, DocumentValue] | Sequence[DocumentValue] | None = None
+    _type: ShapeType | None = None
+    _schema: Schema
+
+    def __init__(
+        self,
+        value: DocumentValue | dict[str, "Document"] | list["Document"] = None,
+        *,
+        schema: Schema | None = None,
+    ) -> None:
+        """Initializes a document.
+
+        :param value: The underlying value of a document.
+        :param schema: A schema defining the document's structure. The default value is
+            a plain document schema with no traits.
+        """
+        self._schema = schema or _DOCUMENT
+
+        # Mappings and Sequences are lazily converted to/from the inner value type.
+        if isinstance(value, Mapping):
+            if self._is_raw_map(value):
+                self._raw_value = value
+            else:
+                self._value = value  # type: ignore
+        elif isinstance(value, Sequence):
+            if self._is_raw_list(value):
+                self._raw_value = value
+            else:
+                self._value = value  # type: ignore
+        else:
+            self._value = value
+
+    def _is_raw_map(
+        self, value: Mapping[str, "Document"] | Mapping[str, DocumentValue]
+    ) -> TypeGuard[Mapping[str, DocumentValue]]:
+        return len(value) != 0 and not isinstance(next(iter(value.values())), Document)
+
+    def _is_raw_list(
+        self, value: Sequence["Document"] | Sequence[DocumentValue]
+    ) -> TypeGuard[Sequence[DocumentValue]]:
+        return (
+            len(value) != 0
+            and not isinstance(value, str | bytes)
+            and not isinstance(next(iter(value)), Document)
+        )
+
+    @property
+    def type(self) -> ShapeType:
+        """The Smithy data model type for the underlying contents of the document."""
+        if self._type is None:
+            if self._schema is not _DOCUMENT:
+                self._type = self._schema.type
+            elif isinstance(self._raw_value, Sequence):
+                self._type = ShapeType.LIST
+            else:
+                match self._value:
+                    case bool():
+                        self._type = ShapeType.BOOLEAN
+                    case str():
+                        self._type = ShapeType.STRING
+                    case int():
+                        self._type = ShapeType.LONG
+                    case float():
+                        self._type = ShapeType.DOUBLE
+                    case Decimal():
+                        self._type = ShapeType.BIG_DECIMAL
+                    case bytes():
+                        self._type = ShapeType.BLOB
+                    case datetime.datetime():
+                        self._type = ShapeType.TIMESTAMP
+                    case list():
+                        self._type = ShapeType.LIST
+                    case _:
+                        self._type = ShapeType.DOCUMENT
+        return self._type
+
+    def as_blob(self) -> bytes:
+        """Asserts the document is a blob and returns it as bytes."""
+        return expect_type(bytes, self._value)
+
+    def as_boolean(self) -> bool:
+        """Asserts the document is a boolean and returns it."""
+        return expect_type(bool, self._value)
+
+    def as_string(self) -> str:
+        """Asserts the document is a string and returns it."""
+        return expect_type(str, self._value)
+
+    def as_timestamp(self) -> datetime.datetime:
+        """Asserts the document is a timestamp and returns it."""
+        return expect_type(datetime.datetime, self._value)
+
+    def as_integer(self) -> int:
+        """Asserts the document is an integer and returns it.
+
+        This method is to be used for any type from the Smithy data model that
+        translates to Python's int type. This includes: byte, short, integer, long, and
+        bigInteger.
+        """
+        if isinstance(self._value, int) and not isinstance(self._value, bool):
+            return self._value
+        raise ExpectationNotMetException(
+            f"Expected int, found {type(self._value)}: {self._value}"
+        )
+
+    def as_float(self) -> float:
+        """Asserts the document is a float and returns it.
+
+        This method is to be used for any type from the Smithy data model that
+        translates to Python's float type. This includes float and double.
+        """
+        return expect_type(float, self._value)
+
+    def as_decimal(self) -> Decimal:
+        """Asserts the document is a Decimal and returns it."""
+        return expect_type(Decimal, self._value)
+
+    def as_list(self) -> list["Document"]:
+        """Asserts the document is a list and returns it."""
+        if isinstance(self._value, list):
+            return self._value
+        if (
+            self._value is None
+            and isinstance(self._raw_value, Sequence)
+            and not isinstance(self._raw_value, str | bytes)
+        ):
+            self._value = self._wrap_list(self._raw_value)
+            return self._value
+        raise ExpectationNotMetException(
+            f"Expected list, found {type(self._value)}: {self._value}"
+        )
+
+    def _wrap_list(self, value: Sequence[DocumentValue]) -> list["Document"]:
+        schema = self._schema
+        if schema is not _DOCUMENT:
+            schema = self._schema.members["member"]
+        return [Document(e, schema=schema) for e in value]
+
+    def as_map(self) -> dict[str, "Document"]:
+        """Asserts the document is a map and returns it."""
+        if isinstance(self._value, Mapping):
+            return self._value
+        if self._value is None and isinstance(self._raw_value, Mapping):
+            self._value = self._wrap_map(self._raw_value)
+            return self._value
+        raise ExpectationNotMetException(
+            f"Expected map, found {type(self._value)}: {self._value}"
+        )
+
+    def _wrap_map(self, value: Mapping[str, DocumentValue]) -> dict[str, "Document"]:
+        if self._schema is _DOCUMENT:
+            return {k: Document(v) for k, v in value.items()}
+
+        result: dict[str, "Document"] = {}
+        for k, v in value.items():
+            result[k] = Document(v, schema=self._schema.members[k])
+        return result
+
+    def as_value(self) -> DocumentValue:
+        """Converts the document to a plain, protocol-agnostic DocumentValue and returns
+        it."""
+        if self._value is not None and self._raw_value is None:
+            match self._value:
+                case dict():
+                    self._raw_value = {k: v.as_value() for k, v in self._value.items()}
+                case list():
+                    self._raw_value = [e.as_value() for e in self._value]
+                case _:
+                    return self._value
+        return self._raw_value
+
+    def get(self, name: str, default: "Document | None" = None) -> "Document | None":
+        """Gets a named member of the document or a default value."""
+        return self.as_map().get(name, default)
+
+    def __getitem__(self, key: str | int | slice) -> "Document":
+        match key:
+            case str():
+                return self.as_map()[key]
+            case int():
+                return self.as_list()[key]
+            case slice():
+                return Document(self.as_list()[key], schema=self._schema)
+
+    def __setitem__(
+        self,
+        key: str | int,
+        value: "Document | list[Document] | dict[str, Document] | DocumentValue",
+    ) -> None:
+        if isinstance(key, str):
+            if not isinstance(value, Document):
+                schema = self._schema
+                if schema is not _DOCUMENT:
+                    schema = schema.members[key]
+                value = Document(value, schema=schema)
+            self.as_map()[key] = value
+        else:
+            if not isinstance(value, Document):
+                schema = self._schema
+                if schema is not _DOCUMENT:
+                    schema = schema.members["member"]
+                value = Document(value, schema=schema)
+            self.as_list()[key] = value
+        self._raw_value = None
+
+    def __delitem__(self, key: str | int) -> None:
+        if isinstance(key, str):
+            del self.as_map()[key]
+        else:
+            del self.as_list()[key]
+        self._raw_value = None
+
+    def __repr__(self) -> str:
+        value: str
+        if self._value is not None:
+            value = repr(self._value)
+        else:
+            value = repr(self._raw_value)
+
+        if self._schema is _DOCUMENT:
+            return f"Document(value={value})"
+        return f"Document(value={value}, schema={self._schema})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Document):
+            return False
+        # Note that the schema isn't important to equality. If some subclass, such as a
+        # JsonDocument, cares about the schema then it's responsible for transforming
+        # the output of `as_value` to the canonical form.
+        return self.as_value() == other.as_value()

--- a/python-packages/smithy-core/smithy_core/schemas.py
+++ b/python-packages/smithy-core/smithy_core/schemas.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
@@ -139,7 +140,7 @@ class Schema:
         id: ShapeID,
         type: ShapeType = ShapeType.STRUCTURE,
         traits: list["Trait"] | None = None,
-        members: dict[str, "MemberSchema"] | None = None,
+        members: Mapping[str, "MemberSchema"] | None = None,
     ) -> Self:
         """Create a schema for a collection shape.
 

--- a/python-packages/smithy-core/tests/unit/test_documents.py
+++ b/python-packages/smithy-core/tests/unit/test_documents.py
@@ -1,0 +1,447 @@
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from smithy_core.documents import Document, DocumentValue
+from smithy_core.exceptions import ExpectationNotMetException
+from smithy_core.schemas import Schema
+from smithy_core.shapes import ShapeID, ShapeType
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (True, ShapeType.BOOLEAN),
+        ("foo", ShapeType.STRING),
+        (1, ShapeType.LONG),
+        (1.1, ShapeType.DOUBLE),
+        (Decimal("1.1"), ShapeType.BIG_DECIMAL),
+        (b"foo", ShapeType.BLOB),
+        (datetime(2024, 5, 2), ShapeType.TIMESTAMP),
+        (["foo"], ShapeType.LIST),
+        ({"foo": "bar"}, ShapeType.DOCUMENT),
+        ([Document("foo")], ShapeType.LIST),
+        ({"foo": Document("bar")}, ShapeType.DOCUMENT),
+    ],
+)
+def test_type_inference(
+    value: DocumentValue | list[Document] | dict[str, Document],
+    expected: ShapeType,
+) -> None:
+    assert Document(value).type == expected
+
+
+def test_type_inherited_from_schema():
+    schema = Schema(id=ShapeID("smithy.api#Short"), type=ShapeType.SHORT)
+    assert Document(1, schema=schema).type == ShapeType.SHORT
+
+
+def test_as_blob() -> None:
+    assert Document(b"foo").as_blob() == b"foo"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo",
+        1,
+        1.1,
+        Decimal("1.1"),
+        False,
+        None,
+        datetime(2024, 5, 2),
+        [b"foo"],
+        {"foo": b"bar"},
+    ],
+)
+def test_as_blob_invalid(value: DocumentValue) -> None:
+    with pytest.raises(ExpectationNotMetException):
+        Document(value).as_blob()
+
+
+def test_as_boolean() -> None:
+    assert Document(True).as_boolean() is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo",
+        1,
+        1.1,
+        Decimal("1.1"),
+        b"foo",
+        None,
+        datetime(2024, 5, 2),
+        [b"foo"],
+        {"foo": b"bar"},
+    ],
+)
+def test_as_boolean_invalid(value: DocumentValue) -> None:
+    with pytest.raises(ExpectationNotMetException):
+        Document(value).as_boolean()
+
+
+def test_as_string() -> None:
+    assert Document("foo").as_string() == "foo"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"foo",
+        1,
+        1.1,
+        Decimal("1.1"),
+        False,
+        None,
+        datetime(2024, 5, 2),
+        [b"foo"],
+        {"foo": b"bar"},
+    ],
+)
+def test_as_string_invalid(value: DocumentValue) -> None:
+    with pytest.raises(ExpectationNotMetException):
+        Document(value).as_string()
+
+
+def test_as_timestamp() -> None:
+    assert Document(datetime(2024, 5, 2)).as_timestamp() == datetime(2024, 5, 2)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo",
+        1,
+        1.1,
+        Decimal("1.1"),
+        False,
+        None,
+        b"foo",
+        [b"foo"],
+        {"foo": b"bar"},
+    ],
+)
+def test_as_timestamp_invalid(value: DocumentValue) -> None:
+    with pytest.raises(ExpectationNotMetException):
+        Document(value).as_timestamp()
+
+
+def test_as_integer() -> None:
+    assert Document(1).as_integer() == 1
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo",
+        b"foo",
+        1.1,
+        Decimal("1.1"),
+        False,
+        None,
+        datetime(2024, 5, 2),
+        [b"foo"],
+        {"foo": b"bar"},
+    ],
+)
+def test_as_integer_invalid(value: DocumentValue) -> None:
+    with pytest.raises(ExpectationNotMetException):
+        Document(value).as_integer()
+
+
+def test_as_float() -> None:
+    assert Document(1.1).as_float() == 1.1
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo",
+        1,
+        b"foo",
+        Decimal("1.1"),
+        False,
+        None,
+        datetime(2024, 5, 2),
+        [b"foo"],
+        {"foo": b"bar"},
+    ],
+)
+def test_as_float_invalid(value: DocumentValue) -> None:
+    with pytest.raises(ExpectationNotMetException):
+        Document(value).as_float()
+
+
+def test_as_decimal() -> None:
+    assert Document(Decimal("1.1")).as_decimal() == Decimal("1.1")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo",
+        1,
+        1.1,
+        b"foo",
+        False,
+        None,
+        datetime(2024, 5, 2),
+        [b"foo"],
+        {"foo": b"bar"},
+    ],
+)
+def test_as_decimal_invalid(value: DocumentValue) -> None:
+    with pytest.raises(ExpectationNotMetException):
+        Document(value).as_decimal()
+
+
+def test_as_list() -> None:
+    assert Document(["foo"]).as_list() == [Document("foo")]
+    assert Document([Document("foo")]).as_list() == [Document("foo")]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo",
+        1,
+        1.1,
+        Decimal("1.1"),
+        False,
+        None,
+        datetime(2024, 5, 2),
+        b"foo",
+        {"foo": b"bar"},
+    ],
+)
+def test_as_list_invalid(value: DocumentValue) -> None:
+    with pytest.raises(ExpectationNotMetException):
+        Document(value).as_list()
+
+
+def test_as_map() -> None:
+    assert Document({"foo": "bar"}).as_map() == {"foo": Document("bar")}
+    assert Document({"foo": Document("bar")}).as_map() == {"foo": Document("bar")}
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo",
+        1,
+        1.1,
+        Decimal("1.1"),
+        False,
+        None,
+        datetime(2024, 5, 2),
+        [b"foo"],
+        b"foo",
+    ],
+)
+def test_as_map_invalid(value: DocumentValue) -> None:
+    with pytest.raises(ExpectationNotMetException):
+        Document(value).as_map()
+
+
+@pytest.mark.parametrize(
+    "value, raw_value",
+    [
+        ("foo", "foo"),
+        (1, 1),
+        (1.1, 1.1),
+        (Decimal("1.1"), Decimal("1.1")),
+        (True, True),
+        (None, None),
+        (b"foo", b"foo"),
+        (datetime(2024, 5, 2), datetime(2024, 5, 2)),
+        (["foo"], ["foo"]),
+        ([Document("foo")], ["foo"]),
+        ({"foo": "bar"}, {"foo": "bar"}),
+        ({"foo": Document("bar")}, {"foo": "bar"}),
+    ],
+)
+def test_as_value(
+    value: DocumentValue | dict[str, Document] | list[Document],
+    raw_value: DocumentValue,
+) -> None:
+    assert Document(value).as_value() == raw_value
+
+
+def test_get_from_map() -> None:
+    document = Document({"foo": "bar"})
+    assert document["foo"] == Document("bar")
+    with pytest.raises(KeyError):
+        document["baz"]
+
+    with pytest.raises(ExpectationNotMetException):
+        document[0]
+
+    assert document.get("foo") == Document("bar")
+    assert document.get("baz") is None
+    assert document.get("baz", Document("spam")) == Document("spam")
+
+
+def test_slice_map() -> None:
+    document = Document({"foo": "bar"})
+    assert document.as_value() == {"foo": "bar"}
+
+    with pytest.raises(ExpectationNotMetException):
+        document[1:]
+
+
+def test_get_from_list() -> None:
+    document = Document(["foo"])
+    assert document[0] == Document("foo")
+    with pytest.raises(IndexError):
+        document[1]
+
+    with pytest.raises(ExpectationNotMetException):
+        document["foo"]
+
+    with pytest.raises(ExpectationNotMetException):
+        document.get(1)  # type: ignore
+
+
+def test_slice_list() -> None:
+    document = Document(["foo", "bar", "baz"])
+    assert document.as_value() == ["foo", "bar", "baz"]
+
+    sliced = document[1:]
+    assert sliced.as_value() == ["bar", "baz"]
+
+
+def test_insert_into_map() -> None:
+    document = Document({"foo": "bar"})
+    assert document.as_value() == {"foo": "bar"}
+
+    document["spam"] = "eggs"
+    assert document["spam"] == Document("eggs")
+
+    document["eggs"] = Document("spam")
+    assert document["eggs"] == Document("spam")
+
+    assert document.as_value() == {
+        "foo": "bar",
+        "spam": "eggs",
+        "eggs": "spam",
+    }
+
+    with pytest.raises(ExpectationNotMetException):
+        document[0] = "foo"
+
+
+def test_insert_into_list() -> None:
+    document = Document(["foo", "bar", "baz"])
+    assert document.as_value() == ["foo", "bar", "baz"]
+
+    document[1] = "spam"
+    assert document[1] == Document("spam")
+
+    document[2] = Document("eggs")
+    assert document[2] == Document("eggs")
+
+    assert document.as_value() == ["foo", "spam", "eggs"]
+
+    with pytest.raises(ExpectationNotMetException):
+        document["foo"] = "bar"
+
+
+def test_del_from_map() -> None:
+    document = Document({"foo": "bar"})
+    assert document.as_value() == {"foo": "bar"}
+
+    del document["foo"]
+    assert document.get("foo") is None
+    assert document.as_value() == {}
+
+
+def test_del_from_list() -> None:
+    document = Document(["foo", "bar", "baz"])
+    assert document.as_value() == ["foo", "bar", "baz"]
+
+    del document[1]
+    assert document[1] == Document("baz")
+    assert document.as_value() == ["foo", "baz"]
+
+
+def test_wrap_list_passes_schema_to_member_documents() -> None:
+    id = ShapeID("smithy.example#List")
+    target_schema = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
+    expected = Schema(
+        id=id.with_member("member"),
+        type=ShapeType.MEMBER,
+        member_target=target_schema,
+        member_index=0,
+    )
+
+    list_schema = Schema.collection(
+        id=id,
+        type=ShapeType.LIST,
+        members={"member": {"target": target_schema}},
+    )
+    document = Document(["foo"], schema=list_schema)
+    actual = document[0]._schema  # pyright: ignore[reportPrivateUsage]
+    assert actual == expected
+
+
+def test_setitem_on_list_passes_schema_to_member_documents() -> None:
+    id = ShapeID("smithy.example#List")
+    target_schema = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
+    expected = Schema(
+        id=id.with_member("member"),
+        type=ShapeType.MEMBER,
+        member_target=target_schema,
+        member_index=0,
+    )
+
+    list_schema = Schema.collection(
+        id=id,
+        type=ShapeType.LIST,
+        members={"member": {"target": target_schema}},
+    )
+    document = Document(["foo"], schema=list_schema)
+    document[0] = "bar"
+    actual = document[0]._schema  # pyright: ignore[reportPrivateUsage]
+    assert actual == expected
+
+
+def test_wrap_map_passes_schema_to_member_documents() -> None:
+    id = ShapeID("smithy.example#Structure")
+    target_schema = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
+    expected = Schema(
+        id=id.with_member("stringMember"),
+        type=ShapeType.MEMBER,
+        member_target=target_schema,
+        member_index=0,
+    )
+
+    struct_schema = Schema.collection(
+        id=id,
+        members={"stringMember": {"target": target_schema}},
+    )
+    document = Document({"stringMember": "foo"}, schema=struct_schema)
+    actual = document["stringMember"]._schema  # pyright: ignore[reportPrivateUsage]
+    assert actual == expected
+
+
+def test_setitem_on_map_passes_schema_to_member_documents() -> None:
+    id = ShapeID("smithy.example#Structure")
+    target_schema = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
+    expected = Schema(
+        id=id.with_member("stringMember"),
+        type=ShapeType.MEMBER,
+        member_target=target_schema,
+        member_index=0,
+    )
+
+    struct_schema = Schema.collection(
+        id=id,
+        members={"stringMember": {"target": target_schema}},
+    )
+    document = Document({"stringMember": "foo"}, schema=struct_schema)
+    document["stringMember"] = "spam"
+    actual = document["stringMember"]._schema  # pyright: ignore[reportPrivateUsage]
+    assert actual == expected

--- a/python-packages/smithy-http/smithy_http/aio/restjson.py
+++ b/python-packages/smithy-http/smithy_http/aio/restjson.py
@@ -2,7 +2,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 import json
 
-from smithy_core.types import Document
+from smithy_core.documents import DocumentValue
 from smithy_core.utils import expect_type
 
 from ..restjson import _REST_JSON_CODE_HEADER  # pyright: ignore[reportPrivateUsage]
@@ -23,7 +23,7 @@ async def parse_rest_json_error_info(
     """
     code: str | None = None
     message: str | None = None
-    json_body: dict[str, Document] | None = None
+    json_body: dict[str, DocumentValue] | None = None
 
     for field in http_response.fields:
         if field.name.lower() == _REST_JSON_CODE_HEADER:

--- a/python-packages/smithy-http/smithy_http/restjson.py
+++ b/python-packages/smithy-http/smithy_http/restjson.py
@@ -2,7 +2,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 from typing import NamedTuple
 
-from smithy_core.types import Document
+from smithy_core.documents import DocumentValue
 
 _REST_JSON_CODE_HEADER = "x-amzn-errortype"
 
@@ -25,5 +25,5 @@ class RestJsonErrorInfo(NamedTuple):
     either didn't model the message or which are unknown.
     """
 
-    json_body: dict[str, Document] | None = None
+    json_body: dict[str, DocumentValue] | None = None
     """The HTTP response body parsed as JSON."""

--- a/python-packages/smithy-http/tests/unit/aio/test_restjson.py
+++ b/python-packages/smithy-http/tests/unit/aio/test_restjson.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator
 
 import pytest
 from smithy_core.aio.utils import async_list
-from smithy_core.types import Document
+from smithy_core.documents import DocumentValue
 
 from smithy_http import tuples_to_fields
 from smithy_http.aio import HTTPResponse
@@ -74,7 +74,7 @@ from smithy_http.restjson import RestJsonErrorInfo
     ],
 )
 async def test_parse_rest_json_error_info(
-    headers: list[tuple[str, str]], body: Document, expected: RestJsonErrorInfo
+    headers: list[tuple[str, str]], body: DocumentValue, expected: RestJsonErrorInfo
 ) -> None:
     response = HTTPResponse(
         status=400,


### PR DESCRIPTION
This updates the document type to split it into two parts. The first part is a generic JSON-like type which is expected to be fully protocol agnostic.

The second part is a wrapping type which will handle serialization and deserialization, including the possibility of subclasses handling protocol-specific handling of documents that have attached schemas. This will also be what is used for botocore compatibility.

The actual serialization and deserialization components aren't yet implemented, since the interfaces can only be defined once documents are present.

The new type has been integrated into the generated code, though for now the serializers just immediately call `as_value`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
