### PR TITLE
Create client transport interface

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -627,7 +627,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                         self._client_config = client_config
 
                     async def send(
-                        self, *, request: HTTPRequest, request_config: HTTPRequestConfiguration | None = None
+                        self, request: HTTPRequest, *, request_config: HTTPRequestConfiguration | None = None
                     ) -> HTTPResponse:
                         # Raise the exception with the request object to bypass actual request handling
                         raise $1T(request)
@@ -650,7 +650,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                         self.body = body
 
                     async def send(
-                        self, *, request: HTTPRequest, request_config: HTTPRequestConfiguration | None = None
+                        self, request: HTTPRequest, *, request_config: HTTPRequestConfiguration | None = None
                     ) -> _HTTPResponse:
                         # Pre-construct the response from the request and return it
                         return _HTTPResponse(

--- a/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
+++ b/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
@@ -27,14 +27,13 @@ type StreamingBlob = SyncStreamingBlob | AsyncByteStream | AsyncIterable[bytes]
 
 
 class Request(Protocol):
-    """Protocol-agnostic representation of a request.
-
-    :param destination: The URI where the request should be sent to.
-    :param body: The request payload as iterable of chunks of bytes.
-    """
+    """Protocol-agnostic representation of a request."""
 
     destination: URI
+    """The URI where the request should be sent to."""
+
     body: StreamingBlob = b""
+    """The request payload."""
 
     async def consume_body_async(self) -> bytes:
         """Iterate over request body and return as bytes."""
@@ -59,4 +58,12 @@ class Response(Protocol):
 
     def consume_body(self) -> bytes:
         """Iterate over request body and return as bytes."""
+        ...
+
+
+class ClientTransport[I: Request, O: Response](Protocol):
+    """Protocol-agnostic representation of a client tranport (e.g. an HTTP client)."""
+
+    async def send(self, request: I) -> O:
+        """Send a request over the transport and receive the response."""
         ...

--- a/packages/smithy-http/src/smithy_http/aio/aiohttp.py
+++ b/packages/smithy-http/src/smithy_http/aio/aiohttp.py
@@ -66,8 +66,8 @@ class AIOHTTPClient(HTTPClient):
 
     async def send(
         self,
-        *,
         request: HTTPRequest,
+        *,
         request_config: HTTPRequestConfiguration | None = None,
     ) -> HTTPResponseInterface:
         """Send HTTP request using aiohttp client.

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -197,8 +197,8 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     async def send(
         self,
-        *,
         request: http_aio_interfaces.HTTPRequest,
+        *,
         request_config: http_aio_interfaces.HTTPRequestConfiguration | None = None,
     ) -> AWSCRTHTTPResponse:
         """Send HTTP request using awscrt client.

--- a/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
+++ b/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
@@ -2,7 +2,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 from typing import Protocol, TypeVar
 
-from smithy_core.aio.interfaces import Request, Response
+from smithy_core.aio.interfaces import Request, Response, ClientTransport
 from smithy_core.aio.utils import read_streaming_blob, read_streaming_blob_async
 
 from ...interfaces import (
@@ -75,7 +75,7 @@ class HTTPResponse(Response, Protocol):
         return read_streaming_blob(self.body)
 
 
-class HTTPClient(Protocol):
+class HTTPClient(ClientTransport[HTTPRequest, HTTPResponse], Protocol):
     """An asynchronous HTTP client interface."""
 
     def __init__(self, *, client_config: HTTPClientConfiguration | None) -> None:
@@ -87,8 +87,8 @@ class HTTPClient(Protocol):
 
     async def send(
         self,
-        *,
         request: HTTPRequest,
+        *,
         request_config: HTTPRequestConfiguration | None = None,
     ) -> HTTPResponse:
         """Send HTTP request over the wire and return the response.


### PR DESCRIPTION
This adds a generic interface to represent client transports, such as HTTP clients. It additionally makes the HTTP client implement that interface explicitly.

A change to the HTTP client interface as a result of this is that `request` is no longer a keyword-only argument. While I understand and agree with the general desire to restrict positional arguments, I think adhering to that too dogmatically can make things less usable to no gain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
