### PR TITLE
Remove read_optional in favor of is_null/read_null

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/ListGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/ListGenerator.java
@@ -81,15 +81,13 @@ public final class ListGenerator implements Runnable {
                     ${?includeSchema}
                     member_schema = schema.members["member"]
                     ${/includeSchema}
-                    deserializer.read_list(
-                        schema,
-                        ${?sparse}
-                        lambda d: result.append(d.read_optional(member_schema, lambda s: ${3C|}))
-                        ${/sparse}
-                        ${^sparse}
-                        lambda d: result.append(${3C|})
-                        ${/sparse}
-                    )
+                    def _read_value(d: ShapeDeserializer):
+                        if d.is_null():
+                            d.read_null()
+                            ${?sparse}result.append(None)${/sparse}
+                        else:
+                            result.append(${3C|})
+                    deserializer.read_list(schema, _read_value)
                     return result
                 """, deserializerSymbol.getName(), listSymbol,
                 writer.consumer(w -> memberTarget.accept(

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/MapGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/generators/MapGenerator.java
@@ -82,15 +82,13 @@ public final class MapGenerator implements Runnable {
                 def $1L(deserializer: ShapeDeserializer, schema: Schema) -> $2T:
                     result: $2T = {}
                     value_schema = schema.members["value"]
-                    deserializer.read_map(
-                        schema,
-                        ${?sparse}
-                        lambda k, d: result.__setitem__(k, d.read_optional(value_schema, lambda s: ${3C|}))
-                        ${/sparse}
-                        ${^sparse}
-                        lambda k, d: result.__setitem__(k, ${3C|})
-                        ${/sparse}
-                    )
+                    def _read_value(k: str, d: ShapeDeserializer):
+                        if d.is_null():
+                            d.read_null()
+                            ${?sparse}result[k] = None${/sparse}
+                        else:
+                            result[k] = ${3C|}
+                    deserializer.read_map(schema, _read_value)
                     return result
                 """, deserializerSymbol.getName(), listSymbol,
                 writer.consumer(w -> valueTarget.accept(

--- a/python-packages/smithy-core/smithy_core/deserializers.py
+++ b/python-packages/smithy-core/smithy_core/deserializers.py
@@ -53,24 +53,15 @@ class ShapeDeserializer(Protocol):
         """
         ...
 
-    def read_null(self, schema: "Schema") -> None:
-        """Read a null value from the underlying data.
+    def is_null(self) -> bool:
+        """Returns whether the next value in the underlying data represents null.
 
         :param schema: The shape's schema.
         """
         ...
 
-    def read_optional[
-        T
-    ](self, schema: "Schema", optional: Callable[["Schema"], T]) -> T | None:
-        """Read an optional value from the underlying data.
-
-        This is intended to be used with sparse lists or maps.
-
-        :param schema: The shape's schema.
-        :param optional: A callable that takes a schema and reads a non-nullable value
-            from the underlying data.
-        """
+    def read_null(self) -> None:
+        """Read a null value from the underlying data."""
         ...
 
     def read_boolean(self, schema: "Schema") -> bool:

--- a/python-packages/smithy-core/smithy_core/documents.py
+++ b/python-packages/smithy-core/smithy_core/documents.py
@@ -578,19 +578,15 @@ class _DocumentDeserializer(ShapeDeserializer):
             consumer(k, _DocumentDeserializer(v))
 
     @override
-    def read_null(self, schema: "Schema") -> None:
+    def is_null(self) -> bool:
+        return self._value.is_none()
+
+    @override
+    def read_null(self) -> None:
         if (value := self._value.as_value()) is not None:
             raise ExpectationNotMetException(
                 f"Expected document value to be None, but was: {value}"
             )
-
-    @override
-    def read_optional[
-        T
-    ](self, schema: "Schema", optional: Callable[["Schema"], T]) -> T | None:
-        if self._value.is_none():
-            return None
-        return optional(schema)
 
     @override
     def read_boolean(self, schema: "Schema") -> bool:

--- a/python-packages/smithy-json/smithy_json/_private/deserializers.py
+++ b/python-packages/smithy-json/smithy_json/_private/deserializers.py
@@ -106,19 +106,14 @@ class JSONShapeDeserializer(ShapeDeserializer):
         # populated on an as-needed basis.
         self._json_names: dict[ShapeID, dict[str, str]] = {}
 
-    def read_null(self, schema: Schema) -> None:
+    def is_null(self) -> bool:
+        return self._stream.peek().type == "null"
+
+    def read_null(self) -> None:
         event = next(self._stream)
         if event.value is not None:
             raise JSONTokenError("null", event)
         return None
-
-    def read_optional[
-        T
-    ](self, schema: "Schema", optional: Callable[["Schema"], T]) -> T | None:
-        if self._stream.peek().value is None:
-            next(self._stream)
-            return None
-        return optional(schema)
 
     def read_boolean(self, schema: Schema) -> bool:
         event = next(self._stream)

--- a/python-packages/smithy-json/tests/unit/__init__.py
+++ b/python-packages/smithy-json/tests/unit/__init__.py
@@ -270,20 +270,32 @@ class SerdeShape:
                     kwargs["struct_member"] = SerdeShape.deserialize(de)
                 case 15:
                     sparse_list_value: list[str | None] = []
+
+                    def _read_optional_list(d: ShapeDeserializer):
+                        if d.is_null():
+                            d.read_null()
+                            sparse_list_value.append(None)
+                        else:
+                            sparse_list_value.append(d.read_string(STRING))
+
                     de.read_list(
                         SCHEMA.members["sparseListMember"],
-                        lambda d: sparse_list_value.append(
-                            d.read_optional(STRING, d.read_string)
-                        ),
+                        _read_optional_list,
                     )
                     kwargs["sparse_list_member"] = sparse_list_value
                 case 16:
                     sparse_map_value: dict[str, str | None] = {}
+
+                    def _read_optional_map(k: str, d: ShapeDeserializer):
+                        if d.is_null():
+                            d.read_null()
+                            sparse_map_value[k] = None
+                        else:
+                            sparse_map_value[k] = d.read_string(STRING)
+
                     de.read_map(
                         SCHEMA.members["sparseMapMember"],
-                        lambda k, d: sparse_map_value.__setitem__(
-                            k, d.read_optional(STRING, d.read_string)
-                        ),
+                        _read_optional_map,
                     )
                     kwargs["sparse_map_member"] = sparse_map_value
                 case _:


### PR DESCRIPTION
This removes read_optional in favor of is_null and read_null on shape deserializers. This lets us reduce the number of lambdas created and gives us more flexibility. This allows, for example, for skipping nulls in dense collections.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
