### PR TITLE
Add deserializer interfaces and document implementation of them

### DIFF
--- a/python-packages/smithy-core/smithy_core/deserializers.py
+++ b/python-packages/smithy-core/smithy_core/deserializers.py
@@ -1,0 +1,180 @@
+import datetime
+from collections.abc import Callable
+from decimal import Decimal
+from typing import TYPE_CHECKING, Protocol, Self, runtime_checkable
+
+if TYPE_CHECKING:
+    from .documents import Document
+    from .schemas import Schema
+
+
+@runtime_checkable
+class ShapeDeserializer(Protocol):
+    """Protocol used for deserializing shapes based on the Smithy data model.
+
+    If used as a base class, all non-float number methods default to calling
+    ``read_integer`` and ``read_double`` defaults to calling ``read_float``.
+    These extra numeric methods are for types in the Smithy data model that
+    don't have Python equivalents, but may have equivalents in the format
+    being read.
+    """
+
+    def read_struct(
+        self,
+        schema: "Schema",
+        consumer: Callable[["Schema", "ShapeDeserializer"], None],
+    ) -> None:
+        """Read a struct value from the underlying data.
+
+        :param schema: The shape's schema.
+        :param consumer: A callable to read struct members with.
+        """
+        ...
+
+    def read_list(
+        self, schema: "Schema", consumer: Callable[["ShapeDeserializer"], None]
+    ) -> None:
+        """Read a list value from the underlying data.
+
+        :param schema: The shape's schema.
+        :param consumer: A callable to read list elements with.
+        """
+        ...
+
+    def read_map(
+        self,
+        schema: "Schema",
+        consumer: Callable[[str, "ShapeDeserializer"], None],
+    ) -> None:
+        """Read a map value from the underlying data.
+
+        :param schema: The shape's schema.
+        :param consumer: A callable to read map values with.
+        """
+        ...
+
+    def read_null(self, schema: "Schema") -> None:
+        """Read a null value from the underlying data.
+
+        :param schema: The shape's schema.
+        """
+        ...
+
+    def read_boolean(self, schema: "Schema") -> bool:
+        """Read a boolean value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A bool from the underlying data.
+        """
+        ...
+
+    def read_blob(self, schema: "Schema") -> bytes:
+        """Read a blob value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A blob from the underlying data.
+        """
+        ...
+
+    def read_byte(self, schema: "Schema") -> int:
+        """Read a byte (8-bit integer) value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A byte from the underlying data.
+        """
+        return self.read_integer(schema)
+
+    def read_short(self, schema: "Schema") -> int:
+        """Read a short (16-bit integer) value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A short from the underlying data.
+        """
+        return self.read_integer(schema)
+
+    def read_integer(self, schema: "Schema") -> int:
+        """Read an integer (32-bit) value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: An integer from the underlying data.
+        """
+        ...
+
+    def read_long(self, schema: "Schema") -> int:
+        """Read a long (64-bit integer) value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A long from the underlying data.
+        """
+        return self.read_integer(schema)
+
+    def read_float(self, schema: "Schema") -> float:
+        """Read a float (32-bit) value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A float from the underlying data.
+        """
+        ...
+
+    def read_double(self, schema: "Schema") -> float:
+        """Read a double (64-bit float) value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A double from the underlying data.
+        """
+        return self.read_double(schema)
+
+    def read_big_integer(self, schema: "Schema") -> int:
+        """Read a big integer (arbitrarily large integer) value from the underlying
+        data.
+
+        :param schema: The shape's schema.
+        :returns: A big integer from the underlying data.
+        """
+        return self.read_integer(schema)
+
+    def read_big_decimal(self, schema: "Schema") -> Decimal:
+        """Read a big decimal (arbitrarily large float) value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A big decimal from the underlying data.
+        """
+        ...
+
+    def read_string(self, schema: "Schema") -> str:
+        """Read a string value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A string from the underlying data.
+        """
+        ...
+
+    def read_document(self, schema: "Schema") -> "Document":
+        """Read a document value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A document from the underlying data.
+        """
+        ...
+
+    def read_timestamp(self, schema: "Schema") -> datetime.datetime:
+        """Read a timestamp value from the underlying data.
+
+        :param schema: The shape's schema.
+        :returns: A timestamp from the underlying data.
+        """
+        ...
+
+
+@runtime_checkable
+class DeserializeableShape(Protocol):
+    """Protocol for shapes that are deserializeable using a ShapeDeserializer."""
+
+    @classmethod
+    def deserialize(cls, deserializer: ShapeDeserializer) -> Self:
+        """Construct an instance of this class using the given deserializer.
+
+        :param deserializer: The deserializer to read from.
+        :returns: An instance of this class created from the deserializer.
+        """
+        ...

--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -243,7 +243,7 @@ class Document:
 
         :param shape_class: A class that implements the DeserializeableShape protocol.
         """
-        return shape_class.deserialize(DocumentDeserializer(self))
+        return shape_class.deserialize(_DocumentDeserializer(self))
 
     @classmethod
     def from_shape(cls, shape: SerializeableShape) -> "Document":
@@ -460,7 +460,7 @@ class _DocumentMapSerializer(MapSerializer):
         self._delegate.result = None
 
 
-class DocumentDeserializer(ShapeDeserializer):
+class _DocumentDeserializer(ShapeDeserializer):
     """Deserializes documents into shapes."""
 
     def __init__(self, value: Document) -> None:
@@ -478,14 +478,14 @@ class DocumentDeserializer(ShapeDeserializer):
     ):
         for member_name, member_schema in schema.members.items():
             if (value := self._value.get(member_name)) is not None:
-                consumer(member_schema, DocumentDeserializer(value))
+                consumer(member_schema, _DocumentDeserializer(value))
 
     @override
     def read_list(
         self, schema: "Schema", consumer: Callable[[ShapeDeserializer], None]
     ):
         for element in self._value.as_list():
-            consumer(DocumentDeserializer(element))
+            consumer(_DocumentDeserializer(element))
 
     @override
     def read_map(
@@ -494,7 +494,7 @@ class DocumentDeserializer(ShapeDeserializer):
         consumer: Callable[[str, ShapeDeserializer], None],
     ):
         for k, v in self._value.as_map().items():
-            consumer(k, DocumentDeserializer(v))
+            consumer(k, _DocumentDeserializer(v))
 
     @override
     def read_null(self, schema: "Schema") -> None:

--- a/python-packages/smithy-core/tests/unit/test_documents.py
+++ b/python-packages/smithy-core/tests/unit/test_documents.py
@@ -6,7 +6,13 @@ from typing import Any, cast
 
 import pytest
 
-from smithy_core.documents import Document, DocumentValue, _DocumentSerializer
+from smithy_core.deserializers import ShapeDeserializer
+from smithy_core.documents import (
+    Document,
+    DocumentDeserializer,
+    _DocumentSerializer,
+    DocumentValue,
+)
 from smithy_core.exceptions import ExpectationNotMetException
 from smithy_core.prelude import (
     BIG_DECIMAL,
@@ -561,6 +567,66 @@ class DocumentSerdeShape:
         if self.struct_member is not None:
             serializer.write_struct(SCHEMA.members["structMember"], self.struct_member)
 
+    @classmethod
+    def deserialize(cls, deserializer: ShapeDeserializer) -> "DocumentSerdeShape":
+        kwargs: dict[str, Any] = {}
+
+        def _consumer(schema: Schema, de: ShapeDeserializer) -> None:
+            match schema.expect_member_index():
+                case 0:
+                    kwargs["boolean_member"] = de.read_boolean(
+                        SCHEMA.members["booleanMember"]
+                    )
+                case 1:
+                    kwargs["integer_member"] = de.read_integer(
+                        SCHEMA.members["integerMember"]
+                    )
+                case 2:
+                    kwargs["float_member"] = de.read_float(
+                        SCHEMA.members["floatMember"]
+                    )
+                case 3:
+                    kwargs["big_decimal_member"] = de.read_big_decimal(
+                        SCHEMA.members["bigDecimalMember"]
+                    )
+                case 4:
+                    kwargs["string_member"] = de.read_string(
+                        SCHEMA.members["stringMember"]
+                    )
+                case 5:
+                    kwargs["blob_member"] = de.read_blob(SCHEMA.members["blobMember"])
+                case 6:
+                    kwargs["timestamp_member"] = de.read_timestamp(
+                        SCHEMA.members["timestampMember"]
+                    )
+                case 7:
+                    kwargs["document_member"] = de.read_document(
+                        SCHEMA.members["documentMember"]
+                    )
+                case 8:
+                    list_value: list[str] = []
+                    de.read_list(
+                        SCHEMA.members["listMember"],
+                        lambda d: list_value.append(d.read_string(STRING)),
+                    )
+                    kwargs["list_member"] = list_value
+                case 9:
+                    map_value: dict[str, str] = {}
+                    de.read_map(
+                        SCHEMA.members["mapMember"],
+                        lambda k, d: map_value.__setitem__(k, d.read_string(STRING)),
+                    )
+                    kwargs["map_member"] = map_value
+                case 10:
+                    kwargs["struct_member"] = DocumentSerdeShape.deserialize(de)
+                case _:
+                    # In actual generated code, this will just log in order to ignore
+                    # unknown members.
+                    raise Exception(f"Unexpected schema: {schema}")
+
+        deserializer.read_struct(schema=SCHEMA, consumer=_consumer)
+        return cls(**kwargs)
+
 
 DOCUMENT_SERDE_CASES = [
     (True, Document(True, schema=BOOLEAN)),
@@ -707,3 +773,42 @@ def test_from_shape() -> None:
     assert result == Document(
         {"stringMember": Document("foo", schema=STRING)}, schema=SCHEMA
     )
+
+
+@pytest.mark.parametrize("expected, given", DOCUMENT_SERDE_CASES)
+def test_document_deserializer(given: Document, expected: Any):
+    actual: Any
+    match expected:
+        case bool():
+            actual = DocumentDeserializer(given).read_boolean(BOOLEAN)
+        case int():
+            actual = DocumentDeserializer(given).read_integer(INTEGER)
+        case float():
+            actual = DocumentDeserializer(given).read_float(FLOAT)
+        case Decimal():
+            actual = DocumentDeserializer(given).read_big_decimal(BIG_DECIMAL)
+        case bytes():
+            actual = DocumentDeserializer(given).read_blob(BLOB)
+        case str():
+            actual = DocumentDeserializer(given).read_string(STRING)
+        case datetime():
+            actual = DocumentDeserializer(given).read_timestamp(TIMESTAMP)
+        case Document():
+            actual = DocumentDeserializer(given).read_document(DOCUMENT)
+        case list():
+            actual = []
+            deserializer = DocumentDeserializer(given)
+            deserializer.read_list(
+                STRING_LIST_SCHEMA, lambda d: actual.append(d.read_string(STRING))
+            )
+        case dict():
+            actual = {}
+            deserializer = DocumentDeserializer(given)
+            deserializer.read_map(
+                STRING_MAP_SCHEMA,
+                lambda k, d: actual.__setitem__(k, d.read_string(STRING)),
+            )
+        case DocumentSerdeShape():
+            actual = given.as_shape(DocumentSerdeShape)
+        case _:
+            raise Exception(f"Unexpected type: {type(given)}")

--- a/python-packages/smithy-core/tests/unit/test_documents.py
+++ b/python-packages/smithy-core/tests/unit/test_documents.py
@@ -9,9 +9,9 @@ import pytest
 from smithy_core.deserializers import ShapeDeserializer
 from smithy_core.documents import (
     Document,
-    DocumentDeserializer,
-    _DocumentSerializer,
     DocumentValue,
+    _DocumentDeserializer,
+    _DocumentSerializer,
 )
 from smithy_core.exceptions import ExpectationNotMetException
 from smithy_core.prelude import (
@@ -780,30 +780,30 @@ def test_document_deserializer(given: Document, expected: Any):
     actual: Any
     match expected:
         case bool():
-            actual = DocumentDeserializer(given).read_boolean(BOOLEAN)
+            actual = _DocumentDeserializer(given).read_boolean(BOOLEAN)
         case int():
-            actual = DocumentDeserializer(given).read_integer(INTEGER)
+            actual = _DocumentDeserializer(given).read_integer(INTEGER)
         case float():
-            actual = DocumentDeserializer(given).read_float(FLOAT)
+            actual = _DocumentDeserializer(given).read_float(FLOAT)
         case Decimal():
-            actual = DocumentDeserializer(given).read_big_decimal(BIG_DECIMAL)
+            actual = _DocumentDeserializer(given).read_big_decimal(BIG_DECIMAL)
         case bytes():
-            actual = DocumentDeserializer(given).read_blob(BLOB)
+            actual = _DocumentDeserializer(given).read_blob(BLOB)
         case str():
-            actual = DocumentDeserializer(given).read_string(STRING)
+            actual = _DocumentDeserializer(given).read_string(STRING)
         case datetime():
-            actual = DocumentDeserializer(given).read_timestamp(TIMESTAMP)
+            actual = _DocumentDeserializer(given).read_timestamp(TIMESTAMP)
         case Document():
-            actual = DocumentDeserializer(given).read_document(DOCUMENT)
+            actual = _DocumentDeserializer(given).read_document(DOCUMENT)
         case list():
             actual = []
-            deserializer = DocumentDeserializer(given)
+            deserializer = _DocumentDeserializer(given)
             deserializer.read_list(
                 STRING_LIST_SCHEMA, lambda d: actual.append(d.read_string(STRING))
             )
         case dict():
             actual = {}
-            deserializer = DocumentDeserializer(given)
+            deserializer = _DocumentDeserializer(given)
             deserializer.read_map(
                 STRING_MAP_SCHEMA,
                 lambda k, d: actual.__setitem__(k, d.read_string(STRING)),


### PR DESCRIPTION
Depends on #245 

This adds interfaces for shape deserializers, as well as document implementations for those interfaces. See #245 for additional context on why this approach is being taken.

Another advantage with both document serializers and deserializers available is a sort of compatibility layer with botocore:

```python
botocore_style_input: dict[str, Any] = {"foo": "bar"}
smithy_style_input: InputShape = Document(botocore_style).as_shape(InputShape)

smithy_style_output: OutputShape = OutputShape(foo="bar")
botocore_style_output: dict[str, Any] = Document.from_shape(smithy_style_output).as_value()
```

There will of course be some cases where this won't work, mostly regarding cases where botocore has customized the type or name of a parameter, but for the vast majority of inputs and outputs, this should work. We could write a compatibility package that addresses those extra cases if needed.

In this way people could migrate gradually without much difficulty.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
