### PR TITLE
Fix AsyncBytesReader, read when bytes are already available

### DIFF
--- a/packages/smithy-core/src/smithy_core/aio/types.py
+++ b/packages/smithy-core/src/smithy_core/aio/types.py
@@ -72,10 +72,11 @@ class AsyncBytesReader:
             self._remainder = b""
             return result
 
-        async for element in iterator:
-            result += element
-            if len(result) >= size:
-                break
+        if len(result) < size:
+            async for element in iterator:
+                result += element
+                if len(result) >= size:
+                    break
 
         self._remainder = result[size:]
         return result[:size]


### PR DESCRIPTION
*Description of changes:*
Output event streams were hanging when trying to read bytes from the AsyncBytesReader when `self._remainder` already had sufficient bytes to satisfy the read.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
