### PR TITLE
Add read_optional method to deserializers

### DIFF
--- a/python-packages/smithy-core/smithy_core/deserializers.py
+++ b/python-packages/smithy-core/smithy_core/deserializers.py
@@ -60,6 +60,19 @@ class ShapeDeserializer(Protocol):
         """
         ...
 
+    def read_optional[
+        T
+    ](self, schema: "Schema", optional: Callable[["Schema"], T]) -> T | None:
+        """Read an optional value from the underlying data.
+
+        This is intended to be used with sparse lists or maps.
+
+        :param schema: The shape's schema.
+        :param optional: A callable that takes a schema and reads a non-nullable value
+            from the underlying data.
+        """
+        ...
+
     def read_boolean(self, schema: "Schema") -> bool:
         """Read a boolean value from the underlying data.
 

--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -585,6 +585,14 @@ class _DocumentDeserializer(ShapeDeserializer):
             )
 
     @override
+    def read_optional[
+        T
+    ](self, schema: "Schema", optional: Callable[["Schema"], T]) -> T | None:
+        if self._value.is_none():
+            return None
+        return optional(schema)
+
+    @override
     def read_boolean(self, schema: "Schema") -> bool:
         return self._value.as_boolean()
 


### PR DESCRIPTION
This adds a method to deserializers to read nulllable values from the source. This is primarily useful for sparse lists and maps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
