### PR TITLE
Lock Smithy to a static version

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,0 @@
-smithyVersion=[1.48.0,2.0)
-smithyGradleVersion=1.0.0

--- a/codegen/settings.gradle.kts
+++ b/codegen/settings.gradle.kts
@@ -26,6 +26,6 @@ pluginManagement {
     }
     val smithyGradleVersion: String by settings
     plugins {
-        id("software.amazon.smithy.gradle.smithy-base").version(smithyGradleVersion)
+        id("software.amazon.smithy.gradle.smithy-base").version("1.1.0")
     }
 }

--- a/codegen/smithy-aws-python-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-python-codegen/build.gradle.kts
@@ -7,21 +7,7 @@ description = "Generates AWS Python code from Smithy models"
 extra["displayName"] = "Smithy :: AWS :: Python :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.aws.python.codegen"
 
-val smithyVersion: String by project
-
-buildscript {
-    val smithyVersion: String by project
-
-    repositories {
-        mavenLocal()
-        mavenCentral()
-    }
-    dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
-    }
-}
-
 dependencies {
     implementation(project(":smithy-python-codegen"))
-    implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-aws-traits:1.52.0")
 }

--- a/codegen/smithy-python-codegen-test/build.gradle.kts
+++ b/codegen/smithy-python-codegen-test/build.gradle.kts
@@ -26,10 +26,8 @@ repositories {
     mavenCentral()
 }
 
-val smithyVersion: String by project
-
 dependencies {
     implementation(project(":smithy-python-codegen"))
-    implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-waiters:1.52.0")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:1.52.0")
 }

--- a/codegen/smithy-python-codegen/build.gradle.kts
+++ b/codegen/smithy-python-codegen/build.gradle.kts
@@ -17,24 +17,10 @@ description = "Generates Python code from Smithy models"
 extra["displayName"] = "Smithy :: Python :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.python.codegen"
 
-val smithyVersion: String by project
-
-buildscript {
-    val smithyVersion: String by project
-
-    repositories {
-        mavenLocal()
-        mavenCentral()
-    }
-    dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
-    }
-}
-
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
-    implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
+    api("software.amazon.smithy:smithy-codegen-core:1.52.0")
+    implementation("software.amazon.smithy:smithy-waiters:1.52.0")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:1.52.0")
     // We have this because we're using RestJson1 as a 'generic' protocol.
-    implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-aws-traits:1.52.0")
 }

--- a/codegen/smithy-python-protocol-test/build.gradle.kts
+++ b/codegen/smithy-python-protocol-test/build.gradle.kts
@@ -26,9 +26,7 @@ repositories {
     mavenCentral()
 }
 
-val smithyVersion: String by project
-
 dependencies {
     implementation(project(":smithy-python-codegen"))
-    implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-aws-protocol-tests:1.52.0")
 }


### PR DESCRIPTION
This updates our Smithy versioning to a single static version that is not synced via gradle properties. The version currently locked in is 1.52.0, which is not the latest, but 1.52.1 has a bug that prevents us from generating protocol tests.

Instead of relying on the version range to keep us up to date, we will now be relying on dependabot. It can also track all the different dependency file locations, which removes the need for the syncing via gradle properties.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
