### PR TITLE
De-duplicate Config (Fix duplicate Region)

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
@@ -10,6 +10,7 @@ import software.amazon.smithy.aws.traits.auth.SigV4Trait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
+import static software.amazon.smithy.python.aws.codegen.AwsConfiguration.REGION;
 import software.amazon.smithy.python.codegen.ApplicationProtocol;
 import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.ConfigProperty;
@@ -30,13 +31,6 @@ public class AwsAuthIntegration implements PythonIntegration {
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins(GenerationContext context) {
-        var regionConfig = ConfigProperty.builder()
-                .name("region")
-                .type(Symbol.builder().name("str").build())
-                .documentation(" The AWS region to connect to. The configured region is used to "
-                        + "determine the service endpoint.")
-                .build();
-
         return List.of(
                 RuntimeClientPlugin.builder()
                         .servicePredicate((model, service) -> service.hasTrait(SigV4Trait.class))
@@ -65,7 +59,7 @@ public class AwsAuthIntegration implements PythonIntegration {
                                 // TODO: Initialize with the provider chain?
                                 .nullable(true)
                                 .build())
-                        .addConfigProperty(regionConfig)
+                        .addConfigProperty(REGION)
                         .authScheme(new Sigv4AuthScheme())
                         .build()
         );

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsConfiguration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsConfiguration.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.python.aws.codegen;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.python.codegen.ConfigProperty;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Common configuration for AWS Clients.
+ */
+@SmithyUnstableApi
+public final class AwsConfiguration {
+    private AwsConfiguration() {
+    }
+
+    public static final ConfigProperty REGION = ConfigProperty.builder()
+            .name("region")
+            .type(Symbol.builder().name("str").build())
+            .documentation(" The AWS region to connect to. The configured region is used to "
+                    + "determine the service endpoint.")
+            .build();
+}

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
@@ -12,6 +12,10 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  */
 @SmithyUnstableApi
 public class AwsPythonDependency {
+
+    private AwsPythonDependency() {
+    }
+
     /**
      * The core aws smithy runtime python package.
      *

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsStandardRegionalEndpointsIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsStandardRegionalEndpointsIntegration.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.python.aws.codegen;
 import java.util.List;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.Symbol;
+import static software.amazon.smithy.python.aws.codegen.AwsConfiguration.REGION;
 import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.ConfigProperty;
 import software.amazon.smithy.python.codegen.GenerationContext;
@@ -23,15 +24,9 @@ public class AwsStandardRegionalEndpointsIntegration implements PythonIntegratio
     @Override
     public List<RuntimeClientPlugin> getClientPlugins(GenerationContext context) {
         if (context.applicationProtocol().isHttpProtocol()) {
-            var region = ConfigProperty.builder()
-                    .name("region")
-                    .type(Symbol.builder().name("str").build())
-                    .documentation(" The AWS region to connect to. The configured region is used to "
-                            + "determine the service endpoint.")
-                    .build();
             return List.of(
                     RuntimeClientPlugin.builder()
-                            .addConfigProperty(region)
+                            .addConfigProperty(REGION)
                             .build());
         } else {
             return List.of();

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -7,9 +7,11 @@ package software.amazon.smithy.python.codegen.generators;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.knowledge.EventStreamIndex;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
@@ -288,9 +290,9 @@ public final class ConfigGenerator implements Runnable {
     private void generateConfig(GenerationContext context, PythonWriter writer) {
         var configSymbol = CodegenUtils.getConfigSymbol(context.settings());
 
-        // Initialize the list of config properties with our base properties. Here a new
-        // list is constructed because that base list is immutable.
-        var properties = new ArrayList<>(BASE_PROPERTIES);
+        // Initialize a set of config properties with our base properties.
+        var properties = new TreeSet<>(Comparator.comparing(ConfigProperty::name));
+        properties.addAll(BASE_PROPERTIES);
 
         // Smithy is transport agnostic, so we don't add http-related properties by default.
         // Nevertheless, HTTP is the most common use case so we standardize those settings


### PR DESCRIPTION
*Description of changes:*
Previously we collected `ConfigProperty` in a list, however, multiple integrations/runtime plugins may need to independently register and depend on the same configuration properties - an example of this is sigv4 auth and regional endpoints - they both depend on the `region` config and could potentially be used independently of each other, so should both register the config properties they need without trying to inspect or understand what other integrations/runtime plugins are being used.

This PR changes the data structure used to collect ConfigProperties during generation from a `List` to a `TreeSet` which uses the properties `name` to de-dupe it.  

Currently, the *first* registered config value with a specific name will be preserved, which does not allow runtime plugins to override base config properties (eg:  with this ordering, its not possible for a runtime plugin to override the the `http_client`). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
