### PR TITLE
Generate serializer implementations

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
@@ -52,7 +52,7 @@ public final class SymbolProperties {
      * Contains a boolean indicating whether the symbol dependency is a link dependency.
      *
      * <p>A link dependency is a dependency that would be specified in a {@code pyproject.toml}
-     * or {@code requirements.txt} with a a link to the package source rather than a name and
+     * or {@code requirements.txt} with a link to the package source rather than a name and
      * version number.
      */
     public static final Property<Boolean> IS_LINK = Property.named("isLink");
@@ -61,6 +61,12 @@ public final class SymbolProperties {
      * Contains a list of optional dependencies that the symbol dependency has.
      */
     public static final Property<List<String>> OPTIONAL_DEPENDENCIES = Property.named("optionalDependencies");
+
+    /**
+     * Contains a symbol pointing to the shape's serializer method. This is only used for
+     * lists and maps.
+     */
+    public static final Property<Symbol> SERIALIZER = Property.named("serializer");
 
     private SymbolProperties() {}
 }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
@@ -162,7 +162,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         if (shape.hasTrait(MediaTypeTrait.class)) {
             var mediaType = shape.expectTrait(MediaTypeTrait.class).getValue();
             if (MediaType.isJson(mediaType)) {
-                return createSymbolBuilder(shape, "bytes | bytearray | JsonBlob")
+                return createSymbolBuilder(shape, "bytes | JsonBlob")
                         .addReference(Symbol.builder()
                                 .name("JsonBlob")
                                 .namespace("smithy_core.types", ".")
@@ -171,7 +171,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                         .build();
             }
         }
-        return createSymbolBuilder(shape, "bytes | bytearray").build();
+        return createSymbolBuilder(shape, "bytes").build();
     }
 
     @Override
@@ -187,6 +187,10 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         var builder = createSymbolBuilder(shape, "list[" + type + "]")
                 .addReference(reference);
 
+        builder.putProperty(SymbolProperties.SERIALIZER, createGeneratedSymbolBuilder(
+                shape, "_serialize_" + CaseUtils.toSnakeCase(shape.getId().getName()), SHAPES_FILE, false)
+                .build());
+
         return builder.build();
     }
 
@@ -197,6 +201,10 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         String type = String.format(shape.hasTrait(SparseTrait.class) ? "%s | None" : "%s", reference.getName());
         var builder = createSymbolBuilder(shape, "dict[str, " + type + "]")
                 .addReference(reference);
+
+        builder.putProperty(SymbolProperties.SERIALIZER, createGeneratedSymbolBuilder(
+                shape, "_serialize_" + CaseUtils.toSnakeCase(shape.getId().getName()), SHAPES_FILE, false)
+                .build());
 
         return builder.build();
     }

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/ListGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/ListGenerator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.python.codegen.generators;
+
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.traits.SparseTrait;
+import software.amazon.smithy.python.codegen.GenerationContext;
+import software.amazon.smithy.python.codegen.PythonWriter;
+import software.amazon.smithy.python.codegen.SymbolProperties;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Generates helper serde functions for lists.
+ */
+@SmithyInternalApi
+public final class ListGenerator implements Runnable {
+    private final GenerationContext context;
+    private final PythonWriter writer;
+    private final ListShape shape;
+
+    public ListGenerator(GenerationContext context, PythonWriter writer, ListShape shape) {
+        this.context = context;
+        this.writer = writer;
+        this.shape = shape;
+    }
+
+    @Override
+    public void run() {
+        generateSerializer();
+    }
+
+    private void generateSerializer() {
+        var listSymbol = context.symbolProvider().toSymbol(shape);
+        var serializerSymbol = listSymbol.expectProperty(SymbolProperties.SERIALIZER);
+        writer.pushState();
+        writer.addImport("smithy_core.serializers", "ShapeSerializer");
+        writer.addImport("smithy_core.schemas", "Schema");
+        writer.putContext("sparse", shape.hasTrait(SparseTrait.class));
+        writer.putContext("propertyName", "e");
+        var memberTarget = context.model().expectShape(shape.getMember().getTarget());
+        writer.write("""
+                def $1L(serializer: ShapeSerializer, schema: Schema, value: $2T) -> None:
+                    member_schema = schema.members["member"]
+                    with serializer.begin_list(schema) as ls:
+                        for e in value:
+                            ${?sparse}
+                            if e is None:
+                                serializer.write_null(member_schema)
+                            else:
+                                ${3C|}
+                            ${/sparse}
+                            ${^sparse}
+                            ${3C|}
+                            ${/sparse}
+
+                """, serializerSymbol.getName(), listSymbol,
+                writer.consumer(w -> memberTarget.accept(
+                        new MemberSerializerGenerator(context, w, shape.getMember(), "ls"))));
+        writer.popState();
+    }
+}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/MapGenerator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.python.codegen.generators;
+
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.traits.SparseTrait;
+import software.amazon.smithy.python.codegen.GenerationContext;
+import software.amazon.smithy.python.codegen.PythonWriter;
+import software.amazon.smithy.python.codegen.SymbolProperties;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Generates helper serde functions for maps.
+ */
+@SmithyInternalApi
+public final class MapGenerator implements Runnable {
+    private final GenerationContext context;
+    private final PythonWriter writer;
+    private final MapShape shape;
+
+    public MapGenerator(GenerationContext context, PythonWriter writer, MapShape shape) {
+        this.context = context;
+        this.writer = writer;
+        this.shape = shape;
+    }
+
+    @Override
+    public void run() {
+        generateSerializer();
+    }
+
+    private void generateSerializer() {
+        var mapSymbol = context.symbolProvider().toSymbol(shape);
+        var serializerSymbol = mapSymbol.expectProperty(SymbolProperties.SERIALIZER);
+        writer.pushState();
+        writer.addImport("smithy_core.serializers", "ShapeSerializer");
+        writer.addImport("smithy_core.schemas", "Schema");
+        writer.putContext("sparse", shape.hasTrait(SparseTrait.class));
+        writer.putContext("propertyName", "v");
+        var valueTarget = context.model().expectShape(shape.getValue().getTarget());
+
+        // Note that we have to disable typing in the sparse case because pyright for some reason isn't
+        // narrowing out the None even though there's an explicit is None check.
+        writer.write("""
+                def $1L(serializer: ShapeSerializer, schema: Schema, value: $2T) -> None:
+                    with serializer.begin_map(schema) as m:
+                        value_schema = schema.members["value"]
+                        for k, v in value.items():
+                            ${?sparse}
+                            if v is None:
+                                m.entry(k, lambda vs: vs.write_null(value_schema))
+                            else:
+                                m.entry(k, lambda vs: ${3C|})  # type: ignore
+                            ${/sparse}
+                            ${^sparse}
+                            m.entry(k, lambda vs: ${3C|})
+                            ${/sparse}
+
+                """, serializerSymbol.getName(), mapSymbol,
+                writer.consumer(w -> valueTarget.accept(
+                        new MemberSerializerGenerator(context, w, shape.getValue(), "vs"))));
+        writer.popState();
+    }
+}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/MemberSerializerGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/MemberSerializerGenerator.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.python.codegen.generators;
+
+import java.util.Locale;
+import java.util.logging.Logger;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.EnumShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.python.codegen.GenerationContext;
+import software.amazon.smithy.python.codegen.PythonWriter;
+import software.amazon.smithy.python.codegen.SymbolProperties;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Generates calls to shape serializers for member shapes.
+ */
+@SmithyInternalApi
+public final class MemberSerializerGenerator extends ShapeVisitor.DataShapeVisitor<Void> {
+
+    private static final Logger LOGGER = Logger.getLogger(MemberSerializerGenerator.class.getName());
+
+    private final GenerationContext context;
+    private final PythonWriter writer;
+    private final MemberShape member;
+    private final String serializerName;
+
+    public MemberSerializerGenerator(
+            GenerationContext context,
+            PythonWriter writer,
+            MemberShape member,
+            String serializerName
+    ) {
+        this.context = context;
+        this.writer = writer;
+        this.member = member;
+        this.serializerName = serializerName;
+    }
+
+    private void pushMemberState() {
+        pushMemberState(member);
+    }
+
+    private void pushMemberState(MemberShape member) {
+        writer.pushState();
+        writer.putContext("serializer", serializerName);
+        writer.putContext("member", member.getMemberName());
+        writer.putContext("isListMember", false);
+        writer.putContext("isMapMember", false);
+        var parent = context.model().expectShape(member.getContainer());
+        if (parent.isUnionShape()) {
+            writer.putContext("property", "self.value");
+        } else if (parent.isListShape()) {
+            writer.putContext("property", "e");
+            writer.putContext("isListMember", true);
+        } else if (parent.isMapShape()) {
+            writer.putContext("property", "v");
+            writer.putContext("isMapMember", true);
+        } else {
+            writer.putContext("property", "self." + context.symbolProvider().toMemberName(member));
+        }
+    }
+
+    private void writeSerializer(Shape shape) {
+        writeSerializer(shape.getType().name().toLowerCase(Locale.ENGLISH));
+    }
+
+    private void writeSerializer(String typeName) {
+        pushMemberState();
+        writer.write("${serializer:L}.write_$L(${C|}, ${property:L})", typeName, writer.consumer(w -> writeSchema()));
+        writer.popState();
+
+    }
+
+    private void writeSchema() {
+        var parent = context.model().expectShape(member.getContainer());
+        if (parent.isListShape()) {
+            writer.writeInline("member_schema");
+        } else if (parent.isMapShape()) {
+            writer.writeInline("value_schema");
+        } else {
+            writer.writeInline("${schema:T}.members[${member:S}]");
+        }
+    }
+
+    @Override
+    public Void blobShape(BlobShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void booleanShape(BooleanShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void byteShape(ByteShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void shortShape(ShortShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void integerShape(IntegerShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void intEnumShape(IntEnumShape shape) {
+        writeSerializer("integer");
+        return null;
+    }
+
+    @Override
+    public Void longShape(LongShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void floatShape(FloatShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void documentShape(DocumentShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void doubleShape(DoubleShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void bigIntegerShape(BigIntegerShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void bigDecimalShape(BigDecimalShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void stringShape(StringShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void enumShape(EnumShape shape) {
+        writeSerializer("string");
+        return null;
+    }
+
+    @Override
+    public Void memberShape(MemberShape shape) {
+        pushMemberState();
+        throw new CodegenException("Unexpected shape type: Member");
+    }
+
+    @Override
+    public Void timestampShape(TimestampShape shape) {
+        writeSerializer(shape);
+        return null;
+    }
+
+    @Override
+    public Void listShape(ListShape shape) {
+        pushMemberState();
+        var serializerSymbol = context.symbolProvider().toSymbol(shape)
+                .expectProperty(SymbolProperties.SERIALIZER);
+        writer.write("$T(${serializer:L}, ${C|}, ${property:L})",
+                serializerSymbol, writer.consumer(w -> writeSchema()));
+        writer.popState();
+        return null;
+    }
+
+    @Override
+    public Void mapShape(MapShape shape) {
+        pushMemberState();
+        var serializerSymbol = context.symbolProvider().toSymbol(shape)
+                .expectProperty(SymbolProperties.SERIALIZER);
+        writer.write("$T(${serializer:L}, ${C|}, ${property:L})",
+                serializerSymbol, writer.consumer(w -> writeSchema()));
+        writer.popState();
+        return null;
+    }
+
+    @Override
+    public Void structureShape(StructureShape shape) {
+        writeSerializer("struct");
+        return null;
+    }
+
+    @Override
+    public Void unionShape(UnionShape shape) {
+        writeSerializer("struct");
+        return null;
+    }
+}


### PR DESCRIPTION
This adds generated implementations for structures and unions to for the SerializeableStruct protocol.

Currently all http bound members are excluded so that the JSON codec can be integrated relatively quickly. They'll be added back in later when full protocol support exists.

I've also started putting the "Generator" classes into their own package to keep things tidy. Eventually the others will be moved into it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
