### PR TITLE
Use StrEnum for string enums

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
@@ -226,15 +226,7 @@ final class DirectedPythonCodegen implements DirectedCodegen<GenerationContext, 
         if (!directive.shape().isEnumShape()) {
             return;
         }
-        directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
-            EnumGenerator generator = new EnumGenerator(
-                    directive.model(),
-                    directive.symbolProvider(),
-                    writer,
-                    directive.shape().asEnumShape().get()
-            );
-            generator.run();
-        });
+        new EnumGenerator(directive.context(), directive.shape().asEnumShape().get()).run();
     }
 
     @Override


### PR DESCRIPTION
This updates generated classes for string enums to use the StrEnum base that was introduced in 3.11. Members of classes inheriting from StrEnum can be used as strings for most purposes. They do, however, have a repr and a type that is not compatible. Since we aren't actually using them in the type signature or returning them, these aren't important.

This doesn't majorly change the way customers engage with the generated class, though it does remove the need to generate a `values` method to list known values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
