### PR TITLE
Add serailze methods to documents

### DIFF
--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -217,7 +217,7 @@ class Document:
         )
 
     def _wrap_map(self, value: Mapping[str, DocumentValue]) -> dict[str, "Document"]:
-        if self._schema.shape_type not in [ShapeType.STRUCTURE, ShapeType.UNION]:
+        if self._schema.shape_type not in (ShapeType.STRUCTURE, ShapeType.UNION):
             member_schema = self._schema
             if self._schema.shape_type is ShapeType.MAP:
                 member_schema = self._schema.members["value"]


### PR DESCRIPTION
This adds a serialize method to documents and fixes a few small issues that cropped up when testing those changes. Notably an is_null method was added since it became apparent that otherwise there's no way to tell. More importantly though, document members no longer resolve to their target shapes, but rather the proper member shapes. This necessitated some changes to setitem. Lastly, some improvements were added to shape type inference that leave the result as document only when the value is null.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
