### PR TITLE
Handle string/blob event payloads correctly

### DIFF
--- a/python-packages/aws-event-stream/aws_event_stream/_private/__init__.py
+++ b/python-packages/aws-event-stream/aws_event_stream/_private/__init__.py
@@ -1,5 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+from smithy_core.schemas import Schema
+
+from .traits import EVENT_PAYLOAD_TRAIT
 
 INITIAL_REQUEST_EVENT_TYPE = "initial-request"
 INITIAL_RESPONSE_EVENT_TYPE = "initial-response"
+
+
+def get_payload_member(schema: Schema) -> Schema | None:
+    for member in schema.members.values():
+        if EVENT_PAYLOAD_TRAIT in member.traits:
+            return member
+    return None


### PR DESCRIPTION
When the event payload trait targets a blob or string, the event payload must be the direct value of the blob or the direct value of the string encoded as utf8. Previously, they were just being treated as JSON, so this PR fixes that and fixes errant test cases whilst adding a new one for blobs specifically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
