### PR TITLE
Raise modeled errors

### DIFF
--- a/python-packages/aws-event-stream/aws_event_stream/_private/deserializers.py
+++ b/python-packages/aws-event-stream/aws_event_stream/_private/deserializers.py
@@ -51,7 +51,10 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
             payload_codec=self._payload_codec,
             is_client_mode=self._is_client_mode,
         )
-        return self._deserializer(deserializer)
+        result = self._deserializer(deserializer)
+        if isinstance(getattr(result, "value"), Exception):
+            raise result.value  # type: ignore
+        return result
 
     async def close(self) -> None:
         if (close := getattr(self._source, "close", None)) is not None:

--- a/python-packages/aws-event-stream/tests/unit/_private/__init__.py
+++ b/python-packages/aws-event-stream/tests/unit/_private/__init__.py
@@ -341,7 +341,7 @@ class EventStreamBlobPayloadEvent:
 
 
 @dataclass
-class ErrorEvent:
+class ErrorEvent(Exception):
     code: ClassVar[str] = "NoSuchResource"
     fault: ClassVar[Literal["client", "server"]] = "client"
 

--- a/python-packages/aws-event-stream/tests/unit/_private/test_deserializers.py
+++ b/python-packages/aws-event-stream/tests/unit/_private/test_deserializers.py
@@ -1,12 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from io import BytesIO
+from typing import Any
 
 import pytest
+from smithy_core.aio.types import AsyncBytesReader
 from smithy_core.deserializers import DeserializeableShape
 from smithy_json import JSONCodec
 
-from aws_event_stream._private.deserializers import EventDeserializer
+from aws_event_stream._private.deserializers import (
+    AWSAsyncEventReceiver,
+    EventDeserializer,
+)
 from aws_event_stream.events import Event, EventMessage
 from aws_event_stream.exceptions import UnmodeledEventError
 
@@ -14,9 +19,33 @@ from . import (
     EVENT_STREAM_SERDE_CASES,
     INITIAL_REQUEST_CASE,
     INITIAL_RESPONSE_CASE,
+    ErrorEvent,
     EventStreamDeserializer,
+    EventStreamErrorEvent,
     EventStreamOperationInputOutput,
 )
+
+
+@pytest.mark.parametrize("expected,given", EVENT_STREAM_SERDE_CASES)
+async def test_event_receiver(expected: DeserializeableShape, given: EventMessage):
+    source = AsyncBytesReader(given.encode())
+    deserializer = EventStreamDeserializer()
+    receiver = AWSAsyncEventReceiver[Any](
+        payload_codec=JSONCodec(), source=source, deserializer=deserializer.deserialize
+    )
+
+    result: Any = None
+
+    try:
+        result = await receiver.receive()
+    except ErrorEvent as e:
+        if isinstance(expected, EventStreamErrorEvent):
+            expected = expected.value
+        else:
+            raise
+        result = e
+
+    assert result == expected
 
 
 @pytest.mark.parametrize("expected,given", EVENT_STREAM_SERDE_CASES)


### PR DESCRIPTION
Modeled errors should be raised, this updates the event receiver to raise them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
