### PR TITLE
Fix for optional dependencies of SymbolDependencies.

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
@@ -45,7 +45,7 @@ public class AwsAuthIntegration implements PythonIntegration {
                                 .name("aws_credentials_identity_resolver")
                                 .documentation("Resolves AWS Credentials. Required for operations that use Sigv4 Auth.")
                                 .type(Symbol.builder()
-                                        .name("IdentityResolver[AWSCredentialIdentity, IdentityProperties]")
+                                        .name("IdentityResolver[AWSCredentialsIdentity, IdentityProperties]")
                                         .addReference(Symbol.builder()
                                                 .addDependency(SmithyPythonDependency.SMITHY_CORE)
                                                 .name("IdentityResolver")
@@ -53,7 +53,7 @@ public class AwsAuthIntegration implements PythonIntegration {
                                                 .build())
                                         .addReference(Symbol.builder()
                                                 .addDependency(AwsPythonDependency.SMITHY_AWS_CORE)
-                                                .name("AWSCredentialIdentity")
+                                                .name("AWSCredentialsIdentity")
                                                 .namespace("smithy_aws_core.identity", ".")
                                                 .build())
                                         .addReference(Symbol.builder()
@@ -154,7 +154,7 @@ public class AwsAuthIntegration implements PythonIntegration {
         public Symbol getAuthSchemeSymbol(GenerationContext context) {
             return Symbol.builder()
                     .name("SigV4AuthScheme")
-                    .namespace("smithy_aws_core.auth.sigv4", ".")
+                    .namespace("smithy_aws_core.auth", ".")
                     .addDependency(AwsPythonDependency.SMITHY_AWS_CORE)
                     .build();
         }

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
@@ -4,12 +4,10 @@
  */
 package software.amazon.smithy.python.aws.codegen;
 
-import java.util.Collections;
 import java.util.List;
 import software.amazon.smithy.aws.traits.auth.SigV4Trait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
 import software.amazon.smithy.python.codegen.ApplicationProtocol;
 import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.ConfigProperty;
@@ -67,8 +65,7 @@ public class AwsAuthIntegration implements PythonIntegration {
                                 .build())
                         .addConfigProperty(regionConfig)
                         .authScheme(new Sigv4AuthScheme())
-                        .build()
-        );
+                        .build());
     }
 
     @Override
@@ -135,10 +132,8 @@ public class AwsAuthIntegration implements PythonIntegration {
                             .source(DerivedProperty.Source.CONFIG)
                             .type(Symbol.builder().name("str").build())
                             .sourcePropertyName("region")
-                            .build()
-            );
+                            .build());
         }
-
 
         @Override
         public Symbol getAuthOptionGenerator(GenerationContext context) {

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
@@ -4,11 +4,159 @@
  */
 package software.amazon.smithy.python.aws.codegen;
 
+import java.util.Collections;
+import java.util.List;
+import software.amazon.smithy.aws.traits.auth.SigV4Trait;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
+import software.amazon.smithy.python.codegen.ApplicationProtocol;
+import software.amazon.smithy.python.codegen.CodegenUtils;
+import software.amazon.smithy.python.codegen.ConfigProperty;
+import software.amazon.smithy.python.codegen.DerivedProperty;
+import software.amazon.smithy.python.codegen.GenerationContext;
+import software.amazon.smithy.python.codegen.SmithyPythonDependency;
+import software.amazon.smithy.python.codegen.integrations.AuthScheme;
 import software.amazon.smithy.python.codegen.integrations.PythonIntegration;
+import software.amazon.smithy.python.codegen.integrations.RuntimeClientPlugin;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Adds support for AWS auth traits.
  */
 @SmithyInternalApi
-public class AwsAuthIntegration implements PythonIntegration {}
+public class AwsAuthIntegration implements PythonIntegration {
+    private static final String SIGV4_OPTION_GENERATOR_NAME = "_generate_sigv4_option";
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins(GenerationContext context) {
+        var regionConfig = ConfigProperty.builder()
+                .name("region")
+                .type(Symbol.builder().name("str").build())
+                .documentation(" The AWS region to connect to. The configured region is used to "
+                        + "determine the service endpoint.")
+                .build();
+
+        return List.of(
+                RuntimeClientPlugin.builder()
+                        .servicePredicate((model, service) -> service.hasTrait(SigV4Trait.class))
+                        .addConfigProperty(ConfigProperty.builder()
+                                // TODO: Naming of this config RE: backwards compatability/migation considerations
+                                .name("aws_credentials_identity_resolver")
+                                .documentation("Resolves AWS Credentials. Required for operations that use Sigv4 Auth.")
+                                .type(Symbol.builder()
+                                        .name("IdentityResolver[AWSCredentialIdentity, IdentityProperties]")
+                                        .addReference(Symbol.builder()
+                                                .addDependency(SmithyPythonDependency.SMITHY_CORE)
+                                                .name("IdentityResolver")
+                                                .namespace("smithy_core.aio.interfaces.identity", ".")
+                                                .build())
+                                        .addReference(Symbol.builder()
+                                                .addDependency(AwsPythonDependency.SMITHY_AWS_CORE)
+                                                .name("AWSCredentialIdentity")
+                                                .namespace("smithy_aws_core.identity", ".")
+                                                .build())
+                                        .addReference(Symbol.builder()
+                                                .addDependency(SmithyPythonDependency.SMITHY_CORE)
+                                                .name("IdentityProperties")
+                                                .namespace("smithy_core.interfaces.identity", ".")
+                                                .build())
+                                        .build())
+                                // TODO: Initialize with the provider chain?
+                                .nullable(true)
+                                .build())
+                        .addConfigProperty(regionConfig)
+                        .authScheme(new Sigv4AuthScheme())
+                        .build()
+        );
+    }
+
+    @Override
+    public void customize(GenerationContext context) {
+        if (!hasSigV4Auth(context)) {
+            return;
+        }
+        var trait = context.settings().service(context.model()).expectTrait(SigV4Trait.class);
+        var params = CodegenUtils.getHttpAuthParamsSymbol(context.settings());
+        var resolver = CodegenUtils.getHttpAuthSchemeResolverSymbol(context.settings());
+
+        // Add a function that generates the http auth option for api key auth.
+        // This needs to be generated because there's modeled parameters that
+        // must be accounted for.
+        context.writerDelegator().useFileWriter(resolver.getDefinitionFile(), resolver.getNamespace(), writer -> {
+            writer.addDependency(SmithyPythonDependency.SMITHY_HTTP);
+            writer.addImport("smithy_http.aio.interfaces.auth", "HTTPAuthOption");
+            writer.pushState();
+
+            writer.write("""
+                    def $1L(auth_params: $2T) -> HTTPAuthOption | None:
+                        return HTTPAuthOption(
+                            scheme_id=$3S,
+                            identity_properties={},
+                            signer_properties={
+                                "service": $4S,
+                                "region": auth_params.region
+                            }
+                        )
+                    """,
+                    SIGV4_OPTION_GENERATOR_NAME,
+                    params,
+                    SigV4Trait.ID.toString(),
+                    trait.getName());
+            writer.popState();
+        });
+    }
+
+    private boolean hasSigV4Auth(GenerationContext context) {
+        var service = context.settings().service(context.model());
+        return service.hasTrait(SigV4Trait.class);
+    }
+
+    /**
+     * The AuthScheme representing api key auth.
+     */
+    private static final class Sigv4AuthScheme implements AuthScheme {
+
+        @Override
+        public ShapeId getAuthTrait() {
+            return SigV4Trait.ID;
+        }
+
+        @Override
+        public ApplicationProtocol getApplicationProtocol() {
+            return ApplicationProtocol.createDefaultHttpApplicationProtocol();
+        }
+
+        @Override
+        public List<DerivedProperty> getAuthProperties() {
+            return List.of(
+                    DerivedProperty.builder()
+                            .name("region")
+                            .source(DerivedProperty.Source.CONFIG)
+                            .type(Symbol.builder().name("str").build())
+                            .sourcePropertyName("region")
+                            .build()
+            );
+        }
+
+
+        @Override
+        public Symbol getAuthOptionGenerator(GenerationContext context) {
+            var resolver = CodegenUtils.getHttpAuthSchemeResolverSymbol(context.settings());
+            return Symbol.builder()
+                    .name(SIGV4_OPTION_GENERATOR_NAME)
+                    .namespace(resolver.getNamespace(), ".")
+                    .definitionFile(resolver.getDefinitionFile())
+                    .build();
+        }
+
+        @Override
+        public Symbol getAuthSchemeSymbol(GenerationContext context) {
+            return Symbol.builder()
+                    .name("SigV4AuthScheme")
+                    .namespace("smithy_aws_core.auth.sigv4", ".")
+                    .addDependency(AwsPythonDependency.SMITHY_AWS_CORE)
+                    .build();
+        }
+    }
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -416,6 +416,7 @@ final class ClientGenerator implements Runnable {
                             for option in auth_options:
                                 if option.scheme_id in config.http_auth_schemes:
                                     auth_option = option
+                                    break
 
                             signer: HTTPSigner[Any, Any] | None = None
                             identity: Identity | None = None

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -40,24 +40,6 @@ public final class SmithyPythonDependency {
             false);
 
     /**
-     * The awscrt package.
-     */
-    public static final PythonDependency AWS_CRT = new PythonDependency(
-            "awscrt",
-            ">=0.23.10",
-            Type.DEPENDENCY,
-            false);
-
-    /**
-     * The aiohttp package.
-     */
-    public static final PythonDependency AIO_HTTP = new PythonDependency(
-            "aiohttp",
-            "~=3",
-            Type.DEPENDENCY,
-            false);
-
-    /**
      * The core smithy-json python package.
      */
     public static final PythonDependency SMITHY_JSON = new PythonDependency(

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -138,8 +138,7 @@ public final class ConfigGenerator implements Runnable {
         if (usesHttp2(context)) {
             clientBuilder
                     .initialize(writer -> {
-                        writer.addDependency(SmithyPythonDependency.SMITHY_HTTP);
-                        writer.addDependency(SmithyPythonDependency.AWS_CRT);
+                        writer.addDependency(SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("awscrt"));
                         writer.addImport("smithy_http.aio.crt", "AWSCRTHTTPClient");
                         writer.write("self.http_client = http_client or AWSCRTHTTPClient()");
                     });
@@ -147,8 +146,7 @@ public final class ConfigGenerator implements Runnable {
         } else {
             clientBuilder
                     .initialize(writer -> {
-                        writer.addDependency(SmithyPythonDependency.SMITHY_HTTP);
-                        writer.addDependency(SmithyPythonDependency.AIO_HTTP);
+                        writer.addDependency(SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("aiohttp"));
                         writer.addImport("smithy_http.aio.aiohttp", "AIOHTTPClient");
                         writer.write("self.http_client = http_client or AIOHTTPClient()");
                     });

--- a/packages/smithy-aws-core/pyproject.toml
+++ b/packages/smithy-aws-core/pyproject.toml
@@ -6,6 +6,8 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "smithy-core",
+    "smithy-http",
+    "aws-sdk-signers"
 ]
 
 [build-system]

--- a/packages/smithy-aws-core/src/smithy_aws_core/auth/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/auth/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0

--- a/packages/smithy-aws-core/src/smithy_aws_core/auth/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/auth/__init__.py
@@ -1,2 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
+
+from .sigv4 import SigV4AuthScheme
+
+__all__ = ("SigV4AuthScheme",)

--- a/packages/smithy-aws-core/src/smithy_aws_core/auth/sigv4.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/auth/sigv4.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import Protocol
 
-from smithy_aws_core.identity import AWSCredentialIdentity
+from smithy_aws_core.identity import AWSCredentialsIdentity
 from smithy_core.aio.interfaces.identity import IdentityResolver
 from smithy_core.exceptions import SmithyIdentityException
 from smithy_core.interfaces.identity import IdentityProperties
@@ -13,25 +13,26 @@ from aws_sdk_signers import SigV4SigningProperties, SigV4Signer
 
 class SigV4Config(Protocol):
     aws_credentials_identity_resolver: (
-        IdentityResolver[AWSCredentialIdentity, IdentityProperties] | None
+        IdentityResolver[AWSCredentialsIdentity, IdentityProperties] | None
     )
 
 
 @dataclass(init=False)
 class SigV4AuthScheme(
     HTTPAuthScheme[
-        AWSCredentialIdentity, SigV4Config, IdentityProperties, SigV4SigningProperties
+        AWSCredentialsIdentity, SigV4Config, IdentityProperties, SigV4SigningProperties
     ]
 ):
     """SigV4 AuthScheme."""
 
     scheme_id: str
-    signer: HTTPSigner[AWSCredentialIdentity, SigV4SigningProperties]
+    signer: HTTPSigner[AWSCredentialsIdentity, SigV4SigningProperties]
 
     def __init__(
         self,
         *,
-        signer: HTTPSigner[AWSCredentialIdentity, SigV4SigningProperties] | None = None,
+        signer: HTTPSigner[AWSCredentialsIdentity, SigV4SigningProperties]
+        | None = None,
     ) -> None:
         """Constructor.
 
@@ -44,7 +45,7 @@ class SigV4AuthScheme(
 
     def identity_resolver(
         self, *, config: SigV4Config
-    ) -> IdentityResolver[AWSCredentialIdentity, IdentityProperties]:
+    ) -> IdentityResolver[AWSCredentialsIdentity, IdentityProperties]:
         if not config.aws_credentials_identity_resolver:
             raise SmithyIdentityException(
                 "Attempted to use SigV4 auth, but aws_credentials_identity_resolver was not "

--- a/packages/smithy-aws-core/src/smithy_aws_core/auth/sigv4.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/auth/sigv4.py
@@ -1,0 +1,53 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import Protocol
+
+from smithy_aws_core.identity import AWSCredentialIdentity
+from smithy_core.aio.interfaces.identity import IdentityResolver
+from smithy_core.exceptions import SmithyIdentityException
+from smithy_core.interfaces.identity import IdentityProperties
+from smithy_http.aio.interfaces.auth import HTTPAuthScheme, HTTPSigner
+from aws_sdk_signers import SigV4SigningProperties, SigV4Signer
+
+
+class SigV4Config(Protocol):
+    aws_credentials_identity_resolver: (
+        IdentityResolver[AWSCredentialIdentity, IdentityProperties] | None
+    )
+
+
+@dataclass(init=False)
+class SigV4AuthScheme(
+    HTTPAuthScheme[
+        AWSCredentialIdentity, SigV4Config, IdentityProperties, SigV4SigningProperties
+    ]
+):
+    """SigV4 AuthScheme."""
+
+    scheme_id: str
+    signer: HTTPSigner[AWSCredentialIdentity, SigV4SigningProperties]
+
+    def __init__(
+        self,
+        *,
+        signer: HTTPSigner[AWSCredentialIdentity, SigV4SigningProperties] | None = None,
+    ) -> None:
+        """Constructor.
+
+        :param identity_resolver: The identity resolver to extract the api key identity.
+        :param signer: The signer used to sign the request.
+        """
+        self.scheme_id = "aws.auth#sigv4"
+        # TODO: There are type mismatches in the signature of the "sign" method.
+        self.signer = signer or SigV4Signer()  # type: ignore
+
+    def identity_resolver(
+        self, *, config: SigV4Config
+    ) -> IdentityResolver[AWSCredentialIdentity, IdentityProperties]:
+        if not config.aws_credentials_identity_resolver:
+            raise SmithyIdentityException(
+                "Attempted to use SigV4 auth, but aws_credentials_identity_resolver was not "
+                "set on the config."
+            )
+        return config.aws_credentials_identity_resolver

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/__init__.py
@@ -1,0 +1,6 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from .environment_credentials_resolver import EnvironmentCredentialsResolver
+from .static_credentials_resolver import StaticCredentialsResolver
+
+__all__ = ("EnvironmentCredentialsResolver", "StaticCredentialsResolver")

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/environment_credentials_resolver.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/environment_credentials_resolver.py
@@ -1,0 +1,34 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+import os
+
+from smithy_aws_core.identity import AWSCredentialsIdentity
+from smithy_core.aio.interfaces.identity import IdentityResolver
+from smithy_core.exceptions import SmithyIdentityException
+from smithy_core.interfaces.identity import IdentityProperties
+
+
+class EnvironmentCredentialsResolver(
+    IdentityResolver[AWSCredentialsIdentity, IdentityProperties]
+):
+    """Resolves AWS Credentials from system environment variables."""
+
+    async def get_identity(
+        self, *, identity_properties: IdentityProperties
+    ) -> AWSCredentialsIdentity:
+        access_key_id = os.getenv("AWS_ACCESS_KEY_ID")
+        secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+        session_token = os.getenv("AWS_SESSION_TOKEN")
+        account_id = os.getenv("AWS_ACCOUNT_ID")
+
+        if access_key_id is None or secret_access_key is None:
+            raise SmithyIdentityException(
+                "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required"
+            )
+
+        return AWSCredentialsIdentity(
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+            account_id=account_id,
+        )

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/static_credentials_resolver.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/static_credentials_resolver.py
@@ -1,0 +1,19 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from smithy_aws_core.identity import AWSCredentialsIdentity
+from smithy_core.aio.interfaces.identity import IdentityResolver
+from smithy_core.interfaces.identity import IdentityProperties
+
+
+class StaticCredentialsResolver(
+    IdentityResolver[AWSCredentialsIdentity, IdentityProperties]
+):
+    """Resolve Static AWS Credentials."""
+
+    def __init__(self, *, credentials: AWSCredentialsIdentity) -> None:
+        self._credentials = credentials
+
+    async def get_identity(
+        self, *, identity_properties: IdentityProperties
+    ) -> AWSCredentialsIdentity:
+        return self._credentials

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from smithy_core.identity import Identity
 
 
-class AWSCredentialIdentity(Identity):
+class AWSCredentialsIdentity(Identity):
     """Container for AWS authentication credentials."""
 
     def __init__(
@@ -25,6 +25,7 @@ class AWSCredentialIdentity(Identity):
         secret_access_key: str,
         session_token: str | None = None,
         expiration: datetime | None = None,
+        account_id: str | None = None,
     ) -> None:
         """Initialize the AWSCredentialIdentity.
 
@@ -35,11 +36,13 @@ class AWSCredentialIdentity(Identity):
             the supplied credentials.
         :param expiration: The expiration time of the identity. If time zone is
             provided, it is updated to UTC. The value must always be in UTC.
+        :param account_id: The AWS account's ID.
         """
         super().__init__(expiration=expiration)
         self._access_key_id: str = access_key_id
         self._secret_access_key: str = secret_access_key
         self._session_token: str | None = session_token
+        self._account_id: str | None = account_id
 
     @property
     def access_key_id(self) -> str:
@@ -52,3 +55,7 @@ class AWSCredentialIdentity(Identity):
     @property
     def session_token(self) -> str | None:
         return self._session_token
+
+    @property
+    def account_id(self) -> str | None:
+        return self._account_id

--- a/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_environment_credentials_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_environment_credentials_resolver.py
@@ -1,0 +1,68 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from smithy_aws_core.credentials_resolvers import EnvironmentCredentialsResolver
+from smithy_core.exceptions import SmithyIdentityException
+from smithy_core.interfaces.identity import IdentityProperties
+
+
+async def test_no_values_set():
+    with pytest.raises(SmithyIdentityException):
+        await EnvironmentCredentialsResolver().get_identity(
+            identity_properties=IdentityProperties()
+        )
+
+
+async def test_required_values_missing(monkeypatch):  # type: ignore
+    monkeypatch.setenv("AWS_ACCOUNT_ID", "123456789012")  # type: ignore
+
+    with pytest.raises(SmithyIdentityException):
+        await EnvironmentCredentialsResolver().get_identity(
+            identity_properties=IdentityProperties()
+        )
+
+
+async def test_akid_missing(monkeypatch):  # type: ignore
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")  # type: ignore
+
+    with pytest.raises(SmithyIdentityException):
+        await EnvironmentCredentialsResolver().get_identity(
+            identity_properties=IdentityProperties()
+        )
+
+
+async def test_secret_missing(monkeypatch):  # type: ignore
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")  # type: ignore
+
+    with pytest.raises(SmithyIdentityException):
+        await EnvironmentCredentialsResolver().get_identity(
+            identity_properties=IdentityProperties()
+        )
+
+
+async def test_minimum_required(monkeypatch):  # type: ignore
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")  # type: ignore
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")  # type: ignore
+
+    credentials = await EnvironmentCredentialsResolver().get_identity(
+        identity_properties=IdentityProperties()
+    )
+    assert credentials.access_key_id == "akid"
+    assert credentials.secret_access_key == "secret"
+
+
+async def test_all_values(monkeypatch):  # type: ignore
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")  # type: ignore
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")  # type: ignore
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "session")  # type: ignore
+    monkeypatch.setenv("AWS_ACCOUNT_ID", "123456789012")  # type: ignore
+
+    credentials = await EnvironmentCredentialsResolver().get_identity(
+        identity_properties=IdentityProperties()
+    )
+    assert credentials.access_key_id == "akid"
+    assert credentials.secret_access_key == "secret"
+    assert credentials.session_token == "session"
+    assert credentials.account_id == "123456789012"

--- a/packages/smithy-http/src/smithy_http/aio/auth/apikey.py
+++ b/packages/smithy-http/src/smithy_http/aio/auth/apikey.py
@@ -74,7 +74,7 @@ class ApiKeyAuthScheme(
     ) -> IdentityResolver[ApiKeyIdentity, IdentityProperties]:
         if not config.api_key_identity_resolver:
             raise SmithyIdentityException(
-                "Attempted to use API key auth, but api_key_identity_resolver was not"
+                "Attempted to use API key auth, but api_key_identity_resolver was not "
                 "set on the config."
             )
         return config.api_key_identity_resolver

--- a/uv.lock
+++ b/uv.lock
@@ -653,11 +653,17 @@ name = "smithy-aws-core"
 version = "0.0.1"
 source = { editable = "packages/smithy-aws-core" }
 dependencies = [
+    { name = "aws-sdk-signers" },
     { name = "smithy-core" },
+    { name = "smithy-http" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "smithy-core", editable = "packages/smithy-core" }]
+requires-dist = [
+    { name = "aws-sdk-signers", editable = "packages/aws-sdk-signers" },
+    { name = "smithy-core", editable = "packages/smithy-core" },
+    { name = "smithy-http", editable = "packages/smithy-http" },
+]
 
 [[package]]
 name = "smithy-core"


### PR DESCRIPTION

*Description of changes:*
Addresses comment from: https://github.com/smithy-lang/smithy-python/pull/409#discussion_r1984187213

The issue is that optional dependencies are stored as typed properties on the symbol dependencies and those properties are not merged by smithy's [gatherDependencies](https://github.com/smithy-lang/smithy/blob/main/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependency.java#L131) method.  We're adding the smithy_http dependency hundreds of times through out the code, but only once with the optionalDependencies specified.

This PR sets awscrt and aiohttp as optional dependencies on the smithy_http SymbolDependency (undooing changes from #409) and uses a custom `gatherDependencies` with a custom merge function that merges the `OPTIONAL_DEPENDENCIES` property. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
