### PR TITLE
Add types and code generation for event stream operation signatures

### DIFF
--- a/codegen/smithy-python-codegen-test/model/main.smithy
+++ b/codegen/smithy-python-codegen-test/model/main.smithy
@@ -20,11 +20,14 @@ service Weather {
     operations: [
         GetCurrentTime
         TestUnionListOperation
+        StreamAtmosphericConditions
     ]
 }
 
 resource City {
-    identifiers: { cityId: CityId }
+    identifiers: {
+        cityId: CityId
+    }
     read: GetCity
     list: ListCities
     resources: [
@@ -56,12 +59,16 @@ union UnionListMember {
 }
 
 resource Forecast {
-    identifiers: { cityId: CityId }
+    identifiers: {
+        cityId: CityId
+    }
     read: GetForecast
 }
 
 resource CityImage {
-    identifiers: { cityId: CityId }
+    identifiers: {
+        cityId: CityId
+    }
     read: GetCityImage
 }
 
@@ -620,6 +627,67 @@ union Precipitation {
     blob: Blob
     foo: example.weather.nested#Foo
     baz: example.weather.nested.more#Baz
+}
+
+@http(method: "POST", uri: "/cities/{cityId}/atmosphere")
+operation StreamAtmosphericConditions {
+    input := {
+        @required
+        @httpLabel
+        cityId: CityId
+
+        @required
+        @httpPayload
+        stream: AtmosphericConditions
+    }
+
+    output := {
+        @required
+        @httpHeader("x-initial-sample-rate")
+        initialSampleRate: Double
+
+        @required
+        @httpPayload
+        stream: CollectionDirectives
+    }
+}
+
+@streaming
+union AtmosphericConditions {
+    humidity: HumiditySample
+    pressure: PressureSample
+    temperature: TemperatureSample
+}
+
+@mixin
+structure Sample {
+    @required
+    collectionTime: Timestamp
+}
+
+structure HumiditySample with [Sample] {
+    @required
+    humidity: Double
+}
+
+structure PressureSample with [Sample] {
+    @required
+    pressure: Double
+}
+
+structure TemperatureSample with [Sample] {
+    @required
+    temperature: Double
+}
+
+@streaming
+union CollectionDirectives {
+    sampleRate: SampleRate
+}
+
+structure SampleRate {
+    @required
+    samplesPerMinute: Double
 }
 
 structure OtherStructure {}

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -356,7 +356,7 @@ final class ClientGenerator implements Runnable {
                         )
 
                 """, CodegenUtils.getHttpAuthParamsSymbol(context.settings()),
-                    writer.consumer(this::initializeHttpAuthParameters));
+                writer.consumer(this::initializeHttpAuthParameters));
             writer.popState();
 
             writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
@@ -649,16 +649,16 @@ final class ClientGenerator implements Runnable {
 
         writer.openBlock("async def $L(self, input: $T, plugins: list[$T] | None = None) -> $T:", "",
                 operationSymbol.getName(), inputSymbol, pluginSymbol, outputSymbol, () -> {
-                    writer.writeDocs(() -> {
-                        var docs = operation.getTrait(DocumentationTrait.class)
-                                .map(StringTrait::getValue)
-                                .orElse(String.format("Invokes the %s operation.", operation.getId().getName()));
+            writer.writeDocs(() -> {
+                var docs = operation.getTrait(DocumentationTrait.class)
+                        .map(StringTrait::getValue)
+                        .orElse(String.format("Invokes the %s operation.", operation.getId().getName()));
 
-                        var inputDocs = input.getTrait(DocumentationTrait.class)
-                                .map(StringTrait::getValue)
-                                .orElse("The operation's input.");
+                var inputDocs = input.getTrait(DocumentationTrait.class)
+                        .map(StringTrait::getValue)
+                        .orElse("The operation's input.");
 
-                        writer.write("""
+                writer.write("""
                         $L
 
                         :param input: $L
@@ -666,17 +666,17 @@ final class ClientGenerator implements Runnable {
                         :param plugins: A list of callables that modify the configuration dynamically.
                         Changes made by these plugins only apply for the duration of the operation
                         execution and will not affect any other operation invocations.""", docs, inputDocs);
-                    });
+            });
 
-                    var defaultPlugins = new LinkedHashSet<SymbolReference>();
-                    for (PythonIntegration integration : context.integrations()) {
-                        for (RuntimeClientPlugin runtimeClientPlugin : integration.getClientPlugins()) {
-                            if (runtimeClientPlugin.matchesOperation(context.model(), service, operation)) {
-                                runtimeClientPlugin.getPythonPlugin().ifPresent(defaultPlugins::add);
-                            }
-                        }
+            var defaultPlugins = new LinkedHashSet<SymbolReference>();
+            for (PythonIntegration integration : context.integrations()) {
+                for (RuntimeClientPlugin runtimeClientPlugin : integration.getClientPlugins()) {
+                    if (runtimeClientPlugin.matchesOperation(context.model(), service, operation)) {
+                        runtimeClientPlugin.getPythonPlugin().ifPresent(defaultPlugins::add);
                     }
-                    writer.write("""
+                }
+            }
+            writer.write("""
                 operation_plugins: list[Plugin] = [
                     $C
                 ]
@@ -684,13 +684,13 @@ final class ClientGenerator implements Runnable {
                     operation_plugins.extend(plugins)
                 """, writer.consumer(w -> writeDefaultPlugins(w, defaultPlugins)));
 
-                    if (context.protocolGenerator() == null) {
-                        writer.write("raise NotImplementedError()");
-                    } else {
-                        var protocolGenerator = context.protocolGenerator();
-                        var serSymbol = protocolGenerator.getSerializationFunction(context, operation);
-                        var deserSymbol = protocolGenerator.getDeserializationFunction(context, operation);
-                        writer.write("""
+            if (context.protocolGenerator() == null) {
+                writer.write("raise NotImplementedError()");
+            } else {
+                var protocolGenerator = context.protocolGenerator();
+                var serSymbol = protocolGenerator.getSerializationFunction(context, operation);
+                var deserSymbol = protocolGenerator.getDeserializationFunction(context, operation);
+                writer.write("""
                     return await self._execute_operation(
                         input=input,
                         plugins=operation_plugins,
@@ -700,8 +700,8 @@ final class ClientGenerator implements Runnable {
                         operation_name=$S,
                     )
                     """, serSymbol, deserSymbol, operation.getId().getName());
-                    }
-                });
+            }
+        });
     }
 
     private void generateEventStreamOperation(PythonWriter writer, OperationShape operation) {

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -64,6 +64,13 @@ public final class SmithyPythonDependency {
             false
     );
 
+    public static final PythonDependency SMITHY_EVENT_STREAM = new PythonDependency(
+            "smithy_event_stream",
+            "==0.0.1",
+            Type.DEPENDENCY,
+            false
+    );
+
     /**
      * testing framework used in generated functional tests.
      */

--- a/python-packages/smithy-event-stream/smithy_event_stream/aio/interfaces.py
+++ b/python-packages/smithy-event-stream/smithy_event_stream/aio/interfaces.py
@@ -1,0 +1,177 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any, Protocol, Self
+
+from smithy_core.deserializers import DeserializeableShape
+from smithy_core.serializers import SerializeableShape
+
+
+class InputEventStream[E: SerializeableShape](Protocol):
+    """Asynchronously sends events to a service.
+
+    This may be used as a context manager to ensure the stream is closed before exiting.
+    """
+
+    async def send(self, event: E) -> None:
+        """Sends an event to the service.
+
+        :param event: The event to send.
+        """
+        ...
+
+    def close(self) -> None:
+        """Closes the event stream."""
+        ...
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):
+        self.close()
+
+
+class OutputEventStream[E: DeserializeableShape](Protocol):
+    """Asynchronously receives events from a service.
+
+    Events may be recived via the ``receive`` method or by using this class as
+    an async iterable.
+
+    This may also be used as a context manager to ensure the stream is closed before
+    exiting.
+    """
+
+    async def receive(self) -> E | None:
+        """Receive a single event from the service.
+
+        :returns: An event or None. None indicates that no more events will be sent by
+            the service.
+        """
+        ...
+
+    def close(self) -> None:
+        """Closes the event stream."""
+        ...
+
+    async def __anext__(self) -> E:
+        result = await self.receive()
+        if result is None:
+            self.close()
+            raise StopAsyncIteration
+        return result
+
+    def __aiter__(self) -> Self:
+        return self
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):
+        self.close()
+
+
+class EventStream[I: InputEventStream[Any] | None, O: OutputEventStream[Any] | None, R](
+    Protocol
+):
+    """A unidirectional or bidirectional event stream.
+
+    To ensure that streams are closed upon exiting, this class may be used as an async
+    context manager.
+
+    .. code-block:: python
+
+        async def main():
+            client = ChatClient()
+            input = StreamMessagesInput(chat_room="aws-python-sdk", username="hunter7")
+
+            async with client.stream_messages(input=input) as stream:
+                stream.input_stream.send(MessageStreamMessage("Chat logger starting up."))
+                response_handler = handle_output(stream)
+                stream.input_stream.send(MessageStreamMessage("Chat logger active."))
+                await response_handler
+
+            async def handle_output(stream: EventStream) -> None:
+                _, output_stream = await stream.await_output()
+                async for event in output_stream:
+                    match event:
+                        case MessageStreamMessage():
+                            print(event.value)
+                        case MessageStreamShutdown():
+                            return
+                        case _:
+                            stream.input_stream.send(
+                                MessageStreamMessage("Unknown message type received. Shutting down.")
+                            )
+                            return
+    """
+
+    input_stream: I
+    """An event stream that sends events to the service.
+
+    This value will be None if the operation has no input stream.
+    """
+
+    output_stream: O | None = None
+    """An event stream that receives events from the service.
+
+    This value may be None until ``await_output`` has been called.
+
+    This value will also be None if the operation has no output stream.
+    """
+
+    response: R | None = None
+    """The initial response from the service.
+
+    This value may be None until ``await_output`` has been called.
+
+    This may include context necessary to interpret output events or prepare
+    input events. It will always be available before any events.
+    """
+
+    async def await_output(self) -> tuple[R, O]:
+        """Await the operation's output.
+
+        The EventStream will be returned as soon as the input stream is ready to
+        receive events, which may be before the intitial response has been received
+        and the service is ready to send events.
+
+        Awaiting this method will wait until the initial response was received and the
+        service is ready to send events. The initial response and output stream will
+        be returned by this operation and also cached in ``response`` and
+        ``output_stream``, respectively.
+
+        The default implementation of this method performs the caching behavior,
+        delegating to the abstract ``_await_output`` method to actually retrieve the
+        initial response and output stream.
+
+        :returns: A tuple containing the initial response and output stream. If the
+            operation has no output stream, the second value will be None.
+        """
+        if self.response is not None:
+            self.response, self.output_stream = await self._await_output()
+
+        return self._response, self._output_stream  # type: ignore
+
+    async def _await_output(self) -> tuple[R, O]:
+        """Await the operation's output without caching.
+
+        This method is meant to be used with the default implementation of await_output.
+        It should return the output directly without caching.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Closes the event stream.
+
+        This closes both the input and output streams.
+        """
+        if self.output_stream is None:
+            _, self.output_stream = await self.await_output()
+
+        if self.output_stream is not None:
+            self.output_stream.close()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any):
+        await self.close()

--- a/python-packages/smithy-event-stream/smithy_event_stream/aio/interfaces.py
+++ b/python-packages/smithy-event-stream/smithy_event_stream/aio/interfaces.py
@@ -33,7 +33,7 @@ class InputEventStream[E: SerializeableShape](Protocol):
 class OutputEventStream[E: DeserializeableShape](Protocol):
     """Asynchronously receives events from a service.
 
-    Events may be recived via the ``receive`` method or by using this class as
+    Events may be received via the ``receive`` method or by using this class as
     an async iterable.
 
     This may also be used as a context manager to ensure the stream is closed before
@@ -131,7 +131,7 @@ class EventStream[I: InputEventStream[Any] | None, O: OutputEventStream[Any] | N
         """Await the operation's output.
 
         The EventStream will be returned as soon as the input stream is ready to
-        receive events, which may be before the intitial response has been received
+        receive events, which may be before the initial response has been received
         and the service is ready to send events.
 
         Awaiting this method will wait until the initial response was received and the


### PR DESCRIPTION
This adds in the interfaces for event streams and updates code generation to use them.

Example generated operation:

```python
async def stream_messages(
    self,
    input: StreamMessagesInput,
    plugins: list[Plugin] | None = None,
) -> EventStream[
    InputEventStream[MessageStream],
    OutputEventStream[MessageStream],
    StreamMessagesOutput,
]:
    raise NotImplementedError()
```

These were part of separate prs that included http context, which has been removed. Doc strings have also been majorly beefed up. Example useage from the beefed up docs:

```python
async def main():
    client = ChatClient()
    input = StreamMessagesInput(chat_room="aws-python-sdk", username="hunter7")

    async with client.stream_messages(input=input) as stream:
        stream.input_stream.send(MessageStreamMessage("Chat logger starting up."))
        response_handler = handle_output(stream)
        stream.input_stream.send(MessageStreamMessage("Chat logger active."))
        await response_handler

    async def handle_output(stream: EventStream) -> None:
        _, output_stream = await stream.await_output()
        async for event in output_stream:
            match event:
                case MessageStreamMessage():
                    print(event.value)
                case MessageStreamShutdown():
                    return
                case _:
                    stream.input_stream.send(
                        MessageStreamMessage("Unknown message type received. Shutting down.")
                    )
                    return
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
