### PR TITLE
Add an asynchronous bytes provider

### DIFF
--- a/python-packages/smithy-core/smithy_core/aio/types.py
+++ b/python-packages/smithy-core/smithy_core/aio/types.py
@@ -319,7 +319,7 @@ class AsyncBytesProvider:
         async with self._data_condition:
 
             # Wait for the number of chunks in the buffer to be less than the
-            # specified maximum. This also releases the lock until the condition
+            # specified maximum. This also releases the lock until that condition
             # is met.
             await self._data_condition.wait_for(self._can_write)
 
@@ -360,7 +360,8 @@ class AsyncBytesProvider:
             # Block writes
             self._flushing = True
 
-            # Wait for the stream to be closed or for the data buffer to be empty.
+            # Wait for the stream to be closed or for the data buffer to be empty,
+            # releasing the lock until the condition is met.
             await self._data_condition.wait_for(lambda: len(self._data) == 0)
 
             # Unblock writes
@@ -383,6 +384,7 @@ class AsyncBytesProvider:
         async with self._data_condition:
             self._closing = True
             if flush:
+                # Release the lock until the buffer is empty.
                 await self._data_condition.wait_for(lambda: len(self._data) == 0)
             else:
                 # Clear out any pending data, freeing up memory.
@@ -403,7 +405,7 @@ class AsyncBytesProvider:
         async with self._data_condition:
 
             # Wait for the stream to be closed or for the data buffer to be non-empty.
-            # This also releases the lock until the condition is met.
+            # This also releases the lock until that condition is met.
             await self._data_condition.wait_for(
                 lambda: self._closed or len(self._data) > 0
             )

--- a/python-packages/smithy-core/tests/unit/aio/test_types.py
+++ b/python-packages/smithy-core/tests/unit/aio/test_types.py
@@ -1,11 +1,17 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
+import asyncio
 from io import BytesIO
 from typing import Self
 
 import pytest
 
-from smithy_core.aio.types import AsyncBytesReader, SeekableAsyncBytesReader
+from smithy_core.aio.types import (
+    AsyncBytesProvider,
+    AsyncBytesReader,
+    SeekableAsyncBytesReader,
+)
+from smithy_core.exceptions import SmithyException
 
 
 class _AsyncIteratorWrapper:
@@ -270,3 +276,166 @@ async def test_seekable_iter_chunks() -> None:
 
     assert reader.tell() == 3
     assert result == b"foo"
+
+
+async def test_provider_requires_positive_max_chunks() -> None:
+    with pytest.raises(ValueError):
+        AsyncBytesProvider(max_buffered_chunks=-1)
+
+
+async def drain_provider(provider: AsyncBytesProvider, dest: list[bytes]) -> None:
+    async for chunk in provider:
+        dest.append(chunk)
+
+
+async def test_provider_reads_initial_data() -> None:
+    provider = AsyncBytesProvider(intial_data=b"foo")
+    result: list[bytes] = []
+
+    # Start the read task in the background.
+    read_task = asyncio.create_task(drain_provider(provider, result))
+
+    # Wait for the buffer to drain. At that point all the data should
+    # be read, but the read dask won't actually be complete yet
+    # because it's still waiting on future data.
+    await provider.flush()
+    assert result == [b"foo"]
+    assert not read_task.done()
+
+    # Now actually close the provider, which will let the read task
+    # complete.
+    await provider.close()
+    await read_task
+
+    # The result should not have changed
+    assert result == [b"foo"]
+
+
+async def test_provider_reads_written_data() -> None:
+    provider = AsyncBytesProvider()
+    result: list[bytes] = []
+
+    # Start the read task in the background.
+    read_task = asyncio.create_task(drain_provider(provider, result))
+    await provider.write(b"foo")
+
+    # Wait for the buffer to drain. At that point all the data should
+    # be read, but the read dask won't actually be complete yet
+    # because it's still waiting on future data.
+    await provider.flush()
+    assert result == [b"foo"]
+    assert not read_task.done()
+
+    # Now actually close the provider, which will let the read task
+    # complete.
+    await provider.close()
+    await read_task
+
+    # The result should not have changed
+    assert result == [b"foo"]
+
+
+async def test_close_stops_writes() -> None:
+    provider = AsyncBytesProvider()
+    await provider.close()
+    with pytest.raises(SmithyException):
+        await provider.write(b"foo")
+
+
+async def test_close_deletes_buffered_data() -> None:
+    provider = AsyncBytesProvider(b"foo")
+    await provider.close()
+    result: list[bytes] = []
+    await drain_provider(provider, result)
+    assert result == []
+
+    # We weren't able to read data, which is what we want. But here we dig into
+    # the internals to be sure that the buffer is clear and no data is haning
+    # around.
+    assert provider._data == []  # type: ignore
+
+
+async def test_only_max_chunks_buffered() -> None:
+    # Initialize the provider with a max buffer of one and immediately have it
+    # filled with an initial chunk.
+    provider = AsyncBytesProvider(b"foo", max_buffered_chunks=1)
+
+    # Schedule a write task. Using create_task immediately enqueues it, though it
+    # won't start executing until its turn in the loop.
+    write_task = asyncio.create_task(provider.write(b"bar"))
+
+    # Suspend the current coroutine so the write task can take over. It shouldn't
+    # complete because it should be waiting on the buffer to drain. One tenth of
+    # a second is way more than enough time for it to complete under normal
+    # circumstances.
+    await asyncio.sleep(0.1)
+    assert not write_task.done()
+
+    # Now begin the read task in the background. Since it's draining the buffer, the
+    # write task will become unblocked.
+    result: list[bytes] = []
+    read_task = asyncio.create_task(drain_provider(provider, result))
+
+    # The read task won't be done until we close the provider, but the write task
+    # should be able to complete now.
+    await write_task
+
+    # The write task and read task don't necessarily complete at the same time,
+    # so we wait until the buffer is empty here.
+    await provider.flush()
+    assert result == [b"foo", b"bar"]
+
+    # Now we can close the provider and wait for the read task to end.
+    await provider.close()
+    await read_task
+
+
+async def test_close_stops_queued_writes() -> None:
+    # Initialize the provider with a max buffer of one and immediately have it
+    # filled with an initial chunk.
+    provider = AsyncBytesProvider(b"foo", max_buffered_chunks=1)
+
+    # Schedule a write task. Using create_task immediately enqueues it, though it
+    # can't complete until the buffer is free.
+    write_task = asyncio.create_task(provider.write(b"bar"))
+
+    # Now close the provider. The write task will raise an error.
+    await provider.close()
+
+    with pytest.raises(SmithyException):
+        await write_task
+
+
+async def test_close_with_flush() -> None:
+    # Initialize the provider with a max buffer of one and immediately have it
+    # filled with an initial chunk.
+    provider = AsyncBytesProvider(b"foo", max_buffered_chunks=1)
+
+    # Schedule a write task. Using create_task immediately enqueues it, though it
+    # can't complete until the buffer is free.
+    write_task = asyncio.create_task(provider.write(b"bar"))
+
+    # Now flush the provider and close it. The read task will be able to read the
+    # alredy buffered data, but the write task will fail.
+    close_task = asyncio.create_task(provider.close(flush=True))
+
+    # There is a timing issue to when a write will fail. If they're in the queue
+    # before the close task, they may still make it through. Here the current
+    # coroutine is suspended so that both the write task and close task have a
+    # chance to check their conditions and set necessary state.
+    await asyncio.sleep(0.1)
+
+    # Now we can start the read task. We can immediately await it because the close
+    # task will complete in the background, which will then stop the iteration.
+    result: list[bytes] = []
+    await drain_provider(provider, result)
+
+    # Ensure that the close task is complete.
+    await close_task
+
+    # The write will have been blocked by the close task, so the read task will
+    # only see the initial data. The write task will raise an exception as the
+    # provider closed before it could write its data.
+    assert result == [b"foo"]
+    with pytest.raises(SmithyException):
+        await write_task

--- a/python-packages/smithy-core/tests/unit/aio/test_types.py
+++ b/python-packages/smithy-core/tests/unit/aio/test_types.py
@@ -296,7 +296,7 @@ async def test_provider_reads_initial_data() -> None:
     read_task = asyncio.create_task(drain_provider(provider, result))
 
     # Wait for the buffer to drain. At that point all the data should
-    # be read, but the read dask won't actually be complete yet
+    # be read, but the read task won't actually be complete yet
     # because it's still waiting on future data.
     await provider.flush()
     assert result == [b"foo"]
@@ -320,7 +320,7 @@ async def test_provider_reads_written_data() -> None:
     await provider.write(b"foo")
 
     # Wait for the buffer to drain. At that point all the data should
-    # be read, but the read dask won't actually be complete yet
+    # be read, but the read task won't actually be complete yet
     # because it's still waiting on future data.
     await provider.flush()
     assert result == [b"foo"]


### PR DESCRIPTION
This adds a class that allows bytes to be asynchronously exchanged. This primarily serves the purpose of enabling event streaming. Event streams will create a provider under the hood that will be written to. That provider will then be passed as the trasnport request body, which will read it as an async bytes iterable.

This will also fail until the protocol test suppression is merged.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
