### PR TITLE
Flush AsyncBytesProvider on close by default

### DIFF
--- a/python-packages/smithy-core/smithy_core/aio/types.py
+++ b/python-packages/smithy-core/smithy_core/aio/types.py
@@ -367,7 +367,7 @@ class AsyncBytesProvider:
             # Unblock writes
             self._flushing = False
 
-    async def close(self, flush: bool = False) -> None:
+    async def close(self, flush: bool = True) -> None:
         """Closes the provider.
 
         Pending writing tasks queued after this will fail, so such tasks should be
@@ -424,4 +424,4 @@ class AsyncBytesProvider:
         return self
 
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        await self.close()
+        await self.close(flush=True)


### PR DESCRIPTION
This updates the default behavior of close on AsyncBytesProvider to flush already-written data. This should be the less surprising outcome, particularly when the class is used as a context manager.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
