### PR TITLE
Rewind bodies before retrying

### DIFF
--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -334,7 +334,8 @@ final class ClientGenerator implements Runnable {
                                 except SmithyRetryException:
                                     raise context_with_response.response
                                 await sleep(retry_token.retry_delay)
-                                if (seek := getattr(context_with_transport_request.transport_request.body, "seek")) is not None:
+                                current_body =  context_with_transport_request.transport_request.body
+                                if (seek := getattr(current_body, "seek", None)) is not None:
                                     await seek(0)
                             else:
                                 # Step 8: Invoke record_success

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -334,6 +334,8 @@ final class ClientGenerator implements Runnable {
                                 except SmithyRetryException:
                                     raise context_with_response.response
                                 await sleep(retry_token.retry_delay)
+                                if (seek := getattr(context_with_transport_request.transport_request.body, "seek")) is not None:
+                                    await seek(0)
                             else:
                                 # Step 8: Invoke record_success
                                 retry_strategy.record_success(token=retry_token)

--- a/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/integration/RestJsonProtocolGenerator.java
@@ -138,7 +138,7 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     ) {
         writer.addDependency(SmithyPythonDependency.SMITHY_JSON);
         writer.addImport("smithy_json", "JSONCodec");
-        writer.addImport("smithy_core.aio.types", "AsyncBytesReader");
+        writer.addImport("smithy_core.aio.types", "SeekableAsyncBytesReader");
 
         writer.pushState();
 
@@ -146,7 +146,7 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
             var body = shouldWriteDefaultBody(context, operation) ? "b'{}'" : "b''";
             writer.write("""
                     content_length = 0
-                    body = AsyncBytesReader($L)
+                    body = SeekableAsyncBytesReader($L)
                     """, body);
         } else {
             writer.addImport("smithy_core.types", "TimestampFormat");
@@ -159,7 +159,7 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                         content = b'{}'
                     ${/writeDefaultBody}
                     content_length = len(content)
-                    body = AsyncBytesReader(content)
+                    body = SeekableAsyncBytesReader(content)
                     """);
         }
 
@@ -223,13 +223,13 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
             return;
         }
 
-        writer.addImport("smithy_core.aio.types", "AsyncBytesReader");
+        writer.addImport("smithy_core.aio.types", "SeekableAsyncBytesReader");
         writer.write("content_length: int = 0");
 
         CodegenUtils.accessStructureMember(context, writer, "input", payloadBinding.getMember(), () -> {
             if (target.isBlobShape()) {
                 writer.write("content_length = len($L)", dataSource);
-                writer.write("body = AsyncBytesReader($L)", dataSource);
+                writer.write("body = SeekableAsyncBytesReader($L)", dataSource);
                 return;
             }
 
@@ -244,13 +244,13 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                         """, dataSource);
             }
             writer.write("content_length = len(content)");
-            writer.write("body = AsyncBytesReader(content)");
+            writer.write("body = SeekableAsyncBytesReader(content)");
         });
         if (target.isStructureShape()) {
             writer.write("""
                 else:
                     content_length = 2
-                    body = AsyncBytesReader(b'{}')
+                    body = SeekableAsyncBytesReader(b'{}')
                 """);
         }
     }


### PR DESCRIPTION
Bodies weren't being rewound before a retry, which was causing some issues. Notably asyncio would hang forever awaiting the number of bytes we'd already declared in the content-length. But in general it just meant retries didn't work at all.

This updates the serializer to use a seekable stream wherever possible for non-streaming bodies. For streaming blobs, this was already being done where necessary.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
