### PR TITLE
Don't prematurely handle event streams

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
@@ -41,6 +41,7 @@ import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.InputTrait;
 import software.amazon.smithy.model.traits.OutputTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.python.codegen.generators.MemberDeserializerGenerator;
 import software.amazon.smithy.python.codegen.generators.MemberSerializerGenerator;
 
@@ -417,6 +418,9 @@ final class StructureGenerator implements Runnable {
         int index = 0;
         for (MemberShape member : members) {
             var target = model.expectShape(member.getTarget());
+            if (target.hasTrait(StreamingTrait.class) && target.isUnionShape()) {
+                continue;
+            }
             writer.write("""
                     case $L:
                         kwargs[$S] = ${C|}


### PR DESCRIPTION
This removes event streams from the generated deser methods, as they aren't handled there. They will eventually be handled by the protocol python implementation on a higher level. This also removes the attempt at handling them as if they were a blob stream, as they are currently handled elsewhere.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
