### PR TITLE
Event stream interfaces and HTTP streaming support

### DIFF
--- a/python-packages/smithy-event-stream/smithy_event_stream/aio/__init__.py
+++ b/python-packages/smithy-event-stream/smithy_event_stream/aio/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/python-packages/smithy-event-stream/smithy_event_stream/aio/interfaces.py
+++ b/python-packages/smithy-event-stream/smithy_event_stream/aio/interfaces.py
@@ -1,0 +1,86 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Protocol, Self, Any
+
+
+class InputEventStream[E](Protocol):
+    """Asynchronously sends events to a service."""
+
+    async def send(self, event: E) -> None:
+        """Sends an event to the service.
+        
+        :param event: The event to send.
+        """
+        ...
+
+    def close(self) -> None:
+        """Closes the event stream."""
+        ...
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):
+        self.close()
+
+
+class OutputEventStream[E](Protocol):
+    """Asynchronously receives events from a service."""
+
+    async def receive(self) -> E | None:
+        """Receive a single event from the service.
+        
+        :returns: An event or None. None indicates that no more events will be sent by
+            the service.
+        """
+        ...
+
+    def close(self) -> None:
+        """Closes the event stream."""
+        ...
+
+    async def __anext__(self) -> E:
+        result = await self.receive()
+        if result is None:
+            self.close()
+            raise StopAsyncIteration
+        return result
+
+    def __aiter__(self) -> Self:
+        return self
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):
+        self.close()
+
+
+class EventStream[I: InputEventStream[Any] | None, O: OutputEventStream[Any] | None, R](Protocol):
+    """A unidirectional or bidirectional event stream."""
+
+    input_stream: I
+    _output_stream: O | None = None
+    _response: R | None = None
+
+    async def await_output(self) -> tuple[R, O]:
+        if self._response is not None:
+            self._response, self._output_stream = await self._await_output()
+
+        return self._response, self._output_stream  # type: ignore
+
+
+    async def _await_output(self) -> tuple[R, O]: ...
+
+    async def close(self) -> None:
+        if self._output_stream is None:
+            _, self._output_stream = await self.await_output()
+
+        if self._output_stream is not None:
+            self._output_stream.close()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any):
+        await self.close()

--- a/python-packages/smithy-event-stream/smithy_event_stream/aio/interfaces.py
+++ b/python-packages/smithy-event-stream/smithy_event_stream/aio/interfaces.py
@@ -1,14 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Protocol, Self, Any
+from typing import Any, Protocol, Self
+
+from smithy_core.deserializers import DeserializeableShape
+from smithy_core.serializers import SerializeableShape
 
 
-class InputEventStream[E](Protocol):
+class InputEventStream[E: SerializeableShape](Protocol):
     """Asynchronously sends events to a service."""
 
     async def send(self, event: E) -> None:
         """Sends an event to the service.
-        
+
         :param event: The event to send.
         """
         ...
@@ -24,12 +27,12 @@ class InputEventStream[E](Protocol):
         self.close()
 
 
-class OutputEventStream[E](Protocol):
+class OutputEventStream[E: DeserializeableShape](Protocol):
     """Asynchronously receives events from a service."""
 
     async def receive(self) -> E | None:
         """Receive a single event from the service.
-        
+
         :returns: An event or None. None indicates that no more events will be sent by
             the service.
         """
@@ -56,7 +59,9 @@ class OutputEventStream[E](Protocol):
         self.close()
 
 
-class EventStream[I: InputEventStream[Any] | None, O: OutputEventStream[Any] | None, R](Protocol):
+class EventStream[I: InputEventStream[Any] | None, O: OutputEventStream[Any] | None, R](
+    Protocol
+):
     """A unidirectional or bidirectional event stream."""
 
     input_stream: I
@@ -68,7 +73,6 @@ class EventStream[I: InputEventStream[Any] | None, O: OutputEventStream[Any] | N
             self._response, self._output_stream = await self._await_output()
 
         return self._response, self._output_stream  # type: ignore
-
 
     async def _await_output(self) -> tuple[R, O]: ...
 

--- a/python-packages/smithy-http/smithy_http/aio/__init__.py
+++ b/python-packages/smithy-http/smithy_http/aio/__init__.py
@@ -51,3 +51,8 @@ class HTTPResponse:
     def consume_body(self) -> bytes:
         """Iterate over request body and return as bytes."""
         return read_streaming_blob(body=self.body)
+
+    def close(self) -> None:
+        """Close the HTTP request body without reading remaining data."""
+        if (closer := getattr(self.body, "close", None)) is not None:
+            closer()

--- a/python-packages/smithy-http/smithy_http/aio/aiohttp.py
+++ b/python-packages/smithy-http/smithy_http/aio/aiohttp.py
@@ -1,5 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
+from collections.abc import Awaitable
 from copy import copy, deepcopy
 from itertools import chain
 from typing import TYPE_CHECKING, Any
@@ -31,7 +32,7 @@ from ..interfaces import (
     HTTPRequestConfiguration,
 )
 from . import HTTPResponse
-from .interfaces import HTTPClient, HTTPRequest
+from .interfaces import HTTPClient, HTTPRequest, HTTPRequestStream
 from .interfaces import HTTPResponse as HTTPResponseInterface
 
 
@@ -132,3 +133,11 @@ class AIOHTTPClient(HTTPClient):
             client_config=deepcopy(self._config),
             _session=copy(self._session),
         )
+
+    async def stream(
+        self,
+        *,
+        request: HTTPRequest,
+        request_config: HTTPRequestConfiguration | None = None,
+    ) -> tuple[HTTPRequestStream, Awaitable[HTTPResponse]]:
+        raise NotImplementedError("aiohttp does not support bidirectional streaming.")


### PR DESCRIPTION
This adds a `stream` operation to the HTTP client interface which opens a bidirectional-capable stream. This operation is implmented for the CRT, but not for aiohttp because it doesn't have bidirectional support.

The reason that this requires an entirely new operation is that a caller must be capable of immediately sending request frames without waiting for *any kind of response* and be capable of sending them at the same time as they are receiving server events. The `send` method kinda forces them to either wait for the initial responses or force the caller to guess when it's okay to start sending request frames. Buffering can be done of course, but that starts to pile on memory.

Having the implementation return an input stream also has the benefit of letting the underlying client create their own writer, which the CRT is tentatively planning to do in leu of wrapping a BytesIO.

Another potentially questionable decision here is the banning of setting the HTTP request body for streaming requests. An alternative would be to use that as initial data. But if that initial data is itself an async reader, you're potentially having to buffer a lot of data while you wait for the initial data to empty out.


This also adds in the interfaces for streaming that operations will use. Initially I was planning on having the HTTP interfaces also implement these event stream interfaces, but that would require passing codecs down through the HTTP clients where they don't necessarily belong.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
