### PR TITLE
Generate RestJson event stream implementation

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -64,8 +64,21 @@ public final class SmithyPythonDependency {
             false
     );
 
+    /**
+     * Core interfaces for event streams.
+     */
     public static final PythonDependency SMITHY_EVENT_STREAM = new PythonDependency(
             "smithy_event_stream",
+            "==0.0.1",
+            Type.DEPENDENCY,
+            false
+    );
+
+    /**
+     * EventStream implementations for application/vnd.amazon.eventstream.
+     */
+    public static final PythonDependency AWS_EVENT_STREAM = new PythonDependency(
+            "aws_event_stream",
             "==0.0.1",
             Type.DEPENDENCY,
             false

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/ProtocolGenerator.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.python.codegen.ApplicationProtocol;
 import software.amazon.smithy.python.codegen.GenerationContext;
+import software.amazon.smithy.python.codegen.PythonWriter;
 import software.amazon.smithy.utils.CaseUtils;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -166,5 +167,26 @@ public interface ProtocolGenerator {
      * @param context Generation context
      */
     default void generateProtocolTests(GenerationContext context) {
+    }
+
+    /**
+     * Generates the code to wrap an operation output into an event stream.
+     *
+     * <p>Important context variables are:
+     * <ul>
+     *     <li>execution_context - Has the context, including the transport input and output.</li>
+     *     <li>operation_output - The deserialized operation output.</li>
+     *     <li>has_input_stream - Whether or not there is an input stream.</li>
+     *     <li>event_deserializer - The deserialize method for output events, or None for no output stream.</li>
+     *     <li>event_response_deserializer - A DeserializeableShape representing the operation's output shape,
+     *         or None for no output stream. This is used when the operation sends the initial response over the
+     *         event stream.
+     *     </li>
+     * </ul>
+     *
+     * @param context Generation context.
+     * @param writer The writer to write to.
+     */
+    default void wrapEventStream(GenerationContext context, PythonWriter writer) {
     }
 }


### PR DESCRIPTION
This updates generic event stream generation with recently introduced changes and also introduces the concrete implementation for RestJson.

Testing for all of this will be done via protocol tests, and in the early days manual testing.

Since a lot of this is effectively throwaway code, I was more liberal with type ignoring and using Any types than I otherwise would be. The request pipeline is going to be moving to pure python soon^tm, and the typing issues will be resolved at that time.

This depends on #322


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
