### PR TITLE
Interceptor and InterceptorContext typing rework

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
+++ b/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
@@ -1,7 +1,8 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from typing import Protocol, Self
+from typing import Protocol, Self, Any
 
+from smithy_core.interceptors import Interceptor, InterceptorContext
 from smithy_core.aio.interfaces import Request, Response, ClientTransport
 from smithy_core.aio.utils import read_streaming_blob, read_streaming_blob_async
 
@@ -97,3 +98,16 @@ class HTTPClient(ClientTransport[HTTPRequest, HTTPResponse], Protocol):
         :param request_config: Configuration specific to this request.
         """
         ...
+
+
+# Deliberately not a type alias because those can't be subclassed
+AnyHTTPInterceptor = Interceptor[Any, Any, HTTPRequest, HTTPResponse]
+"""Interceptor alias for interceptors that work with HTTP transport types."""
+
+type HTTPInterceptorContext[Request, Response] = InterceptorContext[
+    Request, Response, HTTPRequest, HTTPResponse
+]
+"""Type alias for interceptor contexts that can contain HTTP transport types."""
+
+type AnyHTTPInterceptorContext = InterceptorContext[Any, Any, HTTPRequest, HTTPResponse]
+"""Type alias for interceptor contexts that can contain HTTP transport types."""


### PR DESCRIPTION
Back when interceptors were first created I didn't use dataclasses because they interacted strangely with generics. Now though, that's not the case. So this updates them to be dataclasses.

Another thing I did at the time was to leave the responsibility of declaring nullability for the properties of InterceptorContext to the parametric types. So if you were at the point of the request pipeline where the request was not yet serialized, you'd have this type:

```python
InterceptorContext[Request, None, None, None]
```

That would mean that accessing `context.transport_request` would always be typed as `None`. But after serialization it would be:

```python
InterceptorContext[Request, None, TransportRequest, None]
```

And at that point `context.transport_response` will never be `None`.

But the drawback is that you have to do casts like this all over the request pipeline:

```python
context_with_transport_request = cast(InterceptorContext[Input, None, HTTPRequest, None], context)
```

An alternative would be to have `expect_transport_response` that asserts it isn't null and then returns it. The drawbacks are that type system isn't telling you when it is and isn't null anymore, and there's now another function call. But now you don't have to cast the context all over the place in the request pipeline.

I'm opening this as a draft to discuss whether we should or shouldn't make the typing change (dataclass change is happening regardless).


(Note that protocol tests won't pass because the code generated request pipeline isn't updated)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
