### PR TITLE
Default to CRT HTTP Client for all EventStreams

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -40,6 +40,24 @@ public final class SmithyPythonDependency {
             false);
 
     /**
+     * The awscrt package.
+     */
+    public static final PythonDependency AWS_CRT = new PythonDependency(
+            "awscrt",
+            ">=0.23.10",
+            Type.DEPENDENCY,
+            false);
+
+    /**
+     * The aiohttp package.
+     */
+    public static final PythonDependency AIO_HTTP = new PythonDependency(
+            "aiohttp",
+            "~=3",
+            Type.DEPENDENCY,
+            false);
+
+    /**
      * The core smithy-json python package.
      */
     public static final PythonDependency SMITHY_JSON = new PythonDependency(


### PR DESCRIPTION
*Description of changes:*
Based on internal discussion, use the CRT HTTP Client as the default for all event streams - single and bi-directional.  This provides better forwards compatibility when a service moves from single directional event streams to bi-directional, but is not potentially the right long term solution.

This PR also adds the default HTTP client as an explicit dependency to improve the out of the box experience.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
