### PR TITLE
Add Support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.12", "3.13"]
 
     steps:
       - name: Checkout Repository

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
@@ -82,7 +82,8 @@ public final class SetupGenerator {
                         "Programming Language :: Python",
                         "Programming Language :: Python :: 3",
                         "Programming Language :: Python :: 3 :: Only",
-                        "Programming Language :: Python :: 3.12"
+                        "Programming Language :: Python :: 3.12",
+                        "Programming Language :: Python :: 3.13"
                     ]
                     """, settings.moduleName(), settings.moduleVersion(), settings.moduleDescription());
 

--- a/packages/aws-sdk-signers/pyproject.toml
+++ b/packages/aws-sdk-signers/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Libraries"
 ]


### PR DESCRIPTION
### Summary
This PR adds Python 3.13 to the list of versions our CI runs on. Additionally, it adds the `Programming Language :: Python :: 3.12` classifier to existing classifier lists. This matches our supported python version range (`requires-python = ">=3.12"`). 

> [!NOTE]  
> Note: As of the time of this PR, the `Programming Language :: Python :: 3.14` classifier is available, however, 3.14 is still in the alpha stage and not scheduled to be released until October 2025.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
