### PR TITLE
Gracefully handle non-json error bodies

### DIFF
--- a/python-packages/smithy-http/smithy_http/aio/restjson.py
+++ b/python-packages/smithy-http/smithy_http/aio/restjson.py
@@ -31,7 +31,13 @@ async def parse_rest_json_error_info(
 
     if check_body:
         if body := await http_response.consume_body_async():
-            json_body = json.loads(body)
+            try:
+                json_body = json.loads(body)
+            except json.JSONDecodeError:
+                # In some cases the body might end up being HTML depending on the
+                # configuration of the server. In those cases we can simply ignore
+                # the body because we can't find the information we need there.
+                pass
 
         if json_body:
             for key, value in json_body.items():

--- a/python-packages/smithy-http/tests/unit/aio/test_restjson.py
+++ b/python-packages/smithy-http/tests/unit/aio/test_restjson.py
@@ -118,3 +118,21 @@ async def test_parse_rest_json_error_info_without_body(
     )
     actual = await parse_rest_json_error_info(response, check_body=False)
     assert actual == expected
+
+
+async def test_parse_error_info_non_json_body() -> None:
+    response = HTTPResponse(
+        status=400,
+        fields=tuples_to_fields([]),
+        body=async_list(
+            [
+                (
+                    b"<html>\r\n<head><title>400 Bad Request</title></head>\r\n"
+                    b"<body>\r\n<center><h1>400 Bad Request</h1></center>\r\n</body>\r\n</html>\r\n"
+                )
+            ]
+        ),
+    )
+    expected = RestJsonErrorInfo("Unknown", "Unknown", None)
+    actual = await parse_rest_json_error_info(response, check_body=True)
+    assert actual == expected


### PR DESCRIPTION
This updates the JSON error info method to tolerate non-json bodies. These can occur sometimes when the server sends a pre-canned HTML response.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
