### PR TITLE
Handle empty and incomplete event bytes

### DIFF
--- a/python-packages/aws-event-stream/aws_event_stream/_private/deserializers.py
+++ b/python-packages/aws-event-stream/aws_event_stream/_private/deserializers.py
@@ -38,6 +38,9 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
 
     async def receive(self) -> E | None:
         event = await Event.decode_async(self._source)
+        if event is None:
+            return None
+
         deserializer = EventDeserializer(
             event=event,
             payload_codec=self._payload_codec,

--- a/python-packages/aws-event-stream/aws_event_stream/exceptions.py
+++ b/python-packages/aws-event-stream/aws_event_stream/exceptions.py
@@ -93,6 +93,12 @@ class InvalidIntegerValue(EventError):
         super().__init__(message)
 
 
+class InvalidEventBytes(EventError):
+    def __init__(self) -> None:
+        message = "Invalid event bytes."
+        super().__init__(message)
+
+
 class MissingInitialResponse(EventError):
     def __init__(self) -> None:
         super().__init__("Expected an initial response, but none was found.")

--- a/python-packages/aws-event-stream/tests/unit/_private/test_deserializers.py
+++ b/python-packages/aws-event-stream/tests/unit/_private/test_deserializers.py
@@ -22,6 +22,7 @@ from . import (
 @pytest.mark.parametrize("expected,given", EVENT_STREAM_SERDE_CASES)
 def test_event_deserializer(expected: DeserializeableShape, given: EventMessage):
     source = Event.decode(BytesIO(given.encode()))
+    assert source is not None
     deserializer = EventDeserializer(event=source, payload_codec=JSONCodec())
     result = EventStreamDeserializer().deserialize(deserializer)
     assert result == expected
@@ -30,6 +31,7 @@ def test_event_deserializer(expected: DeserializeableShape, given: EventMessage)
 def test_deserialize_initial_request():
     expected, given = INITIAL_REQUEST_CASE
     source = Event.decode(BytesIO(given.encode()))
+    assert source is not None
     deserializer = EventDeserializer(event=source, payload_codec=JSONCodec())
     result = EventStreamOperationInputOutput.deserialize(deserializer)
     assert result == expected
@@ -38,6 +40,7 @@ def test_deserialize_initial_request():
 def test_deserialize_initial_response():
     expected, given = INITIAL_RESPONSE_CASE
     source = Event.decode(BytesIO(given.encode()))
+    assert source is not None
     deserializer = EventDeserializer(event=source, payload_codec=JSONCodec())
     result = EventStreamOperationInputOutput.deserialize(deserializer)
     assert result == expected
@@ -52,6 +55,7 @@ def test_deserialize_unmodeled_error():
         }
     )
     source = Event.decode(BytesIO(message.encode()))
+    assert source is not None
     deserializer = EventDeserializer(event=source, payload_codec=JSONCodec())
 
     with pytest.raises(UnmodeledEventError, match="InternalError"):


### PR DESCRIPTION
This adds in explicit handling for both emtpy and incomplete event bytes. If nothing is able to be read from the source, event decoders will return None. If there are bytes there, but they're truncated, then an explicit error is thrown that wraps what would otherwise be a `struct.error`. This is only applied for truncations that would not already be caught by checksum validation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
