### PR TITLE
Add basic logging

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -327,7 +327,7 @@ final class ClientGenerator implements Runnable {
                                 except SmithyRetryException:
                                     raise context_with_response.response
                                 logger.debug(
-                                    "Retry needed. Attempting request #%s in %s seconds.",
+                                    "Retry needed. Attempting request #%s in %.4f seconds.",
                                     retry_token.retry_count + 1,
                                     retry_token.retry_delay
                                 )

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -229,7 +229,7 @@ final class ClientGenerator implements Runnable {
                     event_response_deserializer: DeserializeableShape | None = None,
                     ${/hasEventStream}
                 ) -> Output:
-                    logger.debug(f"Making request for operation {operation_name} with parameters: {input}")
+                    logger.debug('Making request for operation "%s" with parameters: %s', operation_name, input)
                     context: InterceptorContext[Input, None, None, None] = InterceptorContext(
                         request=input,
                         response=None,
@@ -326,17 +326,26 @@ final class ClientGenerator implements Runnable {
                                     )
                                 except SmithyRetryException:
                                     raise context_with_response.response
+                                logger.debug(
+                                    "Retry needed. Attempting request #%s in %s seconds.",
+                                    retry_token.retry_count + 1,
+                                    retry_token.retry_delay
+                                )
                                 await sleep(retry_token.retry_delay)
                                 current_body =  context_with_transport_request.transport_request.body
                                 if (seek := getattr(current_body, "seek", None)) is not None:
                                     await seek(0)
                             else:
                                 # Step 8: Invoke record_success
+                                logger.debug(
+                                    "Attempt %s succeeded. Not retrying request.",
+                                    retry_token.retry_count + 1
+                                )
                                 retry_strategy.record_success(token=retry_token)
                                 break
                     except Exception as e:
                         if context.response is not None:
-                            logger.exception(f"Exception occurred while handling: {context.response}")
+                            logger.exception("Exception occurred while handling: %s", context.response)
                             pass
                         context._response = e
 
@@ -443,10 +452,12 @@ final class ClientGenerator implements Runnable {
                                 raise $1T(
                                     "No endpoint_uri found on the operation config."
                                 )
-
+                            endpoint_resolver_parameters = StaticEndpointParams(uri=config.endpoint_uri)
+                            logger.debug("Calling endpoint resolver with parameters: %s", endpoint_resolver_parameters)
                             endpoint = await config.endpoint_resolver.resolve_endpoint(
-                                StaticEndpointParams(uri=config.endpoint_uri)
+                                endpoint_resolver_parameters
                             )
+                            logger.debug("Endpoint resolver result: %s", endpoint)
                             if not endpoint.uri.path:
                                 path = ""
                             elif endpoint.uri.path.endswith("/"):
@@ -484,6 +495,11 @@ final class ClientGenerator implements Runnable {
             writer.write("""
                             # Step 7i: sign the request
                             if auth_option and signer:
+                                logger.debug("HTTP request to sign: %s", context.transport_request)
+                                logger.debug(
+                                    "Signer properties: %s",
+                                    auth_option.signer_properties
+                                )
                                 context._transport_request = await signer.sign(
                                     http_request=context.transport_request,
                                     identity=identity,
@@ -518,10 +534,13 @@ final class ClientGenerator implements Runnable {
                             context_with_response = cast(
                                 InterceptorContext[Input, None, $1T, $2T], context
                             )
+                            logger.debug("HTTP request config: %s", request_config)
+                            logger.debug("Sending HTTP request: %s", context_with_response.transport_request)
                             context_with_response._transport_response = await config.http_client.send(
                                 request=context_with_response.transport_request,
                                 request_config=request_config,
                             )
+                            logger.debug("Received HTTP response: %s", context_with_response.transport_response)
 
                     """, transportRequest, transportResponse);
         }
@@ -556,7 +575,7 @@ final class ClientGenerator implements Runnable {
                             interceptor.read_after_deserialization(context_with_output)
                     except Exception as e:
                         if context.response is not None:
-                            logger.exception(f"Exception occurred while handling: {context.response}")
+                            logger.exception("Exception occurred while handling: %s", context.response)
                             pass
                         context._response = e
 
@@ -582,7 +601,7 @@ final class ClientGenerator implements Runnable {
                             )
                     except Exception as e:
                         if context.response is not None:
-                            logger.exception(f"Exception occurred while handling: {context.response}")
+                            logger.exception("Exception occurred while handling: %s", context.response)
                             pass
                         context._response = e
 
@@ -592,7 +611,7 @@ final class ClientGenerator implements Runnable {
                             interceptor.read_after_attempt(context)
                         except Exception as e:
                             if context.response is not None:
-                                logger.exception(f"Exception occurred while handling: {context.response}")
+                                logger.exception("Exception occurred while handling: %s", context.response)
                                 pass
                             context._response = e
 
@@ -613,11 +632,11 @@ final class ClientGenerator implements Runnable {
                             pass
                         except Exception as e:
                             # log and ignore exceptions
-                            logger.exception(f"Exception occurred while dispatching trace events: {e}")
+                            logger.exception("Exception occurred while dispatching trace events: %s", e)
                             pass
                     except Exception as e:
                         if context.response is not None:
-                            logger.exception(f"Exception occurred while handling: {context.response}")
+                            logger.exception("Exception occurred while handling: %s", context.response)
                             pass
                         context._response = e
 
@@ -627,7 +646,7 @@ final class ClientGenerator implements Runnable {
                             interceptor.read_after_execution(context)
                         except Exception as e:
                             if context.response is not None:
-                                logger.exception(f"Exception occurred while handling: {context.response}")
+                                logger.exception("Exception occurred while handling: %s", context.response)
                                 pass
                             context._response = e
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -412,7 +412,7 @@ public final class StructureGenerator implements Runnable {
                         match schema.expect_member_index():
                             ${C|}
                             case _:
-                                logger.debug(f"Unexpected member schema: {schema}")
+                                logger.debug("Unexpected member schema: %s", schema)
 
                     deserializer.read_struct($T, consumer=_consumer)
                     return kwargs

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
@@ -162,7 +162,7 @@ public final class UnionGenerator implements Runnable {
                         match schema.expect_member_index():
                             ${4C|}
                             case _:
-                                logger.debug(f"Unexpected member schema: {schema}")
+                                logger.debug("Unexpected member schema: %s", schema)
 
                     def _set_result(self, value: $2T) -> None:
                         if self._result is not None:


### PR DESCRIPTION
### Overview
This PR adds the following:
- Basic logging for request and response information.
- Transitions to lazy string formatting to prevent eager evaluation. This approach defers the construction of log messages until they are actually needed, improving performance and consistency.
- Updates codegen logic for determining if a structure's member is sensitive. We currently check if the member itself has a sensitive trait however, the `sensitive` trait can only target _"Any shape that is not a service, operation, resource, or member."_. We instead now check the targeted shape for the `sensitive` trait.

### Why avoid f-strings in logging?
Using f-strings require Python to evaluate their expressions immediately, meaning that the log message is fully formatted regardless of whether it will be output (e.g., if the log level filters it out). Customers who don't configure logs would still experience the performance hit that comes with evaluating log statements.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
