### PR TITLE
Move aws-sdk-signers project format inline with other packages

### DIFF
--- a/packages/aws-sdk-signers/pyproject.toml
+++ b/packages/aws-sdk-signers/pyproject.toml
@@ -1,9 +1,6 @@
-[build-system]
-requires = ["setuptools", "setuptools-scm", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "aws_sdk_signers"
+version = "0.0.2"
 requires-python = ">=3.12"
 authors = [
   {name = "Amazon Web Services"},
@@ -26,13 +23,15 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Libraries"
 ]
-dynamic = ["version"]
 
-[tool.setuptools.dynamic]
-version = {attr = "aws_sdk_signers._version.__version__"}
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.setuptools]
-include-package-data = false
+[tool.hatch.build]
+exclude = [
+ "tests",
+]
 
 [project.optional-dependencies]
 test = [
@@ -42,10 +41,6 @@ test = [
     "mypy",
     "ruff",
 ]
-
-[tool.mypy]
-python_version = "3.12"
-strict = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
@@ -4,15 +4,15 @@
 such as AioHTTP, Curl, Postman, Requests, urllib3, etc."""
 
 from __future__ import annotations
+import importlib.metadata
 
 from ._http import URI, AWSRequest, Field, Fields
 from ._identity import AWSCredentialIdentity
 from ._io import AsyncBytesReader
-from ._version import __version__
 from .signers import AsyncSigV4Signer, SigV4Signer, SigV4SigningProperties
 
 __license__ = "Apache-2.0"
-__version__ = __version__
+__version__ = importlib.metadata.version("aws-sdk-signers")
 
 __all__ = (
     "AsyncBytesReader",

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/_version.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/_version.py
@@ -1,7 +1,0 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-# This file is protected via CODEOWNERS
-from __future__ import annotations
-
-__version__ = "0.0.2"

--- a/uv.lock
+++ b/uv.lock
@@ -110,6 +110,7 @@ requires-dist = [
 
 [[package]]
 name = "aws-sdk-signers"
+version = "0.0.2"
 source = { editable = "packages/aws-sdk-signers" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
*Description of changes:*
Follow up from #399 bringing `aws-sdk-signers` package inline with other projects for both versioning and build system.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
