### PR TITLE
Add serailizer interfaces and document implementations of them

### DIFF
--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -244,7 +244,7 @@ class Document:
         :param shape: The shape to convert to a document.
         :returns: A Document representation of the given shape.
         """
-        serializer = DocumentSerializer()
+        serializer = _DocumentSerializer()
         shape.serialize(serializer=serializer)
         serializer.flush()
         return serializer.expect_result()
@@ -312,7 +312,7 @@ class Document:
         return self.as_value() == other.as_value()
 
 
-class DocumentSerializer(ShapeSerializer):
+class _DocumentSerializer(ShapeSerializer):
     """Serializes shapes into document representations."""
 
     result: Document | None = None
@@ -396,7 +396,7 @@ class DocumentSerializer(ShapeSerializer):
 
 
 class _DocumentStructSerializer(InterceptingSerializer):
-    _delegate = DocumentSerializer()
+    _delegate = _DocumentSerializer()
     _result: Document
 
     def __init__(self, schema: "Schema") -> None:
@@ -415,7 +415,7 @@ class _DocumentStructSerializer(InterceptingSerializer):
 
 
 class _DocumentListSerializer(InterceptingSerializer):
-    _delegate = DocumentSerializer()
+    _delegate = _DocumentSerializer()
     _result: list[Document]
     _schema: "Schema"
 
@@ -436,7 +436,7 @@ class _DocumentListSerializer(InterceptingSerializer):
 
 
 class _DocumentMapSerializer(MapSerializer):
-    _delegate = DocumentSerializer()
+    _delegate = _DocumentSerializer()
     _result: Document
 
     def __init__(self, schema: "Schema") -> None:

--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -441,5 +441,6 @@ class _DocumentMapSerializer(MapSerializer):
         return self._result
 
     def entry(self, key: str, value_writer: Callable[[ShapeSerializer], None]):
-        self._result[key] = value_writer(self._delegate)
+        value_writer(self._delegate)
+        self._result[key] = self._delegate.expect_result()
         self._delegate.result = None

--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -195,7 +195,7 @@ class Document:
 
     def _wrap_list(self, value: Sequence[DocumentValue]) -> list["Document"]:
         schema = self._schema
-        if schema.type == ShapeType.LIST:
+        if schema.type is ShapeType.LIST:
             schema = self._schema.members["member"].expect_member_target()
         return [Document(e, schema=schema) for e in value]
 
@@ -279,7 +279,7 @@ class Document:
         else:
             if not isinstance(value, Document):
                 schema = self._schema
-                if schema.type == ShapeType.LIST:
+                if schema.type is ShapeType.LIST:
                     schema = schema.members["member"].expect_member_target()
                 value = Document(value, schema=schema)
             self.as_list()[key] = value

--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -331,7 +331,9 @@ class DocumentSerializer(ShapeSerializer):
         delegate = _DocumentStructSerializer(schema)
         try:
             yield delegate
-        finally:
+        except Exception:
+            raise
+        else:
             self.result = delegate.result
 
     @override
@@ -340,7 +342,9 @@ class DocumentSerializer(ShapeSerializer):
         delegate = _DocumentListSerializer(schema)
         try:
             yield delegate
-        finally:
+        except Exception:
+            raise
+        else:
             self.result = delegate.result
 
     @override
@@ -349,7 +353,9 @@ class DocumentSerializer(ShapeSerializer):
         delegate = _DocumentMapSerializer(schema)
         try:
             yield delegate
-        finally:
+        except Exception:
+            raise
+        else:
             self.result = delegate.result
 
     @override

--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -126,7 +126,7 @@ class Document:
         )
 
     @property
-    def type(self) -> ShapeType:
+    def shape_type(self) -> ShapeType:
         """The Smithy data model type for the underlying contents of the document."""
         return self._type
 

--- a/python-packages/smithy-core/smithy_core/serializers.py
+++ b/python-packages/smithy-core/smithy_core/serializers.py
@@ -1,0 +1,335 @@
+import datetime
+from abc import ABCMeta, abstractmethod
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
+from decimal import Decimal
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .documents import Document
+    from .schemas import Schema
+
+
+@runtime_checkable
+class ShapeSerializer(Protocol):
+    """Protocol for serializing shapes based on the Smithy data model.
+
+    If used as a base class, all non-float number methods default to calling
+    ``write_integer`` and ``write_double`` defaults to calling ``write_float``.
+    These extra numeric methods are for types in the Smithy data model that
+    don't have Python equivalents, but may have equivalents in the format
+    being written.
+    """
+
+    def begin_struct(
+        self, schema: "Schema"
+    ) -> AbstractContextManager["ShapeSerializer"]:
+        """Open a structure for writing.
+
+        The returned context manager is responsible for closing the structure when the
+        caller has finished writing members.
+
+        The shape serializer contained in the context manager is responsible for writing
+        out the member name as well as any additional data needed between the member
+        name and value and between members.
+
+        :param schema: The schema of the structure.
+        :returns: A context manager containing a member serializer.
+        """
+        ...
+
+    def write_struct(self, schema: "Schema", struct: "SerializeableStruct") -> None:
+        """Write a structured shape to the output.
+
+        This method is primarily intended to be used to serialize members that target
+        structure or union shapes.
+
+        :param schema: The member schema of the structure.
+        :param struct: The structure to serialize.
+        """
+        with self.begin_struct(schema=schema) as struct_serializer:
+            struct.serialize_members(struct_serializer)
+
+    def begin_list(self, schema: "Schema") -> AbstractContextManager["ShapeSerializer"]:
+        """Open a list for writing.
+
+        The returned context manager is responsible for closing the list when the caller
+        has finished writing elements.
+
+        The shape serializer contained in the context manager is responsible for
+        inserting any data needed between elements.
+
+        :param schema: The schema of the list.
+        :returns: A context manager containing an element serializer.
+        """
+        ...
+
+    def begin_map(self, schema: "Schema") -> AbstractContextManager["MapSerializer"]:
+        """Open a map for writing.
+
+        The returned context manager is responsible for closing the map when the caller
+        has finished writing members.
+
+        The MapSerializer contained in the context manager is responsible for writing
+        out any additional data needed between the entry name and value as well as any
+        data needed between entries.
+
+        :param schema: The schema of the map.
+        :returns: A context manager containing a map serializer.
+        """
+        ...
+
+    def write_null(self, schema: "Schema") -> None:
+        """Write a null value to the output.
+
+        :param schema: The shape's schema.
+        """
+        ...
+
+    def write_boolean(self, schema: "Schema", value: bool) -> None:
+        """Write a boolean value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The boolean value to write.
+        """
+        ...
+
+    def write_byte(self, schema: "Schema", value: int) -> None:
+        """Write a byte (8-bit integer) value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The byte value to write.
+        """
+        self.write_integer(schema, value)
+
+    def write_short(self, schema: "Schema", value: int) -> None:
+        """Write a short (16-bit integer) value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The short value to write.
+        """
+        self.write_integer(schema, value)
+
+    def write_integer(self, schema: "Schema", value: int) -> None:
+        """Write an integer (32-bit) value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The integer value to write.
+        """
+        ...
+
+    def write_long(self, schema: "Schema", value: int) -> None:
+        """Write a long (64-bit integer) value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The long value to write.
+        """
+        self.write_integer(schema, value)
+
+    def write_float(self, schema: "Schema", value: float) -> None:
+        """Write a float (32-bit) value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The float value to write.
+        """
+        ...
+
+    def write_double(self, schema: "Schema", value: float) -> None:
+        """Write a double (64-bit float) value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The double value to write.
+        """
+        self.write_float(schema, value)
+
+    def write_big_integer(self, schema: "Schema", value: int) -> None:
+        """Write a big integer (arbirtrarily large integer) value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The big integer value to write.
+        """
+        self.write_integer(schema, value)
+
+    def write_big_decimal(self, schema: "Schema", value: Decimal) -> None:
+        """Write a big decimal (arbitrarily large float) value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The big decimal value to write.
+        """
+        ...
+
+    def write_string(self, schema: "Schema", value: str) -> None:
+        """Write a string value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The string value to write.
+        """
+        ...
+
+    def write_blob(self, schema: "Schema", value: bytes) -> None:
+        """Write a blob value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The blob value to write.
+        """
+        ...
+
+    def write_timestamp(self, schema: "Schema", value: datetime.datetime) -> None:
+        """Write a timestamp value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The timestamp value to write.
+        """
+        ...
+
+    def write_document(self, schema: "Schema", value: "Document") -> None:
+        """Write a document value to the output.
+
+        :param schema: The shape's schema.
+        :param value: The document value to write.
+        """
+        ...
+
+    def flush(self) -> None:
+        """Flush the underlying data."""
+
+
+@runtime_checkable
+class MapSerializer(Protocol):
+    """Protocol for serializing maps.
+
+    These are responsible for writing any data needed between keys and values as well as
+    any data needed between entries.
+    """
+
+    def entry(self, key: str, value_writer: Callable[[ShapeSerializer], None]):
+        """Write a map entry.
+
+        :param key: The entry's key.
+        :param value_writer: A callable that accepts a shape serializer to write values.
+        """
+        ...
+
+
+class InterceptingSerializer(ShapeSerializer, metaclass=ABCMeta):
+    """A shape serializer capable of injecting data before writing.
+
+    This can, for example, be used to add in structure member keys, commas between
+    structure members, or commas between lists.
+    """
+
+    @abstractmethod
+    def before(self, schema: "Schema") -> ShapeSerializer: ...
+
+    @abstractmethod
+    def after(self, schema: "Schema") -> None: ...
+
+    @contextmanager
+    def begin_struct(self, schema: "Schema") -> Iterator[ShapeSerializer]:
+        delegate = self.before(schema)
+
+        try:
+            with delegate.begin_struct(schema) as s:
+                yield s
+        finally:
+            self.after(schema)
+
+    @contextmanager
+    def begin_list(self, schema: "Schema") -> Iterator[ShapeSerializer]:
+        delegate = self.before(schema)
+
+        try:
+            with delegate.begin_list(schema) as s:
+                yield s
+        finally:
+            self.after(schema)
+
+    @contextmanager
+    def begin_map(self, schema: "Schema") -> Iterator[MapSerializer]:
+        delegate = self.before(schema)
+
+        try:
+            with delegate.begin_map(schema) as s:
+                yield s
+        finally:
+            self.after(schema)
+
+    def write_null(self, schema: "Schema") -> None:
+        self.before(schema).write_null(schema)
+        self.after(schema)
+
+    def write_boolean(self, schema: "Schema", value: bool) -> None:
+        self.before(schema).write_boolean(schema, value)
+        self.after(schema)
+
+    def write_byte(self, schema: "Schema", value: int) -> None:
+        self.before(schema).write_byte(schema, value)
+        self.after(schema)
+
+    def write_short(self, schema: "Schema", value: int) -> None:
+        self.before(schema).write_short(schema, value)
+        self.after(schema)
+
+    def write_integer(self, schema: "Schema", value: int) -> None:
+        self.before(schema).write_integer(schema, value)
+        self.after(schema)
+
+    def write_long(self, schema: "Schema", value: int) -> None:
+        self.before(schema).write_long(schema, value)
+        self.after(schema)
+
+    def write_float(self, schema: "Schema", value: float) -> None:
+        self.before(schema).write_float(schema, value)
+        self.after(schema)
+
+    def write_double(self, schema: "Schema", value: float) -> None:
+        self.before(schema).write_double(schema, value)
+        self.after(schema)
+
+    def write_big_integer(self, schema: "Schema", value: int) -> None:
+        self.before(schema).write_big_integer(schema, value)
+        self.after(schema)
+
+    def write_big_decimal(self, schema: "Schema", value: Decimal) -> None:
+        self.before(schema).write_big_decimal(schema, value)
+        self.after(schema)
+
+    def write_string(self, schema: "Schema", value: str) -> None:
+        self.before(schema).write_string(schema, value)
+        self.after(schema)
+
+    def write_blob(self, schema: "Schema", value: bytes) -> None:
+        self.before(schema).write_blob(schema, value)
+        self.after(schema)
+
+    def write_timestamp(self, schema: "Schema", value: datetime.datetime) -> None:
+        self.before(schema).write_timestamp(schema, value)
+        self.after(schema)
+
+    def write_document(self, schema: "Schema", value: "Document") -> None:
+        self.before(schema).write_document(schema, value)
+        self.after(schema)
+
+
+@runtime_checkable
+class SerializeableShape(Protocol):
+    """Protocol for shapes that are serializeable using a ShapeSerializer."""
+
+    def serialize(self, serializer: ShapeSerializer) -> None:
+        """Serialize the shape using the given serializer.
+
+        :param serializer: The serializer to write shape data to.
+        """
+        ...
+
+
+@runtime_checkable
+class SerializeableStruct(SerializeableShape, Protocol):
+    """Protocol for structures that are serializeable using a ShapeSerializer."""
+
+    def serialize_members(self, serializer: ShapeSerializer) -> None:
+        """Serialize structure members using the given serializer.
+
+        :param serializer: The serializer to write member data to.
+        """
+        ...

--- a/python-packages/smithy-core/smithy_core/serializers.py
+++ b/python-packages/smithy-core/smithy_core/serializers.py
@@ -231,7 +231,9 @@ class InterceptingSerializer(ShapeSerializer, metaclass=ABCMeta):
         try:
             with delegate.begin_struct(schema) as s:
                 yield s
-        finally:
+        except Exception:
+            raise
+        else:
             self.after(schema)
 
     @contextmanager
@@ -241,7 +243,9 @@ class InterceptingSerializer(ShapeSerializer, metaclass=ABCMeta):
         try:
             with delegate.begin_list(schema) as s:
                 yield s
-        finally:
+        except Exception:
+            raise
+        else:
             self.after(schema)
 
     @contextmanager
@@ -251,7 +255,9 @@ class InterceptingSerializer(ShapeSerializer, metaclass=ABCMeta):
         try:
             with delegate.begin_map(schema) as s:
                 yield s
-        finally:
+        except Exception:
+            raise
+        else:
             self.after(schema)
 
     def write_null(self, schema: "Schema") -> None:

--- a/python-packages/smithy-core/tests/unit/test_documents.py
+++ b/python-packages/smithy-core/tests/unit/test_documents.py
@@ -5,6 +5,7 @@ import pytest
 
 from smithy_core.documents import Document, DocumentValue
 from smithy_core.exceptions import ExpectationNotMetException
+from smithy_core.prelude import STRING
 from smithy_core.schemas import Schema
 from smithy_core.shapes import ShapeID, ShapeType
 
@@ -370,13 +371,6 @@ def test_del_from_list() -> None:
 def test_wrap_list_passes_schema_to_member_documents() -> None:
     id = ShapeID("smithy.example#List")
     target_schema = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
-    expected = Schema(
-        id=id.with_member("member"),
-        type=ShapeType.MEMBER,
-        member_target=target_schema,
-        member_index=0,
-    )
-
     list_schema = Schema.collection(
         id=id,
         type=ShapeType.LIST,
@@ -384,19 +378,12 @@ def test_wrap_list_passes_schema_to_member_documents() -> None:
     )
     document = Document(["foo"], schema=list_schema)
     actual = document[0]._schema  # pyright: ignore[reportPrivateUsage]
-    assert actual == expected
+    assert actual == target_schema
 
 
 def test_setitem_on_list_passes_schema_to_member_documents() -> None:
     id = ShapeID("smithy.example#List")
     target_schema = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
-    expected = Schema(
-        id=id.with_member("member"),
-        type=ShapeType.MEMBER,
-        member_target=target_schema,
-        member_index=0,
-    )
-
     list_schema = Schema.collection(
         id=id,
         type=ShapeType.LIST,
@@ -405,38 +392,24 @@ def test_setitem_on_list_passes_schema_to_member_documents() -> None:
     document = Document(["foo"], schema=list_schema)
     document[0] = "bar"
     actual = document[0]._schema  # pyright: ignore[reportPrivateUsage]
-    assert actual == expected
+    assert actual == target_schema
 
 
-def test_wrap_map_passes_schema_to_member_documents() -> None:
+def test_wrap_structure_passes_schema_to_member_documents() -> None:
     id = ShapeID("smithy.example#Structure")
     target_schema = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
-    expected = Schema(
-        id=id.with_member("stringMember"),
-        type=ShapeType.MEMBER,
-        member_target=target_schema,
-        member_index=0,
-    )
-
     struct_schema = Schema.collection(
         id=id,
         members={"stringMember": {"target": target_schema}},
     )
     document = Document({"stringMember": "foo"}, schema=struct_schema)
     actual = document["stringMember"]._schema  # pyright: ignore[reportPrivateUsage]
-    assert actual == expected
+    assert actual == target_schema
 
 
-def test_setitem_on_map_passes_schema_to_member_documents() -> None:
+def test_setitem_on_structure_passes_schema_to_member_documents() -> None:
     id = ShapeID("smithy.example#Structure")
     target_schema = Schema(id=ShapeID("smithy.api#String"), type=ShapeType.STRING)
-    expected = Schema(
-        id=id.with_member("stringMember"),
-        type=ShapeType.MEMBER,
-        member_target=target_schema,
-        member_index=0,
-    )
-
     struct_schema = Schema.collection(
         id=id,
         members={"stringMember": {"target": target_schema}},
@@ -444,4 +417,35 @@ def test_setitem_on_map_passes_schema_to_member_documents() -> None:
     document = Document({"stringMember": "foo"}, schema=struct_schema)
     document["stringMember"] = "spam"
     actual = document["stringMember"]._schema  # pyright: ignore[reportPrivateUsage]
-    assert actual == expected
+    assert actual == target_schema
+
+
+def test_wrap_map_passes_schema_to_member_documents() -> None:
+    id = ShapeID("smithy.example#Map")
+    map_schema = Schema.collection(
+        id=id,
+        type=ShapeType.MAP,
+        members={
+            "key": {"target": STRING},
+            "value": {"target": STRING},
+        },
+    )
+    document = Document({"spam": "eggs"}, schema=map_schema)
+    actual = document["spam"]._schema  # pyright: ignore[reportPrivateUsage]
+    assert actual == STRING
+
+
+def test_setitem_on_map_passes_schema_to_member_documents() -> None:
+    id = ShapeID("smithy.example#Map")
+    map_schema = Schema.collection(
+        id=id,
+        type=ShapeType.MAP,
+        members={
+            "key": {"target": STRING},
+            "value": {"target": STRING},
+        },
+    )
+    document = Document({"spam": "eggs"}, schema=map_schema)
+    document["spam"] = "eggsandspam"
+    actual = document["spam"]._schema  # pyright: ignore[reportPrivateUsage]
+    assert actual == STRING

--- a/python-packages/smithy-core/tests/unit/test_documents.py
+++ b/python-packages/smithy-core/tests/unit/test_documents.py
@@ -1,3 +1,4 @@
+# pyright: reportPrivateUsage=false
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -5,7 +6,7 @@ from typing import Any, cast
 
 import pytest
 
-from smithy_core.documents import Document, DocumentSerializer, DocumentValue
+from smithy_core.documents import Document, DocumentValue, _DocumentSerializer
 from smithy_core.exceptions import ExpectationNotMetException
 from smithy_core.prelude import (
     BIG_DECIMAL,
@@ -659,7 +660,7 @@ DOCUMENT_SERDE_CASES = [
 
 @pytest.mark.parametrize("given, expected", DOCUMENT_SERDE_CASES)
 def test_document_serializer(given: Any, expected: Document):
-    serializer = DocumentSerializer()
+    serializer = _DocumentSerializer()
     match given:
         case bool():
             serializer.write_boolean(BOOLEAN, given)

--- a/python-packages/smithy-core/tests/unit/test_documents.py
+++ b/python-packages/smithy-core/tests/unit/test_documents.py
@@ -29,12 +29,12 @@ def test_type_inference(
     value: DocumentValue | list[Document] | dict[str, Document],
     expected: ShapeType,
 ) -> None:
-    assert Document(value).type == expected
+    assert Document(value).shape_type == expected
 
 
 def test_type_inherited_from_schema():
     schema = Schema(id=ShapeID("smithy.api#Short"), type=ShapeType.SHORT)
-    assert Document(1, schema=schema).type == ShapeType.SHORT
+    assert Document(1, schema=schema).shape_type == ShapeType.SHORT
 
 
 def test_as_blob() -> None:


### PR DESCRIPTION
This adds interfaces for shape serializers, and implementations of those serializers for documents. It also fixes a pair of bugs in Document that were uncovered while working on tests.

Serializing in this way instead of generating serializers gives as a few major benefits:

* Protocols will be able to be changed at runtime
* Protocols will be implemented entirely in Python, making them easier to understand, modify, and write for external users.
* The amount of generated code is dramatically reduced. On average, package size will also be significantly reduced. The generated code for schemas is about half the size of the generated code for serializers. All the library code to implement protocols is of course added on top, but those will be shared between services, so the more services a customer uses, the more they'll benefit from this setup.


A follow-up PR will add deserialization support along similar principles.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
