### PR TITLE
Add GitHub Action to update Gradle wrapper

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,20 @@
+name: Update Gradle Wrapper
+# Needed because dependabot doesn't support updating the gradle wrapper
+# see: https://github.com/dependabot/dependabot-core/issues/2223
+
+on:
+  schedule:
+    # Run at midnight (UTC) every wednesday
+    - cron: "0 0 * * 3"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v2
+        with:
+          paths: codegen/**


### PR DESCRIPTION
This adds a GitHub Action that creates a pull request to update the gradle wrapper. We can't use dependabot for this because it doesn't support it (see https://github.com/dependabot/dependabot-core/issues/2223).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
