### PR TITLE
Use ruff formatter in generated clients

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -17,13 +17,10 @@ clients.
 * Use of a
   [Python virtual environment](https://docs.python.org/3/library/venv.html) is
   highly recommended.
-* If `black` is installed in the version of python found on the path, it will be
+* If `ruff` is installed in the version of python found on the path, it will be
   used to format the generated code.
-* If `mypy` is installed in the version of python found on the path, it will be
-  used to check the generated code. For mypy to pass, the `smithy_core` and
-  `smithy_http` packages will need to be installed. To install those into your
-  active environment, run `make install-python-components` from the repository
-  root.
+* If `pyright` is installed in the version of python found on the path, it will be
+  used to check the generated code.
 
 ### Building the generator
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonFormatter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonFormatter.java
@@ -61,28 +61,28 @@ public final class PythonFormatter implements Runnable {
             CodegenUtils.runCommand("python3 " + file, fileManifest.getBaseDir());
         }
         format(fileManifest);
-        check(fileManifest);
+        typeCheck(fileManifest);
     }
 
     private void format(FileManifest fileManifest) {
         try {
-            CodegenUtils.runCommand("python3 -m black -h", fileManifest.getBaseDir());
+            CodegenUtils.runCommand("python3 -m ruff -h", fileManifest.getBaseDir());
         } catch (CodegenException e) {
-            LOGGER.warning("Unable to find the python package black. Skipping formatting.");
+            LOGGER.warning("Unable to find the python package ruff. Skipping formatting.");
             return;
         }
         LOGGER.info("Running code formatter on generated code");
-        CodegenUtils.runCommand("python3 -m black . --exclude \"\"", fileManifest.getBaseDir());
+        CodegenUtils.runCommand("python3 -m ruff format", fileManifest.getBaseDir());
     }
 
-    private void check(FileManifest fileManifest) {
+    private void typeCheck(FileManifest fileManifest) {
         try {
             CodegenUtils.runCommand("python3 -m pyright -h", fileManifest.getBaseDir());
         } catch (CodegenException e) {
             LOGGER.warning("Unable to find the pyright package. Skipping type checking.");
             return;
         }
-        LOGGER.info("Running mypy on generated code");
+        LOGGER.info("Running type checker on generated code");
         CodegenUtils.runCommand("python3 -m pyright .", fileManifest.getBaseDir());
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
@@ -36,8 +36,7 @@ import software.amazon.smithy.utils.StringUtils;
 @SmithyInternalApi
 public final class SetupGenerator {
 
-    private SetupGenerator() {
-    }
+    private SetupGenerator() {}
 
     public static void generateSetup(
             PythonSettings settings,
@@ -123,7 +122,7 @@ public final class SetupGenerator {
                     [build-system]
                     requires = ["setuptools", "setuptools-scm", "wheel"]
                     build-backend = "setuptools.build_meta"
-                    
+
                     [project]
                     name = $1S
                     version = $2S
@@ -159,7 +158,7 @@ public final class SetupGenerator {
             writer.write("""
                     [tool.setuptools.packages.find]
                     exclude=["tests*"]
-                    
+
                     [tool.pyright]
                     typeCheckingMode = "strict"
                     reportPrivateUsage = false
@@ -167,10 +166,10 @@ public final class SetupGenerator {
                     reportUnusedVariable = false
                     reportUnnecessaryComparison = false
                     reportUnusedClass = false
-                    
-                    [tool.black]
-                    target-version = ["py311"]
-                    
+
+                    [tool.ruff]
+                    target-version = "py312"
+
                     [tool.pytest.ini_options]
                     python_classes = ["!Test"]
                     asyncio_mode = "auto"
@@ -181,17 +180,17 @@ public final class SetupGenerator {
     }
 
     private static void writeDependencyList(PythonWriter writer, Collection<SymbolDependency> dependencies) {
-        for (var iter = dependencies.iterator(); iter.hasNext(); ) {
+        for (var iter = dependencies.iterator(); iter.hasNext();) {
             writer.pushState();
             var dependency = iter.next();
             writer.putContext("deps", getOptionalDependencies(dependency));
             writer.putContext("isLink", dependency.getProperty(SymbolProperties.IS_LINK).orElse(false));
             writer.putContext("last", !iter.hasNext());
             writer.write("""
-                            "$L\
-                            ${?deps}[${#deps}${value:L}${^key.last}, ${/key.last}${/deps}]${/deps}\
-                            ${?isLink} @ ${/isLink}$L"\
-                            ${^last},${/last}""",
+                    "$L\
+                    ${?deps}[${#deps}${value:L}${^key.last}, ${/key.last}${/deps}]${/deps}\
+                    ${?isLink} @ ${/isLink}$L"\
+                    ${^last},${/last}""",
                     dependency.getPackageName(),
                     dependency.getVersion());
             writer.popState();
@@ -236,7 +235,7 @@ public final class SetupGenerator {
             writer.pushState(new ReadmeSection());
             writer.write("""
                     ## $L Client
-                    
+
                     $L
                     """, title, description);
 
@@ -249,7 +248,7 @@ public final class SetupGenerator {
                 // since the python code docs are RST format.
                 writer.write("""
                         ### Documentation
-                        
+
                         $L
                         """, documentation);
             });

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
@@ -412,7 +412,9 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                             payload_codec=codec,
                             initial_response=operation_output,
                             async_writer=execution_context.transport_request.body,  # type: ignore
-                            async_reader=AsyncBytesReader(execution_context.transport_response.body),  # type: ignore
+                            async_reader=AsyncBytesReader(
+                                execution_context.transport_response.body  # type: ignore
+                            ),
                             deserializer=event_deserializer,  # type: ignore
                         )
                     else:
@@ -425,7 +427,9 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                     return AWSOutputEventStream[Any, Any](
                         payload_codec=codec,
                         initial_response=operation_output,
-                        async_reader=AsyncBytesReader(execution_context.transport_response.body),  # type: ignore
+                        async_reader=AsyncBytesReader(
+                            execution_context.transport_response.body  # type: ignore
+                        ),
                         deserializer=event_deserializer,  # type: ignore
                     )
                 """);


### PR DESCRIPTION
This updates the formatter used for generated clients to match the one we use for the static python code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
