### PR TITLE
Check for async when closing

### DIFF
--- a/python-packages/smithy-core/smithy_core/aio/interfaces/__init__.py
+++ b/python-packages/smithy-core/smithy_core/aio/interfaces/__init__.py
@@ -21,13 +21,6 @@ class AsyncWriter(Protocol):
     async def write(self, data: bytes) -> None: ...
 
 
-@runtime_checkable
-class AsyncCloseable(Protocol):
-    """An object that can asynchronously close."""
-
-    async def close(self): ...
-
-
 # A union of all acceptable streaming blob types. Deserialized payloads will
 # always return a ByteStream, or AsyncByteStream if async is enabled.
 type StreamingBlob = SyncStreamingBlob | AsyncByteStream | AsyncIterable[bytes]

--- a/python-packages/smithy-core/smithy_core/aio/types.py
+++ b/python-packages/smithy-core/smithy_core/aio/types.py
@@ -110,10 +110,12 @@ class AsyncBytesReader:
         """Returns whether the stream is closed."""
         return self._closed
 
-    def close(self) -> None:
+    async def close(self) -> None:
         """Closes the stream, as well as the underlying stream where possible."""
         if (close := getattr(self._data, "close", None)) is not None:
-            close()
+            if asyncio.iscoroutine(result := close()):
+                await result
+
         self._data = None
         self._closed = True
 
@@ -244,10 +246,12 @@ class SeekableAsyncBytesReader:
         """Returns whether the stream is closed."""
         return self._buffer.closed
 
-    def close(self) -> None:
+    async def close(self) -> None:
         """Closes the stream, as well as the underlying stream where possible."""
-        if callable(close_fn := getattr(self._data_source, "close", None)):
-            close_fn()  # pylint: disable=not-callable
+        if (close := getattr(self._data_source, "close", None)) is not None:
+            if asyncio.iscoroutine(result := close()):
+                await result
+
         self._data_source = None
         self._buffer.close()
 

--- a/python-packages/smithy-core/tests/unit/aio/test_types.py
+++ b/python-packages/smithy-core/tests/unit/aio/test_types.py
@@ -138,7 +138,23 @@ async def test_close_closeable_source() -> None:
     assert not reader.closed
     assert not source.closed
 
-    reader.close()
+    await reader.close()
+
+    assert reader.closed
+    assert source.closed
+
+    with pytest.raises(ValueError):
+        await reader.read()
+
+
+async def test_close_async_closeable_source() -> None:
+    source = AsyncBytesReader(BytesIO(b"foo"))
+    reader = AsyncBytesReader(source)
+
+    assert not reader.closed
+    assert not source.closed
+
+    await reader.close()
 
     assert reader.closed
     assert source.closed
@@ -152,7 +168,7 @@ async def test_close_non_closeable_source() -> None:
     reader = AsyncBytesReader(source)
 
     assert not reader.closed
-    reader.close()
+    await reader.close()
     assert reader.closed
 
     with pytest.raises(ValueError):
@@ -167,7 +183,27 @@ async def test_seekable_close_closeable_source() -> None:
     assert not source.closed
     assert reader.tell() == 0
 
-    reader.close()
+    await reader.close()
+
+    assert reader.closed
+    assert source.closed
+
+    with pytest.raises(ValueError):
+        await reader.read()
+
+    with pytest.raises(ValueError):
+        reader.tell()
+
+
+async def test_seekable_close_async_closeable_source() -> None:
+    source = AsyncBytesReader(BytesIO(b"foo"))
+    reader = SeekableAsyncBytesReader(source)
+
+    assert not reader.closed
+    assert not source.closed
+    assert reader.tell() == 0
+
+    await reader.close()
 
     assert reader.closed
     assert source.closed
@@ -185,7 +221,7 @@ async def test_seekable_close_non_closeable_source() -> None:
 
     assert not reader.closed
     assert reader.tell() == 0
-    reader.close()
+    await reader.close()
     assert reader.closed
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
Protocol isinstance does *not* check whether a function is sync or not. This adds in those checks to the various closeable checks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
