### PR TITLE
Add support for operation and service schemas

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SchemaGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SchemaGenerator.java
@@ -83,8 +83,7 @@ public final class SchemaGenerator implements Consumer<Shape> {
         var index = TopologicalIndex.of(context.model());
         Stream.concat(index.getOrderedShapes().stream(), index.getRecursiveShapes().stream())
                 .filter(shapes::contains)
-                .filter(shape -> !shape.isOperationShape() && !shape.isResourceShape()
-                        && !shape.isServiceShape()
+                .filter(shape -> !shape.isResourceShape()
                         && !shape.isMemberShape()
                         && !Prelude.isPreludeShape(shape))
                 .filter(filter::apply)

--- a/codegen/plugins/types/src/main/java/software/amazon/smithy/python/codegen/types/DirectedPythonTypeCodegen.java
+++ b/codegen/plugins/types/src/main/java/software/amazon/smithy/python/codegen/types/DirectedPythonTypeCodegen.java
@@ -64,6 +64,9 @@ final class DirectedPythonTypeCodegen
     public void customizeBeforeShapeGeneration(CustomizeDirective<GenerationContext, PythonSettings> directive) {
         new ServiceErrorGenerator(directive.settings(), directive.context().writerDelegator()).run();
         SchemaGenerator.generateAll(directive.context(), directive.connectedShapes().values(), shape -> {
+            if (shape.isOperationShape() || shape.isServiceShape()) {
+                return false;
+            }
             if (shape.isStructureShape()) {
                 return shouldGenerateStructure(directive.settings(), shape);
             }

--- a/examples/weather/smithy-build.json
+++ b/examples/weather/smithy-build.json
@@ -5,7 +5,7 @@
     "dependencies": [
       "software.amazon.smithy:smithy-model:[1.41.0,2.0)",
       "software.amazon.smithy:smithy-aws-traits:[1.41.0,2.0)",
-      "software.amazon.smithy.python:smithy-python-codegen:0.1.0"
+      "software.amazon.smithy.python.codegen:core:0.0.1"
     ]
   },
   "projections": {

--- a/packages/smithy-core/src/smithy_core/documents.py
+++ b/packages/smithy-core/src/smithy_core/documents.py
@@ -94,7 +94,11 @@ class Document:
         else:
             self._value = value
 
-        if self._schema.shape_type is not ShapeType.DOCUMENT:
+        if self._schema.shape_type not in (
+            ShapeType.DOCUMENT,
+            ShapeType.OPERATION,
+            ShapeType.SERVICE,
+        ):
             self._type = self._schema.shape_type
         else:
             # TODO: set an appropriate schema if one was not provided
@@ -310,6 +314,10 @@ class Document:
                 # which is a case we've already handled.
                 raise SmithyException(
                     f"Unexpexcted DOCUMENT shape type for document value: {self.as_value()}"
+                )
+            case _:
+                raise SmithyException(
+                    f"Unexpected {self._type} shape type for document value: {self.as_value()}"
                 )
 
     def serialize_members(self, serializer: ShapeSerializer) -> None:

--- a/packages/smithy-core/src/smithy_core/shapes.py
+++ b/packages/smithy-core/src/smithy_core/shapes.py
@@ -122,6 +122,6 @@ class ShapeType(Enum):
 
     # We won't acutally be using these, probably
     # MEMBER = 20
-    # SERVICE = 21
+    SERVICE = 21
     # RESOURCE = 22
-    # OPERATION = 23
+    OPERATION = 23


### PR DESCRIPTION
*Description of changes:*
- Adds support for generating operation and service schemas:
```
GET_FORECAST = Schema(
    id=ShapeID("example.weather#GetForecast"),
    shape_type=ShapeType.OPERATION,
    traits=[
        ...
        Trait.new(id=ShapeID("smithy.api#readonly")),
    ],
)
...
WEATHER = Schema(
    id=ShapeID("example.weather#Weather"),
    shape_type=ShapeType.SERVICE,
    traits=[
        ...
        Trait.new(id=ShapeID("aws.protocols#restJson1")),
    ],
)
```
- Fixes a couple of extraneous issues as well
  - Incorrect dep in example package
  - Bad import when code generating a client for a model that doesn't use the `httpHeader` trait
    - `  serialize.py:8:25 - error: Import "Field" is not accessed (reportUnusedImport)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
