### PR TITLE
Add logging for input and output event streams

### DIFF
--- a/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
@@ -58,8 +58,9 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
             raise
 
         if event is None:
+            logger.debug("No event received from the source.")
             return None
-        logger.debug("Received raw event message: %s", event)
+        logger.debug("Received raw event: %s", event)
 
         deserializer = EventDeserializer(
             event=event,
@@ -67,7 +68,7 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
             is_client_mode=self._is_client_mode,
         )
         result = self._deserializer(deserializer)
-        logger.debug("Deserialized event message: %s", result)
+        logger.debug("Successfully deserialized event: %s", result)
         if isinstance(getattr(result, "value"), Exception):
             raise result.value  # type: ignore
         return result

--- a/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 import datetime
+import logging
 from collections.abc import Callable
 
 from smithy_core.aio.interfaces import AsyncByteStream
@@ -24,6 +25,8 @@ from . import (
     get_payload_member,
 )
 from smithy_core.traits import EventHeaderTrait
+
+logger = logging.getLogger(__name__)
 
 INITIAL_MESSAGE_TYPES = (INITIAL_REQUEST_EVENT_TYPE, INITIAL_RESPONSE_EVENT_TYPE)
 
@@ -56,6 +59,7 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
 
         if event is None:
             return None
+        logger.debug("Received raw event message: %s", event)
 
         deserializer = EventDeserializer(
             event=event,
@@ -63,6 +67,7 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
             is_client_mode=self._is_client_mode,
         )
         result = self._deserializer(deserializer)
+        logger.debug("Deserialized event message: %s", result)
         if isinstance(getattr(result, "value"), Exception):
             raise result.value  # type: ignore
         return result

--- a/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
@@ -26,7 +26,7 @@ from . import (
 )
 from smithy_core.traits import EventHeaderTrait
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 INITIAL_MESSAGE_TYPES = (INITIAL_REQUEST_EVENT_TYPE, INITIAL_RESPONSE_EVENT_TYPE)
 
@@ -58,9 +58,9 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
             raise
 
         if event is None:
-            LOGGER.debug("No event received from the source.")
+            logger.debug("No event received from the source.")
             return None
-        LOGGER.debug("Received raw event: %s", event)
+        logger.debug("Received raw event: %s", event)
 
         deserializer = EventDeserializer(
             event=event,
@@ -68,7 +68,7 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
             is_client_mode=self._is_client_mode,
         )
         result = self._deserializer(deserializer)
-        LOGGER.debug("Successfully deserialized event: %s", result)
+        logger.debug("Successfully deserialized event: %s", result)
         if isinstance(getattr(result, "value"), Exception):
             raise result.value  # type: ignore
         return result

--- a/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
@@ -26,7 +26,7 @@ from . import (
 )
 from smithy_core.traits import EventHeaderTrait
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 INITIAL_MESSAGE_TYPES = (INITIAL_REQUEST_EVENT_TYPE, INITIAL_RESPONSE_EVENT_TYPE)
 
@@ -58,9 +58,9 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
             raise
 
         if event is None:
-            logger.debug("No event received from the source.")
+            LOGGER.debug("No event received from the source.")
             return None
-        logger.debug("Received raw event: %s", event)
+        LOGGER.debug("Received raw event: %s", event)
 
         deserializer = EventDeserializer(
             event=event,
@@ -68,7 +68,7 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
             is_client_mode=self._is_client_mode,
         )
         result = self._deserializer(deserializer)
-        logger.debug("Successfully deserialized event: %s", result)
+        LOGGER.debug("Successfully deserialized event: %s", result)
         if isinstance(getattr(result, "value"), Exception):
             raise result.value  # type: ignore
         return result

--- a/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
@@ -58,7 +58,7 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
     async def send(self, event: E) -> None:
         if self._closed:
             raise IOError("Attempted to write to closed stream.")
-        logger.debug("Raw event message: %s", event)
+        logger.debug("Preparing to publish event: %s", event)
         event.serialize(self._serializer)
         result = self._serializer.get_result()
         if result is None:
@@ -70,7 +70,7 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
 
         encoded_result = result.encode()
         try:
-            logger.debug("Writing event message: %s", result)
+            logger.debug("Publishing serialized event: %s", result)
             await self._writer.write(encoded_result)
         except Exception as e:
             await self.close()

--- a/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
@@ -30,7 +30,7 @@ from . import (
 )
 from smithy_core.traits import ErrorTrait, EventHeaderTrait, MediaTypeTrait
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 _DEFAULT_STRING_CONTENT_TYPE = "text/plain"
 _DEFAULT_BLOB_CONTENT_TYPE = "application/octet-stream"
@@ -58,7 +58,7 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
     async def send(self, event: E) -> None:
         if self._closed:
             raise IOError("Attempted to write to closed stream.")
-        LOGGER.debug("Preparing to publish event: %s", event)
+        logger.debug("Preparing to publish event: %s", event)
         event.serialize(self._serializer)
         result = self._serializer.get_result()
         if result is None:
@@ -70,7 +70,7 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
 
         encoded_result = result.encode()
         try:
-            LOGGER.debug("Publishing serialized event: %s", result)
+            logger.debug("Publishing serialized event: %s", result)
             await self._writer.write(encoded_result)
         except Exception as e:
             await self.close()

--- a/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
@@ -75,7 +75,6 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
         except Exception as e:
             await self.close()
             raise IOError("Failed to write to stream.") from e
-        await self._writer.write(result.encode())
 
     async def close(self) -> None:
         if self._closed:

--- a/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
@@ -30,7 +30,7 @@ from . import (
 )
 from smithy_core.traits import ErrorTrait, EventHeaderTrait, MediaTypeTrait
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_STRING_CONTENT_TYPE = "text/plain"
 _DEFAULT_BLOB_CONTENT_TYPE = "application/octet-stream"
@@ -58,7 +58,7 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
     async def send(self, event: E) -> None:
         if self._closed:
             raise IOError("Attempted to write to closed stream.")
-        logger.debug("Preparing to publish event: %s", event)
+        LOGGER.debug("Preparing to publish event: %s", event)
         event.serialize(self._serializer)
         result = self._serializer.get_result()
         if result is None:
@@ -70,7 +70,7 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
 
         encoded_result = result.encode()
         try:
-            logger.debug("Publishing serialized event: %s", result)
+            LOGGER.debug("Publishing serialized event: %s", result)
             await self._writer.write(encoded_result)
         except Exception as e:
             await self.close()

--- a/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 import datetime
+import logging
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from io import BytesIO
@@ -29,6 +30,8 @@ from . import (
 )
 from smithy_core.traits import ErrorTrait, EventHeaderTrait, MediaTypeTrait
 
+logger = logging.getLogger(__name__)
+
 _DEFAULT_STRING_CONTENT_TYPE = "text/plain"
 _DEFAULT_BLOB_CONTENT_TYPE = "application/octet-stream"
 
@@ -55,6 +58,7 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
     async def send(self, event: E) -> None:
         if self._closed:
             raise IOError("Attempted to write to closed stream.")
+        logger.debug("Raw event message: %s", event)
         event.serialize(self._serializer)
         result = self._serializer.get_result()
         if result is None:
@@ -66,10 +70,12 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
 
         encoded_result = result.encode()
         try:
+            logger.debug("Writing event message: %s", result)
             await self._writer.write(encoded_result)
         except Exception as e:
             await self.close()
             raise IOError("Failed to write to stream.") from e
+        await self._writer.write(result.encode())
 
     async def close(self) -> None:
         if self._closed:


### PR DESCRIPTION
### Summary
This PR adds logging for input and output event streams. Specifically, we will log events before and after serialization/deserialization.

### Input Example
```
DEBUG:aws_event_stream._private.serializers:Preparing to publish event: EventsSimpleEvent(value=SimpleEvent(message='test'))
DEBUG:aws_event_stream._private.serializers:Publishing serialized event: EventMessage(headers={':message-type': 'event', ':event-type': 'simpleEvent', ':content-type': 'application/json'}, payload=b'{"message":"test"}')
DEBUG:aws_event_stream._private.serializers:Preparing to publish event: EventsSimpleEvent(value=SimpleEvent(message='test2'))
DEBUG:aws_event_stream._private.serializers:Publishing serialized event: EventMessage(headers={':message-type': 'event', ':event-type': 'simpleEvent', ':content-type': 'application/json'}, payload=b'{"message":"test2"}')
DEBUG:aws_event_stream._private.serializers:Preparing to publish event: EventsSimpleEvent(value=SimpleEvent(message='test3'))
DEBUG:aws_event_stream._private.serializers:Publishing serialized event: EventMessage(headers={':message-type': 'event', ':event-type': 'simpleEvent', ':content-type': 'application/json'}, payload=b'{"message":"test3"}')
```

### Output Example
```
DEBUG:aws_event_stream._private.deserializers:Received raw event: Event(prelude=EventPrelude(total_length=115, headers_length=81, crc=3342607380), message=EventMessage(headers={':message-type': 'event', ':event-type': 'simpleEvent', ':content-type': 'application/json'}, payload=b'{"message":"test"}'), crc=2514834424)
DEBUG:aws_event_stream._private.deserializers:Successfully deserialized event: EventsSimpleEvent(value=SimpleEvent(message='test'))
DEBUG:aws_event_stream._private.deserializers:Received raw event: Event(prelude=EventPrelude(total_length=116, headers_length=81, crc=1964832772), message=EventMessage(headers={':message-type': 'event', ':event-type': 'simpleEvent', ':content-type': 'application/json'}, payload=b'{"message":"test2"}'), crc=3383786838)
DEBUG:aws_event_stream._private.deserializers:Successfully deserialized event: EventsSimpleEvent(value=SimpleEvent(message='test2'))
DEBUG:aws_event_stream._private.deserializers:Received raw event: Event(prelude=EventPrelude(total_length=116, headers_length=81, crc=1964832772), message=EventMessage(headers={':message-type': 'event', ':event-type': 'simpleEvent', ':content-type': 'application/json'}, payload=b'{"message":"test3"}'), crc=3362920289)
DEBUG:aws_event_stream._private.deserializers:Successfully deserialized event: EventsSimpleEvent(value=SimpleEvent(message='test3'))
DEBUG:aws_event_stream._private.deserializers:No event received from the source.
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
