### PR TITLE
Support error serialization

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -106,8 +106,8 @@ public final class CodegenUtils {
     public static Symbol getServiceError(PythonSettings settings) {
         return Symbol.builder()
                 .name("ServiceError")
-                .namespace(format("%s.errors", settings.moduleName()), ".")
-                .definitionFile(format("./%s/errors.py", settings.moduleName()))
+                .namespace(format("%s.models", settings.moduleName()), ".")
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .build();
     }
 
@@ -123,8 +123,8 @@ public final class CodegenUtils {
     public static Symbol getApiError(PythonSettings settings) {
         return Symbol.builder()
                 .name("ApiError")
-                .namespace(format("%s.errors", settings.moduleName()), ".")
-                .definitionFile(format("./%s/errors.py", settings.moduleName()))
+                .namespace(format("%s.models", settings.moduleName()), ".")
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .build();
     }
 
@@ -140,8 +140,8 @@ public final class CodegenUtils {
     public static Symbol getUnknownApiError(PythonSettings settings) {
         return Symbol.builder()
                 .name("UnknownApiError")
-                .namespace(format("%s.errors", settings.moduleName()), ".")
-                .definitionFile(format("./%s/errors.py", settings.moduleName()))
+                .namespace(format("%s.models", settings.moduleName()), ".")
+                .definitionFile(format("./%s/models.py", settings.moduleName()))
                 .build();
     }
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
@@ -147,9 +147,12 @@ final class StructureGenerator implements Runnable {
 
                     ${7C|}
 
+                    ${8C|}
+
                 """, symbol.getName(), apiError, code, fault,
                 writer.consumer(w -> writeClassDocs(true)),
                 writer.consumer(w -> writeProperties()),
+                writer.consumer(w -> generateSerializeMethod()),
                 writer.consumer(w -> generateDeserializeMethod()));
     }
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
@@ -330,8 +330,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol structureShape(StructureShape shape) {
         String name = getDefaultShapeName(shape);
-        var file = shape.hasTrait(ErrorTrait.class) ? "errors" : SHAPES_FILE;
-        return createGeneratedSymbolBuilder(shape, name, file).build();
+        return createGeneratedSymbolBuilder(shape, name, SHAPES_FILE).build();
     }
 
     @Override


### PR DESCRIPTION
This adds support for error serialization. This is needed for event streams, which can include error shapes. Consequently, this also moves errors from `errors.py` into `models.py` to avoid circular references.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
