### PR TITLE
Catch ImportError when awscrt is not installed

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/interceptors/user_agent.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/interceptors/user_agent.py
@@ -68,5 +68,5 @@ class UserAgentInterceptor(Interceptor[Any, Any, Any, Any]):
             import awscrt
 
             return [UserAgentComponent("md", "awscrt", awscrt.__version__)]
-        except AttributeError:
+        except (ImportError, AttributeError):
             return []


### PR DESCRIPTION
This PR adds handling for the `ImportError` exception when attempting to check if `awscrt` is installed.

When building the user-agent string, we currently attempt to import `awscrt` to add a component similar to `md/awscrt#1.23.4` to the final string. However, when the `awscrt` isn't installed on the user's machine, an `ImportError` is raised and not handled by the current logic. 

User's will not have `awscrt` in the following cases:
- The service doesn't support h2 or have any event streaming operations.
- The user manually configures a non-awscrt client such as `AIOHTTPClient` and opts out of installing the `awscrt`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
