### PR TITLE
Update traits to allow for dynamically discoverable implementations

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SchemaGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SchemaGenerator.java
@@ -122,7 +122,7 @@ public final class SchemaGenerator implements Consumer<Shape> {
         writer.putContext("traits", traits);
         writer.write("""
                 ${#traits}
-                Trait(id=ShapeID(${key:S})${?value}, value=${value:N}${/value}),
+                Trait.new(id=ShapeID(${key:S})${?value}, value=${value:N}${/value}),
                 ${/traits}""");
         writer.popState();
     }

--- a/packages/aws-event-stream/src/aws_event_stream/_private/__init__.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/__init__.py
@@ -10,6 +10,6 @@ INITIAL_RESPONSE_EVENT_TYPE = "initial-response"
 
 def get_payload_member(schema: Schema) -> Schema | None:
     for member in schema.members.values():
-        if EventPayloadTrait.id in member.traits:
+        if EventPayloadTrait in member:
             return member
     return None

--- a/packages/aws-event-stream/src/aws_event_stream/_private/__init__.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from smithy_core.schemas import Schema
 
-from .traits import EVENT_PAYLOAD_TRAIT
+from smithy_core.traits import EventPayloadTrait
 
 INITIAL_REQUEST_EVENT_TYPE = "initial-request"
 INITIAL_RESPONSE_EVENT_TYPE = "initial-response"
@@ -10,6 +10,6 @@ INITIAL_RESPONSE_EVENT_TYPE = "initial-response"
 
 def get_payload_member(schema: Schema) -> Schema | None:
     for member in schema.members.values():
-        if EVENT_PAYLOAD_TRAIT in member.traits:
+        if EventPayloadTrait.id in member.traits:
             return member
     return None

--- a/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
@@ -158,10 +158,7 @@ class EventMessageDeserializer(SpecificShapeDeserializer):
         headers_deserializer = EventHeaderDeserializer(self._headers)
         for key in self._headers.keys():
             member_schema = schema.members.get(key)
-            if (
-                member_schema is not None
-                and EventHeaderTrait.id in member_schema.traits
-            ):
+            if member_schema is not None and EventHeaderTrait in member_schema:
                 consumer(member_schema, headers_deserializer)
 
         if self._payload_deserializer:

--- a/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
@@ -23,7 +23,7 @@ from . import (
     INITIAL_RESPONSE_EVENT_TYPE,
     get_payload_member,
 )
-from .traits import EVENT_HEADER_TRAIT
+from smithy_core.traits import EventHeaderTrait
 
 INITIAL_MESSAGE_TYPES = (INITIAL_REQUEST_EVENT_TYPE, INITIAL_RESPONSE_EVENT_TYPE)
 
@@ -158,7 +158,10 @@ class EventMessageDeserializer(SpecificShapeDeserializer):
         headers_deserializer = EventHeaderDeserializer(self._headers)
         for key in self._headers.keys():
             member_schema = schema.members.get(key)
-            if member_schema is not None and EVENT_HEADER_TRAIT in member_schema.traits:
+            if (
+                member_schema is not None
+                and EventHeaderTrait.id in member_schema.traits
+            ):
                 consumer(member_schema, headers_deserializer)
 
         if self._payload_deserializer:

--- a/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
@@ -102,7 +102,7 @@ class EventSerializer(SpecificShapeSerializer):
 
         headers_encoder = EventHeaderEncoder()
 
-        if ErrorTrait.id in schema.traits:
+        if ErrorTrait in schema:
             headers_encoder.encode_string(":message-type", "exception")
             headers_encoder.encode_string(
                 ":exception-type", schema.expect_member_name()
@@ -214,7 +214,7 @@ class EventStreamBindingSerializer(InterceptingSerializer):
         self._payload_struct_serializer = payload_struct_serializer
 
     def before(self, schema: "Schema") -> ShapeSerializer:
-        if EventHeaderTrait.id in schema.traits:
+        if EventHeaderTrait in schema:
             return self._header_serializer
         return self._payload_struct_serializer
 

--- a/packages/aws-event-stream/src/aws_event_stream/_private/traits.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/traits.py
@@ -1,9 +1,0 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-from smithy_core.shapes import ShapeID
-
-EVENT_HEADER_TRAIT = ShapeID("smithy.api#eventHeader")
-EVENT_PAYLOAD_TRAIT = ShapeID("smithy.api#eventPayload")
-ERROR_TRAIT = ShapeID("smithy.api#error")
-MEDIA_TYPE_TRAIT = ShapeID("smithy.api#mediaType")

--- a/packages/aws-event-stream/tests/unit/_private/__init__.py
+++ b/packages/aws-event-stream/tests/unit/_private/__init__.py
@@ -19,15 +19,21 @@ from smithy_core.prelude import (
 from smithy_core.schemas import Schema
 from smithy_core.serializers import ShapeSerializer
 from smithy_core.shapes import ShapeID, ShapeType
-from smithy_core.traits import Trait
+from smithy_core.traits import (
+    EventHeaderTrait,
+    EventPayloadTrait,
+    ErrorTrait,
+    RequiredTrait,
+    StreamingTrait,
+)
 
 from aws_event_stream.events import Byte, EventMessage, Long, Short
 
-EVENT_HEADER_TRAIT = Trait(id=ShapeID("smithy.api#eventHeader"))
-EVENT_PAYLOAD_TRAIT = Trait(id=ShapeID("smithy.api#eventPayload"))
-ERROR_TRAIT = Trait(id=ShapeID("smithy.api#error"), value="client")
-REQUIRED_TRAIT = Trait(id=ShapeID("smithy.api#required"))
-STREAMING_TRAIT = Trait(id=ShapeID("smith.api#streaming"))
+EVENT_HEADER_TRAIT = EventHeaderTrait()
+EVENT_PAYLOAD_TRAIT = EventPayloadTrait()
+ERROR_TRAIT = ErrorTrait("client")
+REQUIRED_TRAIT = RequiredTrait()
+STREAMING_TRAIT = StreamingTrait()
 
 
 SCHEMA_MESSAGE_EVENT = Schema.collection(

--- a/packages/smithy-core/src/smithy_core/prelude.py
+++ b/packages/smithy-core/src/smithy_core/prelude.py
@@ -4,7 +4,8 @@
 
 from .schemas import Schema
 from .shapes import ShapeID, ShapeType
-from .traits import Trait
+from .traits import DefaultTrait, UnitTypeTrait
+
 
 BLOB = Schema(
     id=ShapeID("smithy.api#Blob"),
@@ -71,54 +72,50 @@ DOCUMENT = Schema(
     shape_type=ShapeType.DOCUMENT,
 )
 
-
-_DEFAULT = ShapeID("smithy.api#default")
-
-
 PRIMITIVE_BOOLEAN = Schema(
     id=ShapeID("smithy.api#PrimitiveBoolean"),
     shape_type=ShapeType.BOOLEAN,
-    traits=[Trait(id=_DEFAULT, value=False)],
+    traits=[DefaultTrait(False)],
 )
 
 PRIMITIVE_BYTE = Schema(
     id=ShapeID("smithy.api#PrimitiveByte"),
     shape_type=ShapeType.BYTE,
-    traits=[Trait(id=_DEFAULT, value=0)],
+    traits=[DefaultTrait(0)],
 )
 
 PRIMITIVE_SHORT = Schema(
     id=ShapeID("smithy.api#PrimitiveShort"),
     shape_type=ShapeType.SHORT,
-    traits=[Trait(id=_DEFAULT, value=0)],
+    traits=[DefaultTrait(0)],
 )
 
 PRIMITIVE_INTEGER = Schema(
     id=ShapeID("smithy.api#PrimitiveInteger"),
     shape_type=ShapeType.INTEGER,
-    traits=[Trait(id=_DEFAULT, value=0)],
+    traits=[DefaultTrait(0)],
 )
 
 PRIMITIVE_LONG = Schema(
     id=ShapeID("smithy.api#PrimitiveLong"),
     shape_type=ShapeType.LONG,
-    traits=[Trait(id=_DEFAULT, value=0)],
+    traits=[DefaultTrait(0)],
 )
 
 PRIMITIVE_FLOAT = Schema(
     id=ShapeID("smithy.api#PrimitiveFloat"),
     shape_type=ShapeType.FLOAT,
-    traits=[Trait(id=_DEFAULT, value=0.0)],
+    traits=[DefaultTrait(0)],
 )
 
 PRIMITIVE_DOUBLE = Schema(
     id=ShapeID("smithy.api#PrimitiveDouble"),
     shape_type=ShapeType.DOUBLE,
-    traits=[Trait(id=_DEFAULT, value=0.0)],
+    traits=[DefaultTrait(0)],
 )
 
 UNIT = Schema(
     id=ShapeID("smithy.api#Unit"),
-    shape_type=ShapeType.DOUBLE,
-    traits=[Trait(id=ShapeID("smithy.api#UnitTypeTrait"))],
+    shape_type=ShapeType.STRUCTURE,
+    traits=[UnitTypeTrait()],
 )

--- a/packages/smithy-core/src/smithy_core/schemas.py
+++ b/packages/smithy-core/src/smithy_core/schemas.py
@@ -137,8 +137,18 @@ class Schema:
         :returns: A Trait if the trait class is known, a DynamicTrait if it isn't, or
             None if the trait is not present on the Schema.
         """
-        id = t if isinstance(t, ShapeID) else t.id
-        return self.traits.get(id)
+        if isinstance(t, ShapeID):
+            return self.traits.get(t)
+
+        result = self.traits.get(t.id)
+
+        # If the trait wasn't known when the schema was created, but is known now, go
+        # ahead and convert it.
+        if isinstance(result, DynamicTrait):
+            result = t(result)
+            self.traits[t.id] = result
+
+        return result
 
     @overload
     def expect_trait[T: "Trait"](self, t: type[T]) -> T: ...

--- a/packages/smithy-core/src/smithy_core/traits.py
+++ b/packages/smithy-core/src/smithy_core/traits.py
@@ -1,19 +1,195 @@
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# This ruff check warns against using the assert statement, which can be stripped out
+# when running Python with certain (common) optimization settings. Assert is used here
+# for trait values. Since these are always generated, we can be fairly confident that
+# they're correct regardless, so it's okay if the checks are stripped out.
+# ruff: noqa: S101
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, ClassVar
+
+from .types import TimestampFormat
+from .shapes import ShapeID
 
 if TYPE_CHECKING:
     from .documents import DocumentValue
-    from .shapes import ShapeID
 
 
-@dataclass(kw_only=True, frozen=True)
+@dataclass(kw_only=True, frozen=True, slots=True)
+class DynamicTrait:
+    """A component that can be attached to a schema to describe additional information
+    about it.
+
+    Typed traits can be used by creating a :py:class:`Trait` subclass.
+    """
+
+    id: ShapeID
+    """The ID of the trait."""
+
+    document_value: "DocumentValue" = None
+    """The value of the trait."""
+
+
+@dataclass(init=False, frozen=True)
 class Trait:
     """A component that can be attached to a schema to describe additional information
     about it.
 
-    :param id: The ID of the trait.
-    :param value: The document value of the trait.
+    This is a base class that registers subclasses. Any known subclasses will
+    automatically be used when constructing schemas. Any unknown traits may instead be
+    created as a :py:class:`DynamicTrait`.
+
+    The `id` property of subclasses is set during subclass creation by
+    `__init_subclass__`, so it is not necessary for subclasses to set it manually.
     """
 
-    id: "ShapeID"
-    value: "DocumentValue" = field(default_factory=dict)
+    _REGISTRY: ClassVar[dict[ShapeID, type["Trait"]]] = {}
+
+    id: ClassVar[ShapeID]
+    """The ID of the trait."""
+
+    document_value: "DocumentValue" = None
+    """The value of the trait as a DocumentValue."""
+
+    def __init_subclass__(cls, id: ShapeID) -> None:
+        cls.id = id
+        Trait._REGISTRY[id] = cls
+
+    def __init__(self, value: "DocumentValue | DynamicTrait" = None):
+        if type(self) is Trait:
+            raise TypeError(
+                "Only subclasses of Trait may be directly instantiated. "
+                "Use DynamicTrait for traits without a concrete class."
+            )
+
+        if isinstance(value, DynamicTrait):
+            if value.id != self.id:
+                raise ValueError(
+                    f"Attempted to instantiate an instance of {type(self)} from an "
+                    f"invalid ID. Expected {self.id} but found {value.id}."
+                )
+            # Note that setattr is needed because it's a frozen (read-only) dataclass
+            object.__setattr__(self, "document_value", value.document_value)
+        else:
+            object.__setattr__(self, "document_value", value)
+
+    # Dynamically creates a subclass instance based on the trait id
+    @staticmethod
+    def new(id: ShapeID, value: "DocumentValue" = None) -> "Trait | DynamicTrait":
+        """Dynamically create a new trait of the given ID.
+
+        If the ID corresponds to a known Trait class, that class will be instantiated
+        and returned. Otherwise, a :py:class:`DynamicTrait` will be returned.
+
+        :returns: A trait of the given ID with the given value.
+        """
+        if (cls := Trait._REGISTRY.get(id, None)) is not None:
+            return cls(value)
+        return DynamicTrait(id=id, document_value=value)
+
+
+@dataclass(init=False, frozen=True)
+class DefaultTrait(Trait, id=ShapeID("smithy.appi#default")):
+    @property
+    def value(self) -> "DocumentValue":
+        return self.document_value
+
+
+@dataclass(init=False, frozen=True)
+class SparseTrait(Trait, id=ShapeID("smithy.api#sparse")):
+    def __post_init__(self):
+        assert self.document_value is None
+
+
+@dataclass(init=False, frozen=True)
+class TimestampFormatTrait(Trait, id=ShapeID("smithy.api#timestampFormat")):
+    format: TimestampFormat
+
+    def __init__(self, value: "DocumentValue | DynamicTrait" = None):
+        super().__init__(value)
+        assert isinstance(self.document_value, str)
+        object.__setattr__(self, "format", TimestampFormat(self.document_value))
+
+
+class ErrorFault(Enum):
+    CLIENT = "client"
+    SERVER = "server"
+
+
+@dataclass(init=False, frozen=True)
+class ErrorTrait(Trait, id=ShapeID("smithy.api#error")):
+    fault: ErrorFault
+
+    def __init__(self, value: "DocumentValue | DynamicTrait" = None):
+        super().__init__(value)
+        assert isinstance(self.document_value, str)
+        object.__setattr__(self, "fault", ErrorFault(self.document_value))
+
+
+@dataclass(init=False, frozen=True)
+class RequiredTrait(Trait, id=ShapeID("smithy.api#required")):
+    def __post_init__(self):
+        assert self.document_value is None
+
+
+@dataclass(init=False, frozen=True)
+class InternalTrait(Trait, id=ShapeID("smithy.api#internal")):
+    def __post_init__(self):
+        assert self.document_value is None
+
+
+@dataclass(init=False, frozen=True)
+class SensitiveTrait(Trait, id=ShapeID("smithy.api#sensitive")):
+    def __post_init__(self):
+        assert self.document_value is None
+
+
+@dataclass(init=False, frozen=True)
+class StreamingTrait(Trait, id=ShapeID("smithy.api#streaming")):
+    def __post_init__(self):
+        assert self.document_value is None
+
+
+@dataclass(init=False, frozen=True)
+class UnitTypeTrait(Trait, id=ShapeID("smithy.api#UnitTypeTrait")):
+    def __post_init__(self):
+        assert self.document_value is None
+
+
+@dataclass(init=False, frozen=True)
+class MediaTypeTrait(Trait, id=ShapeID("smithy.api#mediaType")):
+    document_value: str | None = None
+
+    def __post_init__(self):
+        assert isinstance(self.document_value, str)
+
+    @property
+    def value(self) -> str:
+        return self.document_value  # type: ignore
+
+
+@dataclass(init=False, frozen=True)
+class EventHeaderTrait(Trait, id=ShapeID("smithy.api#eventheader")):
+    def __post_init__(self):
+        assert self.document_value is None
+
+
+@dataclass(init=False, frozen=True)
+class EventPayloadTrait(Trait, id=ShapeID("smithy.api#eventPayload")):
+    def __post_init__(self):
+        assert self.document_value is None
+
+
+@dataclass(init=False, frozen=True)
+class JSONNameTrait(Trait, id=ShapeID("smithy.api#jsonName")):
+    document_value: str | None = None
+
+    def __post_init__(self):
+        assert isinstance(self.document_value, str)
+
+    @property
+    def value(self) -> str:
+        return self.document_value  # type: ignore

--- a/packages/smithy-core/tests/unit/test_documents.py
+++ b/packages/smithy-core/tests/unit/test_documents.py
@@ -27,7 +27,8 @@ from smithy_core.prelude import (
 from smithy_core.schemas import Schema
 from smithy_core.serializers import ShapeSerializer
 from smithy_core.shapes import ShapeID, ShapeType
-from smithy_core.traits import Trait
+
+from smithy_core.traits import SparseTrait
 
 
 @pytest.mark.parametrize(
@@ -515,7 +516,6 @@ def test_is_none():
     assert not Document("foo").is_none()
 
 
-SPARSE_TRAIT = Trait(id=ShapeID("smithy.api#sparse"))
 STRING_LIST_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringList"),
     shape_type=ShapeType.LIST,
@@ -533,7 +533,7 @@ SPARSE_STRING_LIST_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringList"),
     shape_type=ShapeType.LIST,
     members={"member": {"target": STRING, "index": 0}},
-    traits=[SPARSE_TRAIT],
+    traits=[SparseTrait()],
 )
 SPARSE_STRING_MAP_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringMap"),
@@ -542,7 +542,7 @@ SPARSE_STRING_MAP_SCHEMA = Schema.collection(
         "key": {"target": STRING, "index": 0},
         "value": {"target": STRING, "index": 1},
     },
-    traits=[SPARSE_TRAIT],
+    traits=[SparseTrait()],
 )
 SCHEMA: Schema = Schema.collection(
     id=ShapeID("smithy.example#DocumentSerdeShape"),

--- a/packages/smithy-core/tests/unit/test_schemas.py
+++ b/packages/smithy-core/tests/unit/test_schemas.py
@@ -5,17 +5,40 @@ import pytest
 from smithy_core.exceptions import ExpectationNotMetException
 from smithy_core.schemas import Schema
 from smithy_core.shapes import ShapeID, ShapeType
-from smithy_core.traits import Trait
+from smithy_core.traits import InternalTrait, DynamicTrait, SensitiveTrait
 
 ID: ShapeID = ShapeID("ns.foo#bar")
 STRING = Schema(id=ShapeID("smithy.api#String"), shape_type=ShapeType.STRING)
 
 
 def test_traits_list():
-    trait_id = ShapeID("smithy.api#internal")
-    trait = Trait(id=trait_id, value=True)
+    trait = InternalTrait()
     schema = Schema(id=ID, shape_type=ShapeType.STRUCTURE, traits=[trait])
-    assert schema.traits == {trait_id: trait}
+    assert schema.traits == {InternalTrait.id: trait}
+
+
+def test_get_trait_by_class():
+    trait = InternalTrait()
+    schema = Schema(id=ID, shape_type=ShapeType.STRUCTURE, traits=[trait])
+    assert schema.get_trait(InternalTrait) is trait
+
+
+def test_get_unknown_trait_by_class():
+    trait = InternalTrait()
+    schema = Schema(id=ID, shape_type=ShapeType.STRUCTURE, traits=[trait])
+    assert schema.get_trait(SensitiveTrait) is None
+
+
+def test_get_trait_by_id():
+    trait = InternalTrait()
+    schema = Schema(id=ID, shape_type=ShapeType.STRUCTURE, traits=[trait])
+    assert schema.get_trait(InternalTrait.id) is trait
+
+
+def test_get_unknown_trait_by_id():
+    trait = InternalTrait()
+    schema = Schema(id=ID, shape_type=ShapeType.STRUCTURE, traits=[trait])
+    assert schema.get_trait(SensitiveTrait.id) is None
 
 
 def test_members_list():
@@ -59,7 +82,7 @@ def test_member_expectations_raise_on_non_members():
 
 
 def test_collection_constructor():
-    trait_value = Trait(id=ShapeID("smithy.example#trait"), value="foo")
+    trait_value = DynamicTrait(id=ShapeID("smithy.example#trait"), document_value="foo")
     member_name = "baz"
     member = Schema(
         id=ID.with_member(member_name),
@@ -79,8 +102,8 @@ def test_member_constructor():
     target = Schema.collection(
         id=ShapeID("smithy.example#target"),
         traits=[
-            Trait(id=ShapeID("smithy.api#sensitive")),
-            Trait(id=ShapeID("smithy.example#foo"), value="bar"),
+            SensitiveTrait(),
+            DynamicTrait(id=ShapeID("smithy.example#foo"), document_value="bar"),
         ],
         members={"spam": {"target": STRING, "index": 0}},
     )
@@ -92,8 +115,8 @@ def test_member_constructor():
         member_target=target,
         member_index=1,
         traits=[
-            Trait(id=ShapeID("smithy.api#sensitive")),
-            Trait(id=ShapeID("smithy.example#foo"), value="baz"),
+            SensitiveTrait(),
+            DynamicTrait(id=ShapeID("smithy.example#foo"), document_value="baz"),
         ],
     )
 
@@ -101,7 +124,9 @@ def test_member_constructor():
         id=member_id,
         target=target,
         index=1,
-        member_traits=[Trait(id=ShapeID("smithy.example#foo"), value="baz")],
+        member_traits=[
+            DynamicTrait(id=ShapeID("smithy.example#foo"), document_value="baz")
+        ],
     )
 
     assert actual == expected

--- a/packages/smithy-core/tests/unit/test_traits.py
+++ b/packages/smithy-core/tests/unit/test_traits.py
@@ -1,0 +1,58 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+
+from smithy_core.traits import (
+    DynamicTrait,
+    Trait,
+    ErrorTrait,
+    ErrorFault,
+    JSONNameTrait,
+)
+from smithy_core.shapes import ShapeID
+
+import pytest
+
+
+def test_trait_factory_constructs_dynamic_trait():
+    trait_id = ShapeID("com.example#foo")
+    document_value = "bar"
+    trait = Trait.new(id=trait_id, value=document_value)
+    assert isinstance(trait, DynamicTrait)
+    assert trait.id == trait_id
+    assert trait.document_value == document_value
+
+
+def test_trait_factory_constructs_prelude_trait():
+    trait = Trait.new(ErrorTrait.id, "client")
+    assert isinstance(trait, ErrorTrait)
+    assert trait.fault is ErrorFault.CLIENT
+
+
+def test_trait_factory_constructs_new_trait():
+    trait_id = ShapeID("com.example#newTrait")
+
+    @dataclass(init=False, frozen=True)
+    class NewTrait(Trait, id=trait_id):
+        pass
+
+    trait = Trait.new(trait_id)
+    assert isinstance(trait, NewTrait)
+    assert NewTrait.id is trait_id
+
+
+def test_cant_construct_base_trait():
+    with pytest.raises(TypeError):
+        Trait("foo")
+
+
+def test_construct_from_dynamic_trait():
+    dynamic = DynamicTrait(id=ErrorTrait.id, document_value="server")
+    static = ErrorTrait(dynamic)
+    assert static.fault is ErrorFault.SERVER
+
+
+def test_cant_construct_trait_from_non_matching_dynamic_trait():
+    dynamic = DynamicTrait(id=JSONNameTrait.id, document_value="client")
+    with pytest.raises(ValueError):
+        ErrorTrait(dynamic)

--- a/packages/smithy-json/src/smithy_json/_private/deserializers.py
+++ b/packages/smithy-json/src/smithy_json/_private/deserializers.py
@@ -18,7 +18,7 @@ from smithy_core.shapes import ShapeID, ShapeType
 from smithy_core.types import TimestampFormat
 
 from .documents import JSONDocument
-from .traits import JSON_NAME, TIMESTAMP_FORMAT
+from smithy_core.traits import TimestampFormatTrait, JSONNameTrait
 
 # TODO: put these type hints in a pyi somewhere. There here because ijson isn't
 # typed.
@@ -191,8 +191,8 @@ class JSONShapeDeserializer(ShapeDeserializer):
     def read_timestamp(self, schema: Schema) -> datetime.datetime:
         format = self._default_timestamp_format
         if self._use_timestamp_format:
-            if format_trait := schema.traits.get(TIMESTAMP_FORMAT):
-                format = TimestampFormat(format_trait.value)
+            if format_trait := schema.get_trait(TimestampFormatTrait):
+                format = format_trait.format
 
         match format:
             case TimestampFormat.EPOCH_SECONDS:
@@ -234,8 +234,8 @@ class JSONShapeDeserializer(ShapeDeserializer):
         result: dict[str, str] = {}
         for member_name, member_schema in schema.members.items():
             name: str = member_name
-            if json_name := member_schema.traits.get(JSON_NAME):
-                name = cast(str, json_name.value)
+            if json_name := member_schema.get_trait(JSONNameTrait):
+                name = json_name.value
             result[name] = member_name
         self._json_names[schema.id] = result
 

--- a/packages/smithy-json/src/smithy_json/_private/serializers.py
+++ b/packages/smithy-json/src/smithy_json/_private/serializers.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from decimal import Decimal
 from io import BufferedWriter, RawIOBase
 from types import TracebackType
-from typing import Self, cast
+from typing import Self
 
 from smithy_core.documents import Document, DocumentValue
 from smithy_core.interfaces import BytesWriter
@@ -19,9 +19,9 @@ from smithy_core.serializers import (
     ShapeSerializer,
 )
 from smithy_core.types import TimestampFormat
+from smithy_core.traits import TimestampFormatTrait, JSONNameTrait
 
 from . import Flushable
-from .traits import JSON_NAME, TIMESTAMP_FORMAT
 
 _INF: float = float("inf")
 _NEG_INF: float = float("-inf")
@@ -84,8 +84,8 @@ class JSONShapeSerializer(ShapeSerializer):
     def write_timestamp(self, schema: "Schema", value: datetime) -> None:
         format = self._default_timestamp_format
         if self._use_timestamp_format:
-            if format_trait := schema.traits.get(TIMESTAMP_FORMAT):
-                format = TimestampFormat(format_trait.value)
+            if format_trait := schema.get_trait(TimestampFormatTrait):
+                format = format_trait.format
 
         self._stream.write_document_value(format.serialize(value))
 
@@ -132,8 +132,8 @@ class JSONStructSerializer(InterceptingSerializer):
             self._stream.write_more()
 
         member_name = schema.expect_member_name()
-        if self._use_json_name and (json_name := schema.traits.get(JSON_NAME)):
-            member_name = cast(str, json_name.value)
+        if self._use_json_name and (json_name := schema.get_trait(JSONNameTrait)):
+            member_name = json_name.value
 
         self._stream.write_key(member_name)
         return self._parent

--- a/packages/smithy-json/src/smithy_json/_private/traits.py
+++ b/packages/smithy-json/src/smithy_json/_private/traits.py
@@ -1,7 +1,0 @@
-#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#  SPDX-License-Identifier: Apache-2.0
-
-from smithy_core.shapes import ShapeID
-
-JSON_NAME = ShapeID("smithy.api#jsonName")
-TIMESTAMP_FORMAT = ShapeID("smithy.api#timestampFormat")

--- a/packages/smithy-json/tests/unit/__init__.py
+++ b/packages/smithy-json/tests/unit/__init__.py
@@ -18,11 +18,10 @@ from smithy_core.prelude import (
 from smithy_core.schemas import Schema
 from smithy_core.serializers import ShapeSerializer
 from smithy_core.shapes import ShapeID, ShapeType
-from smithy_core.traits import Trait
 
-from smithy_json._private.traits import JSON_NAME, TIMESTAMP_FORMAT
+from smithy_core.traits import TimestampFormatTrait, JSONNameTrait, SparseTrait
 
-SPARSE_TRAIT = Trait(id=ShapeID("smithy.api#sparse"))
+
 STRING_LIST_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringList"),
     shape_type=ShapeType.LIST,
@@ -40,7 +39,7 @@ SPARSE_STRING_LIST_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringList"),
     shape_type=ShapeType.LIST,
     members={"member": {"target": STRING, "index": 0}},
-    traits=[SPARSE_TRAIT],
+    traits=[SparseTrait()],
 )
 SPARSE_STRING_MAP_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringMap"),
@@ -49,7 +48,7 @@ SPARSE_STRING_MAP_SCHEMA = Schema.collection(
         "key": {"target": STRING, "index": 0},
         "value": {"target": STRING, "index": 1},
     },
-    traits=[SPARSE_TRAIT],
+    traits=[SparseTrait()],
 )
 SCHEMA: Schema = Schema.collection(
     id=ShapeID("smithy.example#SerdeShape"),
@@ -61,24 +60,24 @@ SCHEMA: Schema = Schema.collection(
         "stringMember": {"target": STRING, "index": 4},
         "jsonNameMember": {
             "target": STRING,
-            "traits": [Trait(id=JSON_NAME, value="jsonName")],
+            "traits": [JSONNameTrait("jsonName")],
             "index": 5,
         },
         "blobMember": {"target": BLOB, "index": 6},
         "timestampMember": {"target": TIMESTAMP, "index": 7},
         "dateTimeMember": {
             "target": TIMESTAMP,
-            "traits": [Trait(id=TIMESTAMP_FORMAT, value="date-time")],
+            "traits": [TimestampFormatTrait("date-time")],
             "index": 8,
         },
         "httpDateMember": {
             "target": TIMESTAMP,
-            "traits": [Trait(id=TIMESTAMP_FORMAT, value="http-date")],
+            "traits": [TimestampFormatTrait("http-date")],
             "index": 9,
         },
         "epochSecondsMember": {
             "target": TIMESTAMP,
-            "traits": [Trait(id=TIMESTAMP_FORMAT, value="epoch-seconds")],
+            "traits": [TimestampFormatTrait("epoch-seconds")],
             "index": 10,
         },
         "documentMember": {"target": DOCUMENT, "index": 11},


### PR DESCRIPTION
This updates the design for traits from being simple bags of loosely typed data. Now traits may instead have concrete implementations that are discoverable dynamically simply by implementing the relevant subclass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
