### PR TITLE
Generate schemas

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SchemaGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SchemaGenerator.java
@@ -99,7 +99,6 @@ final class SchemaGenerator implements Consumer<Shape> {
 
     private void writeTraits(PythonWriter writer, Map<ShapeId, Node> traits) {
         writer.addImport("smithy_core.traits", "Trait");
-        writer.addImport("smithy_core.documents", "Document");
         writer.pushState();
         writer.putContext("traits", traits);
         writer.write("""

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SchemaGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SchemaGenerator.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.python.codegen;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.loader.Prelude;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.UnitTypeTrait;
+import software.amazon.smithy.model.traits.synthetic.SyntheticEnumTrait;
+import software.amazon.smithy.utils.CaseUtils;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Generates schemas for shapes.
+ *
+ * <p>Schemas are essentially a reduced, runtime-available model.
+ */
+@SmithyUnstableApi
+final class SchemaGenerator implements Consumer<Shape> {
+    private static final Logger LOGGER = Logger.getLogger(SchemaGenerator.class.getName());
+
+    // Filter out traits that already exist as generated parts of the class, such as documentation.
+    private static final Set<ShapeId> DEFAULT_TRAIT_FILTER = Set.of(
+            DocumentationTrait.ID, ErrorTrait.ID, EnumTrait.ID, SyntheticEnumTrait.ID
+    );
+
+    private static final Symbol UNIT_SYMBOL = Symbol.builder()
+            .name("UNIT")
+            .namespace("smithy_core.prelude", ".")
+            .addDependency(SmithyPythonDependency.SMITHY_CORE)
+            .build();
+
+    private final GenerationContext context;
+    private final Set<ShapeId> generatedShapes = new HashSet<>();
+    private final Set<MemberShape> deferredMembers = new HashSet<>();
+
+    SchemaGenerator(GenerationContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void accept(Shape shape) {
+        var symbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.SCHEMA).getSymbol();
+        context.writerDelegator().useFileWriter(
+                symbol.getDefinitionFile(), symbol.getNamespace(), writer -> writeShapeSchema(writer, shape));
+        generatedShapes.add(shape.getId());
+    }
+
+    private void writeShapeSchema(PythonWriter writer, Shape shape) {
+        writer.addImport("smithy_core.schemas", "Schema");
+        writer.addImports("smithy_core.shapes", Set.of("ShapeID", "ShapeType"));
+        writer.pushState();
+
+        var symbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.SCHEMA).getSymbol();
+
+        var traits = filterTraits(shape);
+        writer.putContext("isCollection", shape.isStructureShape() || !shape.members().isEmpty());
+        writer.putContext("isStructure", shape.isStructureShape());
+        writer.putContext("shapeType", CaseUtils.toSnakeCase(shape.getType().toString()).toUpperCase());
+        writer.putContext("hasTraits", !traits.isEmpty());
+
+        writer.write("""
+                $L = Schema${?isCollection}.collection${/isCollection}(
+                    id=ShapeID($S),
+                    ${^isStructure}type=ShapeType.${shapeType:L},${/isStructure}
+                    ${?hasTraits}
+                    traits=[
+                        ${C|}
+                    ],
+                    ${/hasTraits}
+                    ${C|}
+                )
+                """, symbol.getName(), shape.getId(),
+                writer.consumer(w -> writeTraits(w, traits)),
+                writer.consumer(w -> writeSchemaMembers(w, shape)));
+        writer.popState();
+    }
+
+    private Map<ShapeId, Node> filterTraits(Shape shape) {
+        return shape.getAllTraits().entrySet().stream()
+                .filter(t -> !DEFAULT_TRAIT_FILTER.contains(t.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toNode()));
+    }
+
+    private void writeTraits(PythonWriter writer, Map<ShapeId, Node> traits) {
+        writer.addImport("smithy_core.traits", "Trait");
+        writer.addImport("smithy_core.documents", "Document");
+        writer.pushState();
+        writer.putContext("traits", traits);
+        writer.write("""
+                ${#traits}
+                Trait(id=ShapeID(${key:S}), value=Document()),
+                ${/traits}""");
+        writer.popState();
+    }
+
+    private void writeSchemaMembers(PythonWriter writer, Shape shape) {
+        if (shape.members().isEmpty()) {
+            return;
+        }
+
+        writer.openBlock("members={", "}", () -> {
+            for (MemberShape member : shape.members()) {
+                if (!generatedShapes.contains(member.getTarget()) && !Prelude.isPreludeShape(member.getTarget())) {
+                    deferredMembers.add(member);
+                    continue;
+                }
+
+                writer.pushState();
+                var traits = filterTraits(member);
+                writer.putContext("hasTraits", !traits.isEmpty());
+
+                // For some reason the unit shape is being stripped from the model, despite the fact that
+                // it's referenced.
+                Symbol targetSchemaSymbol;
+                if (member.getTarget().equals(UnitTypeTrait.UNIT)) {
+                    targetSchemaSymbol = UNIT_SYMBOL;
+                } else {
+                    var targetSymbol = context.symbolProvider()
+                            .toSymbol(context.model().expectShape(member.getTarget()));
+                    targetSchemaSymbol = targetSymbol.expectProperty(SymbolProperties.SCHEMA).getSymbol();
+                }
+
+                writer.write("""
+                        $S: {
+                            "target": $T,
+                            ${?hasTraits}
+                            "traits": [
+                                ${C|}
+                            ],
+                            ${/hasTraits}
+                        },
+                        """, member.getMemberName(), targetSchemaSymbol,
+                        writer.consumer(w -> writeTraits(w, traits)));
+
+                writer.popState();
+            }
+        });
+    }
+
+    // Some shapes have members that refer to themselves, or members that refer to other
+    // shapes that then refer back to them. In typing we can get around that with forward
+    // references, but when generating schemas we need to instead defer creating those
+    // members until all schemas exist.
+    public void finalizeRecursiveShapes() {
+        var filename = String.format("%s/_private/schemas.py", context.settings().moduleName());
+        var namespace = String.format("%s._private.schemas", context.settings().moduleName());
+        context.writerDelegator().useFileWriter(filename, namespace, this::finalizeRecursiveShapes);
+    }
+
+    private void finalizeRecursiveShapes(PythonWriter writer) {
+        writer.addImport("smithy_core.schemas", "Schema");
+        writer.addImport("smithy_core.shapes", "ShapeType");
+
+        for (MemberShape member : deferredMembers) {
+            LOGGER.warning("Generating member: " + member.getId());
+            var container = context.symbolProvider()
+                    .toSymbol(context.model().expectShape(member.getContainer()))
+                    .expectProperty(SymbolProperties.SCHEMA)
+                    .getSymbol();
+            var target = context.symbolProvider()
+                    .toSymbol(context.model().expectShape(member.getTarget()))
+                    .expectProperty(SymbolProperties.SCHEMA)
+                    .getSymbol();
+
+            writer.pushState();
+            var traits = filterTraits(member);
+            writer.putContext("hasTraits", !traits.isEmpty());
+
+            writer.write("""
+                    $1T.members[$2S] = Schema(
+                        id=$1T.id.with_member($2S),
+                        type=ShapeType.MEMBER,
+                        member_target=$3T,
+                        member_index=len($1T.members) + 1,
+                        ${?hasTraits}
+                        traits=[
+                            ${4C|}
+                        ],
+                        ${/hasTraits}
+                    )
+
+                    """, container, member.getMemberName(), target,
+                    writer.consumer(w -> writeTraits(w, traits)));
+
+            writer.popState();
+        }
+
+        deferredMembers.clear();
+    }
+}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SchemaGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SchemaGenerator.java
@@ -104,7 +104,7 @@ final class SchemaGenerator implements Consumer<Shape> {
         writer.putContext("traits", traits);
         writer.write("""
                 ${#traits}
-                Trait(id=ShapeID(${key:S}), value=Document()),
+                Trait(id=ShapeID(${key:S}), value=${value:N}),
                 ${/traits}""");
         writer.popState();
     }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.python.codegen;
 import java.util.List;
 import software.amazon.smithy.codegen.core.Property;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -21,6 +22,14 @@ public final class SymbolProperties {
      * Contains the shape that the symbol represents.
      */
     public static final Property<Shape> SHAPE = Property.named("shape");
+
+    /**
+     * Contains a symbol reference pointing to the shape's schema symbol.
+     *
+     * <p>The referenced is aliased with a leading underscore so that the schema
+     * isn't re-exported.
+     */
+    public static final Property<SymbolReference> SCHEMA = Property.named("schema");
 
     /**
      * Contains a boolean representing whether the symbol represents a part of the Python standard library.

--- a/python-packages/smithy-core/smithy_core/prelude.py
+++ b/python-packages/smithy-core/smithy_core/prelude.py
@@ -2,7 +2,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Shared schemas for shapes built into Smithy's prelude."""
 
-from .documents import Document, DocumentValue
 from .schemas import Schema
 from .shapes import ShapeID, ShapeType
 from .traits import Trait
@@ -76,54 +75,50 @@ DOCUMENT = Schema(
 _DEFAULT = ShapeID("smithy.api#default")
 
 
-def _default(value: DocumentValue) -> Trait:
-    return Trait(id=_DEFAULT, value=Document(value))
-
-
 PRIMITIVE_BOOLEAN = Schema(
     id=ShapeID("smithy.api#PrimitiveBoolean"),
     type=ShapeType.BOOLEAN,
-    traits=[_default(False)],
+    traits=[Trait(id=_DEFAULT, value=False)],
 )
 
 PRIMITIVE_BYTE = Schema(
     id=ShapeID("smithy.api#PrimitiveByte"),
     type=ShapeType.BYTE,
-    traits=[_default(0)],
+    traits=[Trait(id=_DEFAULT, value=0)],
 )
 
 PRIMITIVE_SHORT = Schema(
     id=ShapeID("smithy.api#PrimitiveShort"),
     type=ShapeType.SHORT,
-    traits=[_default(0)],
+    traits=[Trait(id=_DEFAULT, value=0)],
 )
 
 PRIMITIVE_INTEGER = Schema(
     id=ShapeID("smithy.api#PrimitiveInteger"),
     type=ShapeType.INTEGER,
-    traits=[_default(0)],
+    traits=[Trait(id=_DEFAULT, value=0)],
 )
 
 PRIMITIVE_LONG = Schema(
     id=ShapeID("smithy.api#PrimitiveLong"),
     type=ShapeType.LONG,
-    traits=[_default(0)],
+    traits=[Trait(id=_DEFAULT, value=0)],
 )
 
 PRIMITIVE_FLOAT = Schema(
     id=ShapeID("smithy.api#PrimitiveFloat"),
     type=ShapeType.FLOAT,
-    traits=[_default(0.0)],
+    traits=[Trait(id=_DEFAULT, value=0.0)],
 )
 
 PRIMITIVE_DOUBLE = Schema(
     id=ShapeID("smithy.api#PrimitiveDouble"),
     type=ShapeType.DOUBLE,
-    traits=[_default(0.0)],
+    traits=[Trait(id=_DEFAULT, value=0.0)],
 )
 
 UNIT = Schema(
     id=ShapeID("smithy.api#Unit"),
     type=ShapeType.DOUBLE,
-    traits=[Trait(id=ShapeID("smithy.api#UnitTypeTrait"), value=Document({}))],
+    traits=[Trait(id=ShapeID("smithy.api#UnitTypeTrait"))],
 )

--- a/python-packages/smithy-core/smithy_core/prelude.py
+++ b/python-packages/smithy-core/smithy_core/prelude.py
@@ -1,0 +1,129 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+"""Shared schemas for shapes built into Smithy's prelude."""
+
+from .documents import Document, DocumentValue
+from .schemas import Schema
+from .shapes import ShapeID, ShapeType
+from .traits import Trait
+
+BLOB = Schema(
+    id=ShapeID("smithy.api#Blob"),
+    type=ShapeType.BLOB,
+)
+
+BOOLEAN = Schema(
+    id=ShapeID("smithy.api#Boolean"),
+    type=ShapeType.BOOLEAN,
+)
+
+STRING = Schema(
+    id=ShapeID("smithy.api#String"),
+    type=ShapeType.STRING,
+)
+
+TIMESTAMP = Schema(
+    id=ShapeID("smithy.api#Timestamp"),
+    type=ShapeType.TIMESTAMP,
+)
+
+BYTE = Schema(
+    id=ShapeID("smithy.api#Byte"),
+    type=ShapeType.BYTE,
+)
+
+SHORT = Schema(
+    id=ShapeID("smithy.api#Short"),
+    type=ShapeType.SHORT,
+)
+
+INTEGER = Schema(
+    id=ShapeID("smithy.api#Integer"),
+    type=ShapeType.INTEGER,
+)
+
+LONG = Schema(
+    id=ShapeID("smithy.api#Long"),
+    type=ShapeType.LONG,
+)
+
+FLOAT = Schema(
+    id=ShapeID("smithy.api#Float"),
+    type=ShapeType.FLOAT,
+)
+
+DOUBLE = Schema(
+    id=ShapeID("smithy.api#Double"),
+    type=ShapeType.DOUBLE,
+)
+
+BIG_INTEGER = Schema(
+    id=ShapeID("smithy.api#BigInteger"),
+    type=ShapeType.BIG_INTEGER,
+)
+
+BIG_DECIMAL = Schema(
+    id=ShapeID("smithy.api#BigDecimal"),
+    type=ShapeType.BIG_DECIMAL,
+)
+
+DOCUMENT = Schema(
+    id=ShapeID("smithy.api#Document"),
+    type=ShapeType.DOCUMENT,
+)
+
+
+_DEFAULT = ShapeID("smithy.api#default")
+
+
+def _default(value: DocumentValue) -> Trait:
+    return Trait(id=_DEFAULT, value=Document(value))
+
+
+PRIMITIVE_BOOLEAN = Schema(
+    id=ShapeID("smithy.api#PrimitiveBoolean"),
+    type=ShapeType.BOOLEAN,
+    traits=[_default(False)],
+)
+
+PRIMITIVE_BYTE = Schema(
+    id=ShapeID("smithy.api#PrimitiveByte"),
+    type=ShapeType.BYTE,
+    traits=[_default(0)],
+)
+
+PRIMITIVE_SHORT = Schema(
+    id=ShapeID("smithy.api#PrimitiveShort"),
+    type=ShapeType.SHORT,
+    traits=[_default(0)],
+)
+
+PRIMITIVE_INTEGER = Schema(
+    id=ShapeID("smithy.api#PrimitiveInteger"),
+    type=ShapeType.INTEGER,
+    traits=[_default(0)],
+)
+
+PRIMITIVE_LONG = Schema(
+    id=ShapeID("smithy.api#PrimitiveLong"),
+    type=ShapeType.LONG,
+    traits=[_default(0)],
+)
+
+PRIMITIVE_FLOAT = Schema(
+    id=ShapeID("smithy.api#PrimitiveFloat"),
+    type=ShapeType.FLOAT,
+    traits=[_default(0.0)],
+)
+
+PRIMITIVE_DOUBLE = Schema(
+    id=ShapeID("smithy.api#PrimitiveDouble"),
+    type=ShapeType.DOUBLE,
+    traits=[_default(0.0)],
+)
+
+UNIT = Schema(
+    id=ShapeID("smithy.api#Unit"),
+    type=ShapeType.DOUBLE,
+    traits=[Trait(id=ShapeID("smithy.api#UnitTypeTrait"), value=Document({}))],
+)

--- a/python-packages/smithy-core/smithy_core/schemas.py
+++ b/python-packages/smithy-core/smithy_core/schemas.py
@@ -1,14 +1,6 @@
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import (
-    TYPE_CHECKING,
-    NotRequired,
-    Protocol,
-    Required,
-    Self,
-    TypedDict,
-    runtime_checkable,
-)
+from typing import TYPE_CHECKING, NotRequired, Required, Self, TypedDict
 
 from .exceptions import ExpectationNotMetException, SmithyException
 from .shapes import ShapeID, ShapeType
@@ -25,7 +17,7 @@ class Schema:
     type: ShapeType
     traits: dict[ShapeID, "Trait"] = field(default_factory=dict)
     members: dict[str, "Schema"] = field(default_factory=dict)
-    member_target: "Schema | HasSchema | None" = None
+    member_target: "Schema | None" = None
     member_index: int | None = None
 
     def __init__(
@@ -35,7 +27,7 @@ class Schema:
         type: ShapeType,
         traits: list["Trait"] | dict[ShapeID, "Trait"] | None = None,
         members: list["Schema"] | dict[str, "Schema"] | None = None,
-        member_target: "Schema | HasSchema | None" = None,
+        member_target: "Schema | None" = None,
         member_index: int | None = None,
     ) -> None:
         """Initialize a schema.
@@ -111,15 +103,11 @@ class Schema:
         :raises ExpectationNotMetException: If member_target wasn't set.
         :returns: Returns the target schema.
         """
-        match self.member_target:
-            case None:
-                raise ExpectationNotMetException(
-                    "Expected member_target to be set, but was None."
-                )
-            case HasSchema():
-                return self.member_target.SCHEMA
-            case _:
-                return self.member_target
+        if self.member_target is None:
+            raise ExpectationNotMetException(
+                "Expected member_target to be set, but was None."
+            )
+        return self.member_target
 
     def expect_member_index(self) -> int:
         """Assert the schema is a member schema and return its member index.
@@ -181,15 +169,5 @@ class MemberSchema(TypedDict):
     :param traits: An optional list of traits for the member.
     """
 
-    target: Required["Schema | HasSchema"]
+    target: Required[Schema]
     traits: NotRequired[list["Trait"]]
-
-
-@runtime_checkable
-class HasSchema(Protocol):
-    """Protocol for classes that contain schemas.
-
-    Generated classes will contain these schemas.
-    """
-
-    SCHEMA: Schema

--- a/python-packages/smithy-core/smithy_core/traits.py
+++ b/python-packages/smithy-core/smithy_core/traits.py
@@ -1,9 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from .documents import DocumentValue
     from .shapes import ShapeID
-    from .types import Document
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -16,4 +16,4 @@ class Trait:
     """
 
     id: "ShapeID"
-    value: "Document"
+    value: "DocumentValue" = field(default_factory=dict)

--- a/python-packages/smithy-http/tests/unit/test_schemas.py
+++ b/python-packages/smithy-http/tests/unit/test_schemas.py
@@ -1,5 +1,4 @@
 import pytest
-from smithy_core.documents import Document
 from smithy_core.exceptions import ExpectationNotMetException
 from smithy_core.schemas import Schema
 from smithy_core.shapes import ShapeID, ShapeType
@@ -11,7 +10,7 @@ STRING = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
 
 def test_traits_list():
     trait_id = ShapeID("smithy.api#internal")
-    trait = Trait(id=trait_id, value=Document(True))
+    trait = Trait(id=trait_id, value=True)
     schema = Schema(id=ID, type=ShapeType.STRUCTURE, traits=[trait])
     assert schema.traits == {trait_id: trait}
 

--- a/python-packages/smithy-http/tests/unit/test_schemas.py
+++ b/python-packages/smithy-http/tests/unit/test_schemas.py
@@ -1,8 +1,7 @@
-from typing import Final
-
 import pytest
+from smithy_core.documents import Document
 from smithy_core.exceptions import ExpectationNotMetException
-from smithy_core.schemas import HasSchema, Schema
+from smithy_core.schemas import Schema
 from smithy_core.shapes import ShapeID, ShapeType
 from smithy_core.traits import Trait
 
@@ -12,7 +11,7 @@ STRING = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
 
 def test_traits_list():
     trait_id = ShapeID("smithy.api#internal")
-    trait = Trait(id=trait_id, value=True)
+    trait = Trait(id=trait_id, value=Document(True))
     schema = Schema(id=ID, type=ShapeType.STRUCTURE, traits=[trait])
     assert schema.traits == {trait_id: trait}
 
@@ -67,11 +66,3 @@ def test_collection_constructor():
     )
     schema = Schema.collection(id=ID, members={member_name: {"target": STRING}})
     assert schema.members == {member_name: member}
-
-
-class TestSchemaBearer:
-    SCHEMA: Final[Schema] = Schema.collection(id=ID)
-
-
-def test_has_schema():
-    assert isinstance(TestSchemaBearer, HasSchema)


### PR DESCRIPTION
This adds generation for schemas.

Shapes in the prelude have static definitions which can be found in `prelude.py`, these also work to show what these definitions look like.

Other shapes connected to the service have their schemas generated into a single file in `_private/schemas.py`. I had initially played around with generating schemas onto shapes where possible (i.e. as properties on structure shapes), but it added needless complexity and made their code harder to follow.

The schemas are under `_private` because we don't want to encourage people to look at them outside of scope of the forthcoming serialization methods.

`Trait` was updated to have a default value and to just use `DocumentValue` to save on code size.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
