### PR TITLE
Write CRT data asynchronously

### DIFF
--- a/python-packages/smithy-http/smithy_http/aio/crt.py
+++ b/python-packages/smithy-http/smithy_http/aio/crt.py
@@ -298,7 +298,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
         body = request.body
         if isinstance(body, bytes | bytearray):
-            # If the body is already directly in memory, wrap in in a BytesIO to hand
+            # If the body is already directly in memory, wrap in a BytesIO to hand
             # off to CRT.
             crt_body = BytesIO(body)
         else:
@@ -311,7 +311,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
                 # with read methods will be read in chunks so as not to exhaust memory.
                 body = AsyncBytesReader(body)
 
-            # Start the read task int the background.
+            # Start the read task in the background.
             read_task = asyncio.create_task(self._consume_body_async(body, crt_body))
 
             # Keep track of the read task so that it doesn't get garbage colllected,


### PR DESCRIPTION
This updates the CRT bindings to write data to its ByteIO body asynchronously rather than buffering it all into memory when making a call. This should enable us to support event streaming, and also prevent us from buffering a huge amount of data into memory, even for synchronous bodies of uncertain size.

This should also allow us to get rid of those consume_body utility functions that I detest. But one thing at a time.

Also, we really need to work on standing up a local http2 server for testing. Integ tests will be nice too and all but I'm nevertheless nervous about how hard this is to test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
