### PR TITLE
Safely copy crt clients

### DIFF
--- a/python-packages/smithy-http/smithy_http/aio/crt.py
+++ b/python-packages/smithy-http/smithy_http/aio/crt.py
@@ -5,6 +5,7 @@
 import asyncio
 from collections.abc import AsyncGenerator, AsyncIterable, Awaitable
 from concurrent.futures import Future
+from copy import deepcopy
 from io import BytesIO
 from threading import Lock
 from typing import TYPE_CHECKING, Any
@@ -178,9 +179,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         client.
         """
         _assert_crt()
-        self._config = (
-            AWSCRTHTTPClientConfig() if client_config is None else client_config
-        )
+        self._config = client_config or AWSCRTHTTPClientConfig()
         if eventloop is None:
             eventloop = _AWSCRTEventLoop()
         self._eventloop = eventloop
@@ -334,3 +333,9 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             dest.write(chunk)
         # Should we call close here? Or will that make the crt unable to read the last
         # chunk?
+
+    def __deepcopy__(self, memo: Any) -> "AWSCRTHTTPClient":
+        return AWSCRTHTTPClient(
+            eventloop=self._eventloop,
+            client_config=deepcopy(self._config),
+        )

--- a/python-packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/python-packages/smithy-http/tests/unit/aio/test_crt.py
@@ -1,0 +1,8 @@
+from copy import deepcopy
+
+from smithy_http.aio.crt import AWSCRTHTTPClient
+
+
+def test_deepcopy_client() -> None:
+    client = AWSCRTHTTPClient()
+    deepcopy(client)


### PR DESCRIPTION
The request pipeline currently deepcopies the config since it can be mutated by plugins. This was causing issues when copying a CRT client, which has un-copiable components to it. This implements the deepcopy method to behave better.

It may be necessary in the future to either remove the deepcopy, or modify this implementation to violate the intent of a deepcopy somewhat. I'm a bit concerned about not sharing the connection pool.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
