### PR TITLE
Add back testing to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
 on:
+    push:
+        branches:
+          - develop
+
     pull_request:
         branches:
           - develop


### PR DESCRIPTION
*Description of changes:*
We disabled testing `develop` in #381 so we not longer validate we still have a working branch when multiple PRs are merged in quick succession. This should address the removal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
