### PR TITLE
Codegen event streams

### DIFF
--- a/codegen/smithy-python-codegen-test/model/main.smithy
+++ b/codegen/smithy-python-codegen-test/model/main.smithy
@@ -20,11 +20,14 @@ service Weather {
     operations: [
         GetCurrentTime
         TestUnionListOperation
+        StreamAtmosphericConditions
     ]
 }
 
 resource City {
-    identifiers: { cityId: CityId }
+    identifiers: {
+        cityId: CityId
+    }
     read: GetCity
     list: ListCities
     resources: [
@@ -56,12 +59,16 @@ union UnionListMember {
 }
 
 resource Forecast {
-    identifiers: { cityId: CityId }
+    identifiers: {
+        cityId: CityId
+    }
     read: GetForecast
 }
 
 resource CityImage {
-    identifiers: { cityId: CityId }
+    identifiers: {
+        cityId: CityId
+    }
     read: GetCityImage
 }
 
@@ -620,6 +627,67 @@ union Precipitation {
     blob: Blob
     foo: example.weather.nested#Foo
     baz: example.weather.nested.more#Baz
+}
+
+@http(method: "POST", uri: "/cities/{cityId}/atmosphere")
+operation StreamAtmosphericConditions {
+    input := {
+        @required
+        @httpLabel
+        cityId: CityId
+
+        @required
+        @httpPayload
+        stream: AtmosphericConditions
+    }
+
+    output := {
+        @required
+        @httpHeader("x-initial-sample-rate")
+        initialSampleRate: Double
+
+        @required
+        @httpPayload
+        stream: CollectionDirectives
+    }
+}
+
+@streaming
+union AtmosphericConditions {
+    humidity: HumiditySample
+    pressure: PressureSample
+    temperature: TemperatureSample
+}
+
+@mixin
+structure Sample {
+    @required
+    collectionTime: Timestamp
+}
+
+structure HumiditySample with [Sample] {
+    @required
+    humidity: Double
+}
+
+structure PressureSample with [Sample] {
+    @required
+    pressure: Double
+}
+
+structure TemperatureSample with [Sample] {
+    @required
+    temperature: Double
+}
+
+@streaming
+union CollectionDirectives {
+    sampleRate: SampleRate
+}
+
+structure SampleRate {
+    @required
+    samplesPerMinute: Double
 }
 
 structure OtherStructure {}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -64,6 +64,13 @@ public final class SmithyPythonDependency {
             false
     );
 
+    public static final PythonDependency SMITHY_EVENT_STREAM = new PythonDependency(
+            "smithy_event_stream",
+            "==0.0.1",
+            Type.DEPENDENCY,
+            false
+    );
+
     /**
      * testing framework used in generated functional tests.
      */


### PR DESCRIPTION
This updates operation generation to generate event stream operations with the EventStream type as its return value.

It also updates union generation so that unions contain their own deserialize functions. This is needed to make the them pass the type check, but also it is best to have them own as much of that as possible so that the deserializer function can be left to only dispatch duty.

To demonstrate these changes, an event stream operation was added to the test model.

This depends on #313 

Example output:

```python
async def stream_atmospheric_conditions(
    self,
    input: StreamAtmosphericConditionsInput,
    plugins: list[Plugin] | None = None,
) -> EventStream[
    InputEventStream[AtmosphericConditions],
    OutputEventStream[CollectionDirectives],
    StreamAtmosphericConditionsOutput,
]:
    raise NotImplementedError()
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
