### PR TITLE
Fix for optional dependencies of SymbolDependencies

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -138,8 +138,7 @@ public final class ConfigGenerator implements Runnable {
         if (usesHttp2(context)) {
             clientBuilder
                     .initialize(writer -> {
-                        writer.addDependency(SmithyPythonDependency.SMITHY_HTTP);
-                        writer.addDependency(SmithyPythonDependency.AWS_CRT);
+                        writer.addDependency(SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("awscrt"));
                         writer.addImport("smithy_http.aio.crt", "AWSCRTHTTPClient");
                         writer.write("self.http_client = http_client or AWSCRTHTTPClient()");
                     });
@@ -147,8 +146,7 @@ public final class ConfigGenerator implements Runnable {
         } else {
             clientBuilder
                     .initialize(writer -> {
-                        writer.addDependency(SmithyPythonDependency.SMITHY_HTTP);
-                        writer.addDependency(SmithyPythonDependency.AIO_HTTP);
+                        writer.addDependency(SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("aiohttp"));
                         writer.addImport("smithy_http.aio.aiohttp", "AIOHTTPClient");
                         writer.write("self.http_client = http_client or AIOHTTPClient()");
                     });


### PR DESCRIPTION
*Description of changes:*
Addresses comment from: https://github.com/smithy-lang/smithy-python/pull/409#discussion_r1984187213

The issue is that optional dependencies are stored as typed properties on the symbol dependencies and those properties are not merged by smithy's [gatherDependencies](https://github.com/smithy-lang/smithy/blob/main/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SymbolDependency.java#L131) method.  We're adding the smithy_http dependency hundreds of times through out the code, but only once with the optionalDependencies specified.

This PR sets awscrt and aiohttp as optional dependencies on the smithy_http SymbolDependency (undooing changes from #409) and uses a custom `gatherDependencies` with a custom merge function that merges the `OPTIONAL_DEPENDENCIES` property. 

Resulting dependencies for generated client:

```
dependencies = [
    "aws_event_stream==0.0.1",
    "smithy_core==0.0.1",
    "smithy_event_stream==0.0.1",
    "smithy_http[awscrt]==0.0.1",
    "smithy_json==0.0.1"
]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.