### PR TITLE
Use CRT by default when h2 is needed

### DIFF
--- a/codegen/smithy-python-codegen-test/model/main.smithy
+++ b/codegen/smithy-python-codegen-test/model/main.smithy
@@ -8,7 +8,10 @@ use smithy.test#httpResponseTests
 use smithy.waiters#waitable
 
 /// Provides weather forecasts.
-@restJson1
+@restJson1(
+    http: ["h2", "http/1.1"]
+    eventStreamHttp: ["h2"]
+)
 @fakeProtocol
 @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
 @httpApiKeyAuth(name: "weather-auth", in: "header")

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ApplicationProtocol.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ApplicationProtocol.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.python.codegen;
 
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -24,8 +25,12 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * application protocol (e.g., "http", "mqtt", etc).
  */
 @SmithyUnstableApi
-public record ApplicationProtocol(String name, SymbolReference requestType, SymbolReference responseType) {
-
+public record ApplicationProtocol(
+        String name,
+        SymbolReference requestType,
+        SymbolReference responseType,
+        ObjectNode configuration
+) {
     /**
      * Checks if the protocol is an HTTP based protocol.
      *
@@ -40,7 +45,7 @@ public record ApplicationProtocol(String name, SymbolReference requestType, Symb
      *
      * @return Returns the created application protocol.
      */
-    public static ApplicationProtocol createDefaultHttpApplicationProtocol() {
+    public static ApplicationProtocol createDefaultHttpApplicationProtocol(ObjectNode config) {
         return new ApplicationProtocol(
                 "http",
                 SymbolReference.builder()
@@ -48,8 +53,18 @@ public record ApplicationProtocol(String name, SymbolReference requestType, Symb
                         .build(),
                 SymbolReference.builder()
                         .symbol(createHttpSymbol("HTTPResponse"))
-                        .build()
+                        .build(),
+                config
         );
+    }
+
+    /**
+     * Creates a default HTTP application protocol.
+     *
+     * @return Returns the created application protocol.
+     */
+    public static ApplicationProtocol createDefaultHttpApplicationProtocol() {
+        return createDefaultHttpApplicationProtocol(ObjectNode.objectNode());
     }
 
     private static Symbol createHttpSymbol(String symbolName) {

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/GenerationContext.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/GenerationContext.java
@@ -96,7 +96,7 @@ public final class GenerationContext
      */
     public ApplicationProtocol applicationProtocol() {
         return protocolGenerator != null
-                ? protocolGenerator.getApplicationProtocol()
+                ? protocolGenerator.getApplicationProtocol(this)
                 : ApplicationProtocol.createDefaultHttpApplicationProtocol();
     }
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonDependency.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/PythonDependency.java
@@ -56,6 +56,10 @@ public record PythonDependency(
                 .build();
     }
 
+    public PythonDependency withOptionalDependencies(String... optionalDependencies) {
+        return new PythonDependency(packageName, version, type, isLink, List.of(optionalDependencies));
+    }
+
     /**
      * An enum of valid dependency types.
      */

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -49,9 +49,7 @@ public final class SmithyPythonDependency {
             // You'll need to locally install this before we publish
             "==0.0.1",
             Type.DEPENDENCY,
-            false,
-            // TODO: make this configurable
-            List.of("aiohttp")
+            false
     );
 
     /**

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/HttpBindingProtocolGenerator.java
@@ -92,7 +92,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private final Set<Shape> deserializingDocumentShapes = new TreeSet<>();
 
     @Override
-    public ApplicationProtocol getApplicationProtocol() {
+    public ApplicationProtocol getApplicationProtocol(GenerationContext context) {
         return ApplicationProtocol.createDefaultHttpApplicationProtocol();
     }
 

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/ProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/ProtocolGenerator.java
@@ -55,7 +55,7 @@ public interface ProtocolGenerator {
      *
      * @return Returns the created application protocol.
      */
-    ApplicationProtocol getApplicationProtocol();
+    ApplicationProtocol getApplicationProtocol(GenerationContext context);
 
 
     /**

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Set;
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait;
 import software.amazon.smithy.model.knowledge.HttpBinding;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -27,6 +29,7 @@ import software.amazon.smithy.model.traits.RequiresLengthTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase;
+import software.amazon.smithy.python.codegen.ApplicationProtocol;
 import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.HttpProtocolTestGenerator;
@@ -88,6 +91,17 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     @Override
     public ShapeId getProtocol() {
         return RestJson1Trait.ID;
+    }
+
+    @Override
+    public ApplicationProtocol getApplicationProtocol(GenerationContext context) {
+        var service = context.settings().service(context.model());
+        var trait = service.expectTrait(RestJson1Trait.class);
+        var config = ObjectNode.builder()
+                .withMember("http", ArrayNode.fromStrings(trait.getHttp()))
+                .withMember("eventStreamHttp", ArrayNode.fromStrings(trait.getEventStreamHttp()))
+                .build();
+        return ApplicationProtocol.createDefaultHttpApplicationProtocol(config);
     }
 
     @Override


### PR DESCRIPTION
This updates the code generator to set the default http client to the CRT when the protocol configures it or when bidirectional event streaming is needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
