### PR TITLE
Make member indexes explicit

### DIFF
--- a/python-packages/smithy-core/smithy_core/schemas.py
+++ b/python-packages/smithy-core/smithy_core/schemas.py
@@ -142,11 +142,11 @@ class Schema:
         """
         struct_members: dict[str, "Schema"] = {}
         if members:
-            for i, k in enumerate(members.keys()):
+            for k in members.keys():
                 struct_members[k] = cls.member(
                     id=id.with_member(k),
                     target=members[k]["target"],
-                    index=i,
+                    index=members[k]["index"],
                     member_traits=members[k].get("traits"),
                 )
 
@@ -202,4 +202,5 @@ class MemberSchema(TypedDict):
     """
 
     target: Required[Schema]
+    index: Required[int]
     traits: NotRequired[list["Trait"]]

--- a/python-packages/smithy-core/tests/unit/test_documents.py
+++ b/python-packages/smithy-core/tests/unit/test_documents.py
@@ -402,7 +402,7 @@ def test_wrap_list_passes_schema_to_member_documents() -> None:
     list_schema = Schema.collection(
         id=id,
         shape_type=ShapeType.LIST,
-        members={"member": {"target": target_schema}},
+        members={"member": {"target": target_schema, "index": 0}},
     )
     document = Document(["foo"], schema=list_schema)
     actual = document[0]._schema  # pyright: ignore[reportPrivateUsage]
@@ -421,7 +421,7 @@ def test_setitem_on_list_passes_schema_to_member_documents() -> None:
     list_schema = Schema.collection(
         id=id,
         shape_type=ShapeType.LIST,
-        members={"member": {"target": target_schema}},
+        members={"member": {"target": target_schema, "index": 0}},
     )
     document = Document(["foo"], schema=list_schema)
     document[0] = "bar"
@@ -440,7 +440,7 @@ def test_wrap_structure_passes_schema_to_member_documents() -> None:
     target_schema = Schema(id=ShapeID("smithy.api#String"), shape_type=ShapeType.STRING)
     struct_schema = Schema.collection(
         id=id,
-        members={"stringMember": {"target": target_schema}},
+        members={"stringMember": {"target": target_schema, "index": 0}},
     )
     document = Document({"stringMember": "foo"}, schema=struct_schema)
     actual = document["stringMember"]._schema  # pyright: ignore[reportPrivateUsage]
@@ -458,7 +458,7 @@ def test_setitem_on_structure_passes_schema_to_member_documents() -> None:
     target_schema = Schema(id=ShapeID("smithy.api#String"), shape_type=ShapeType.STRING)
     struct_schema = Schema.collection(
         id=id,
-        members={"stringMember": {"target": target_schema}},
+        members={"stringMember": {"target": target_schema, "index": 0}},
     )
     document = Document({"stringMember": "foo"}, schema=struct_schema)
     document["stringMember"] = "spam"
@@ -478,8 +478,8 @@ def test_wrap_map_passes_schema_to_member_documents() -> None:
         id=id,
         shape_type=ShapeType.MAP,
         members={
-            "key": {"target": STRING},
-            "value": {"target": STRING},
+            "key": {"target": STRING, "index": 0},
+            "value": {"target": STRING, "index": 1},
         },
     )
     document = Document({"spam": "eggs"}, schema=map_schema)
@@ -496,8 +496,8 @@ def test_setitem_on_map_passes_schema_to_member_documents() -> None:
         id=id,
         shape_type=ShapeType.MAP,
         members={
-            "key": {"target": STRING},
-            "value": {"target": STRING},
+            "key": {"target": STRING, "index": 0},
+            "value": {"target": STRING, "index": 1},
         },
     )
     document = Document({"spam": "eggs"}, schema=map_schema)
@@ -517,26 +517,29 @@ def test_is_none():
 STRING_LIST_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringList"),
     shape_type=ShapeType.LIST,
-    members={"member": {"target": STRING}},
+    members={"member": {"target": STRING, "index": 0}},
 )
 STRING_MAP_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringMap"),
     shape_type=ShapeType.MAP,
-    members={"key": {"target": STRING}, "value": {"target": STRING}},
+    members={
+        "key": {"target": STRING, "index": 0},
+        "value": {"target": STRING, "index": 1},
+    },
 )
 SCHEMA: Schema = Schema.collection(
     id=ShapeID("smithy.example#DocumentSerdeShape"),
     members={
-        "booleanMember": {"target": BOOLEAN},
-        "integerMember": {"target": INTEGER},
-        "floatMember": {"target": FLOAT},
-        "bigDecimalMember": {"target": BIG_DECIMAL},
-        "stringMember": {"target": STRING},
-        "blobMember": {"target": BLOB},
-        "timestampMember": {"target": TIMESTAMP},
-        "documentMember": {"target": DOCUMENT},
-        "listMember": {"target": STRING_LIST_SCHEMA},
-        "mapMember": {"target": STRING_MAP_SCHEMA},
+        "booleanMember": {"target": BOOLEAN, "index": 0},
+        "integerMember": {"target": INTEGER, "index": 1},
+        "floatMember": {"target": FLOAT, "index": 2},
+        "bigDecimalMember": {"target": BIG_DECIMAL, "index": 3},
+        "stringMember": {"target": STRING, "index": 4},
+        "blobMember": {"target": BLOB, "index": 5},
+        "timestampMember": {"target": TIMESTAMP, "index": 6},
+        "documentMember": {"target": DOCUMENT, "index": 7},
+        "listMember": {"target": STRING_LIST_SCHEMA, "index": 8},
+        "mapMember": {"target": STRING_MAP_SCHEMA, "index": 9},
     },
 )
 SCHEMA.members["structMember"] = Schema.member(

--- a/python-packages/smithy-core/tests/unit/test_schemas.py
+++ b/python-packages/smithy-core/tests/unit/test_schemas.py
@@ -69,7 +69,8 @@ def test_collection_constructor():
         member_index=0,
     )
     schema = Schema.collection(
-        id=ID, members={member_name: {"target": STRING, "traits": [trait_value]}}
+        id=ID,
+        members={member_name: {"target": STRING, "index": 0, "traits": [trait_value]}},
     )
     assert schema.members == {member_name: member}
 
@@ -81,7 +82,7 @@ def test_member_constructor():
             Trait(id=ShapeID("smithy.api#sensitive")),
             Trait(id=ShapeID("smithy.example#foo"), value="bar"),
         ],
-        members={"spam": {"target": STRING}},
+        members={"spam": {"target": STRING, "index": 0}},
     )
 
     member_id = ShapeID("smithy.example#Spam$eggs")

--- a/python-packages/smithy-json/tests/unit/__init__.py
+++ b/python-packages/smithy-json/tests/unit/__init__.py
@@ -25,42 +25,49 @@ from smithy_json._private.traits import JSON_NAME, TIMESTAMP_FORMAT
 STRING_LIST_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringList"),
     shape_type=ShapeType.LIST,
-    members={"member": {"target": STRING}},
+    members={"member": {"target": STRING, "index": 0}},
 )
 STRING_MAP_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringMap"),
     shape_type=ShapeType.MAP,
-    members={"key": {"target": STRING}, "value": {"target": STRING}},
+    members={
+        "key": {"target": STRING, "index": 0},
+        "value": {"target": STRING, "index": 1},
+    },
 )
 SCHEMA: Schema = Schema.collection(
     id=ShapeID("smithy.example#SerdeShape"),
     members={
-        "booleanMember": {"target": BOOLEAN},
-        "integerMember": {"target": INTEGER},
-        "floatMember": {"target": FLOAT},
-        "bigDecimalMember": {"target": BIG_DECIMAL},
-        "stringMember": {"target": STRING},
+        "booleanMember": {"target": BOOLEAN, "index": 0},
+        "integerMember": {"target": INTEGER, "index": 1},
+        "floatMember": {"target": FLOAT, "index": 2},
+        "bigDecimalMember": {"target": BIG_DECIMAL, "index": 3},
+        "stringMember": {"target": STRING, "index": 4},
         "jsonNameMember": {
             "target": STRING,
             "traits": [Trait(id=JSON_NAME, value="jsonName")],
+            "index": 5,
         },
-        "blobMember": {"target": BLOB},
-        "timestampMember": {"target": TIMESTAMP},
+        "blobMember": {"target": BLOB, "index": 6},
+        "timestampMember": {"target": TIMESTAMP, "index": 7},
         "dateTimeMember": {
             "target": TIMESTAMP,
             "traits": [Trait(id=TIMESTAMP_FORMAT, value="date-time")],
+            "index": 8,
         },
         "httpDateMember": {
             "target": TIMESTAMP,
             "traits": [Trait(id=TIMESTAMP_FORMAT, value="http-date")],
+            "index": 9,
         },
         "epochSecondsMember": {
             "target": TIMESTAMP,
             "traits": [Trait(id=TIMESTAMP_FORMAT, value="epoch-seconds")],
+            "index": 10,
         },
-        "documentMember": {"target": DOCUMENT},
-        "listMember": {"target": STRING_LIST_SCHEMA},
-        "mapMember": {"target": STRING_MAP_SCHEMA},
+        "documentMember": {"target": DOCUMENT, "index": 11},
+        "listMember": {"target": STRING_LIST_SCHEMA, "index": 12},
+        "mapMember": {"target": STRING_MAP_SCHEMA, "index": 13},
     },
 )
 SCHEMA.members["structMember"] = Schema.member(


### PR DESCRIPTION
This makes the assignment of member indexes an explicit thing. The necessity of this became apparent when working on deserializers as the implicit index became something that was only knowable in a fragile, complex way.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
