### PR TITLE
IMDS Credentials Resolver

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/__init__.py
@@ -2,5 +2,10 @@
 #  SPDX-License-Identifier: Apache-2.0
 from .environment import EnvironmentCredentialsResolver
 from .static import StaticCredentialsResolver
+from .imds import IMDSCredentialsResolver
 
-__all__ = ("EnvironmentCredentialsResolver", "StaticCredentialsResolver")
+__all__ = (
+    "EnvironmentCredentialsResolver",
+    "StaticCredentialsResolver",
+    "IMDSCredentialsResolver",
+)

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
@@ -185,6 +185,7 @@ class IMDSCredentialsResolver(
     _METADATA_PATH_BASE = "/latest/meta-data/iam/security-credentials"
 
     def __init__(self, http_client: HTTPClient, config: Config | None = None):
+        # TODO: Respect IMDS specific config values from aws shared config file and environment.
         self._http_client = http_client
         self._ec2_metadata_client = EC2Metadata(http_client=http_client, config=config)
         self._config = config or Config()

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
@@ -186,8 +186,7 @@ class IMDSCredentialsResolver(
 ):
     """Resolves AWS Credentials from an EC2 Instance Metadata Service (IMDS) client."""
 
-    # TODO: Handle fallback to legacy path when a 404 is received.
-    _METADATA_PATH_BASE = "/latest/meta-data/iam/security-credentials-extended/"
+    _METADATA_PATH_BASE = "/latest/meta-data/iam/security-credentials"
 
     def __init__(self, http_client: HTTPClient, config: Config | None = None):
         self._http_client = http_client

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
@@ -52,7 +52,6 @@ class Config:
         self.ec2_instance_profile_name = ec2_instance_profile_name
 
     def _validate_token_ttl(self, ttl: int) -> int:
-        """Validates the token TTL value."""
         if not self._MIN_TTL <= ttl <= self._MAX_TTL:
             raise ValueError(
                 f"Token TTL must be between {self._MIN_TTL} and {self._MAX_TTL} seconds."
@@ -81,7 +80,6 @@ class Token:
         self._created_time = datetime.now()
 
     def is_expired(self) -> bool:
-        """Check if the token has expired."""
         return datetime.now() - self._created_time >= timedelta(seconds=self._ttl)
 
     @property
@@ -105,11 +103,9 @@ class TokenCache:
         self._token = None
 
     def _should_refresh(self) -> bool:
-        """Determines if the token should be refreshed."""
         return self._token is None or self._token.is_expired()
 
     async def _refresh(self) -> None:
-        """Refreshes the token if needed, with thread safety."""
         async with self._refresh_lock:
             if not self._should_refresh():
                 return
@@ -136,7 +132,6 @@ class TokenCache:
             self._token = Token(token_value.decode("utf-8"), self._config.token_ttl)
 
     async def get_token(self) -> Token:
-        """Get the current token, refreshing it if expired."""
         if self._should_refresh():
             await self._refresh()
         assert self._token is not None

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
@@ -36,7 +36,6 @@ class Config:
     retry_strategy: RetryStrategy
     endpoint_uri: URI
     endpoint_mode: Literal["IPv4", "IPv6"]
-    port: int
     token_ttl: int
 
     def __init__(
@@ -45,7 +44,6 @@ class Config:
         retry_strategy: RetryStrategy | None = None,
         endpoint_uri: URI | None = None,
         endpoint_mode: Literal["IPv4", "IPv6"] = "IPv4",
-        port: int = 80,
         token_ttl: int = _MAX_TTL,
         ec2_instance_profile_name: str | None = None,
     ):
@@ -53,7 +51,6 @@ class Config:
         self.retry_strategy = retry_strategy or SimpleRetryStrategy(max_attempts=3)
         self.endpoint_mode = endpoint_mode
         self.endpoint_uri = self._resolve_endpoint(endpoint_uri, endpoint_mode)
-        self.port = port
         self.token_ttl = self._validate_token_ttl(token_ttl)
         self.ec2_instance_profile_name = ec2_instance_profile_name
 
@@ -73,6 +70,7 @@ class Config:
         return URI(
             scheme="http",
             host=self._HOST_MAPPING.get(endpoint_mode, self._HOST_MAPPING["IPv4"]),
+            port=80,
         )
 
 
@@ -129,6 +127,7 @@ class TokenCache:
                 destination=URI(
                     scheme=self._base_uri.scheme,
                     host=self._base_uri.host,
+                    port=self._base_uri.port,
                     path=self._TOKEN_PATH,
                 ),
                 fields=headers,
@@ -168,7 +167,7 @@ class EC2Metadata:
             destination=URI(
                 scheme=self._config.endpoint_uri.scheme,
                 host=self._config.endpoint_uri.host,
-                port=self._config.port,
+                port=self._config.endpoint_uri.port,
                 path=path,
             ),
             fields=headers,

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
@@ -75,7 +75,7 @@ class Token:
     """Represents an IMDSv2 session token with a value and method for checking
     expiration."""
 
-    def __init__(self, value: bytes, ttl: int):
+    def __init__(self, value: str, ttl: int):
         self._value = value
         self._ttl = ttl
         self._created_time = datetime.now()
@@ -85,7 +85,7 @@ class Token:
         return datetime.now() - self._created_time >= timedelta(seconds=self._ttl)
 
     @property
-    def value(self) -> bytes:
+    def value(self) -> str:
         return self._value
 
 
@@ -133,7 +133,7 @@ class TokenCache:
             )
             response = await self._http_client.send(request)
             token_value = await response.consume_body_async()
-            self._token = Token(token_value, self._config.token_ttl)
+            self._token = Token(token_value.decode("utf-8"), self._config.token_ttl)
 
     async def get_token(self) -> Token:
         """Get the current token, refreshing it if expired."""
@@ -158,7 +158,7 @@ class EC2Metadata:
                 # TODO: Add user-agent
                 Field(
                     name="x-aws-ec2-metadata-token",
-                    values=[token.value.decode("utf-8")],
+                    values=[token.value],
                 )
             ]
         )

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
@@ -1,7 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 import json
-import threading
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Literal
@@ -55,7 +55,7 @@ class TokenCache:
         self._http_client = http_client
         self._base_uri = base_uri
         self._token_ttl = self._validate_token_ttl(token_ttl)
-        self._refresh_lock = threading.Lock()
+        self._refresh_lock = asyncio.Lock()
         self._token = None
 
     def _validate_token_ttl(self, ttl: int) -> int:
@@ -72,7 +72,7 @@ class TokenCache:
 
     async def _refresh(self) -> None:
         """Refreshes the token if needed, with thread safety."""
-        with self._refresh_lock:
+        async with self._refresh_lock:
             if not self._should_refresh():
                 return
             headers = Fields(

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/imds.py
@@ -2,6 +2,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 import json
 import asyncio
+import smithy_aws_core
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Literal
@@ -17,6 +18,11 @@ from smithy_http.aio import HTTPRequest
 from smithy_http.aio.interfaces import HTTPClient
 
 from smithy_aws_core.identity import AWSCredentialsIdentity
+
+_USER_AGENT_FIELD = Field(
+    name="User-Agent",
+    values=[f"aws-sdk-python-imds-client/{smithy_aws_core.__version__}"],
+)
 
 
 @dataclass(init=False)
@@ -111,7 +117,7 @@ class TokenCache:
                 return
             headers = Fields(
                 [
-                    # TODO: Add user-agent
+                    _USER_AGENT_FIELD,
                     Field(
                         name="x-aws-ec2-metadata-token-ttl-seconds",
                         values=[str(self._config.token_ttl)],
@@ -150,11 +156,11 @@ class EC2Metadata:
         token = await self._token_cache.get_token()
         headers = Fields(
             [
-                # TODO: Add user-agent
+                _USER_AGENT_FIELD,
                 Field(
                     name="x-aws-ec2-metadata-token",
                     values=[token.value],
-                )
+                ),
             ]
         )
         request = HTTPRequest(

--- a/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_imds.py
+++ b/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_imds.py
@@ -111,4 +111,5 @@ async def test_token_cache_get_token():
     await token_cache.get_token()
     token_cache._refresh.assert_awaited()
 
+
 # TODO: Add tests for EC2Metadata and IMDSCredentialsResolver

--- a/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_imds.py
+++ b/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_imds.py
@@ -22,9 +22,10 @@ from unittest.mock import MagicMock, AsyncMock
 def test_config_defaults():
     config = Config()
     assert isinstance(config.retry_strategy, SimpleRetryStrategy)
-    assert config.endpoint_uri == URI(scheme="http", host=Config._HOST_MAPPING["IPv4"])
+    assert config.endpoint_uri == URI(
+        scheme="http", host=Config._HOST_MAPPING["IPv4"], port=80
+    )
     assert config.endpoint_mode == "IPv4"
-    assert config.port == 80
     assert config.token_ttl == 21600
 
 
@@ -38,15 +39,17 @@ def test_endpoint_resolution():
 def test_config_uses_custom_endpoint():
     # The custom endpoint should take precedence over IPv4 endpoint resolution.
     config = Config(
-        endpoint_uri=URI(scheme="http", host="test.host"), endpoint_mode="IPv4"
+        endpoint_uri=URI(scheme="https", host="test.host", port=123),
+        endpoint_mode="IPv4",
     )
-    assert config.endpoint_uri == URI(scheme="http", host="test.host")
+    assert config.endpoint_uri == URI(scheme="https", host="test.host", port=123)
 
     # The custom endpoint takes precedence over IPv6 endpoint resolution.
     config = Config(
-        endpoint_uri=URI(scheme="http", host="test.host"), endpoint_mode="IPv6"
+        endpoint_uri=URI(scheme="https", host="test.host", port=123),
+        endpoint_mode="IPv6",
     )
-    assert config.endpoint_uri == URI(scheme="http", host="test.host")
+    assert config.endpoint_uri == URI(scheme="https", host="test.host", port=123)
 
 
 def test_config_ttl_validation():

--- a/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_imds.py
+++ b/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_imds.py
@@ -1,0 +1,114 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# pyright: reportPrivateUsage=false
+import pytest
+import time
+from smithy_core.retries import SimpleRetryStrategy
+from smithy_core import URI
+from smithy_aws_core.credentials_resolvers.imds import Config, Token, TokenCache
+from unittest.mock import MagicMock, AsyncMock
+
+
+def test_config_defaults():
+    config = Config()
+    assert isinstance(config.retry_strategy, SimpleRetryStrategy)
+    assert config.endpoint_uri == URI(scheme="http", host=Config._HOST_MAPPING["IPv4"])
+    assert config.endpoint_mode == "IPv4"
+    assert config.port == 80
+    assert config.token_ttl == 21600
+
+
+def test_endpoint_resolution():
+    config_ipv4 = Config(endpoint_mode="IPv4")
+    config_ipv6 = Config(endpoint_mode="IPv6")
+    assert config_ipv4.endpoint_uri.host == Config._HOST_MAPPING["IPv4"]
+    assert config_ipv6.endpoint_uri.host == Config._HOST_MAPPING["IPv6"]
+
+
+def test_config_uses_custom_endpoint():
+    # The custom endpoint should take precedence over IPv4 endpoint resolution.
+    config = Config(
+        endpoint_uri=URI(scheme="http", host="test.host"), endpoint_mode="IPv4"
+    )
+    assert config.endpoint_uri == URI(scheme="http", host="test.host")
+
+    # The custom endpoint takes precedence over IPv6 endpoint resolution.
+    config = Config(
+        endpoint_uri=URI(scheme="http", host="test.host"), endpoint_mode="IPv6"
+    )
+    assert config.endpoint_uri == URI(scheme="http", host="test.host")
+
+
+def test_config_ttl_validation():
+    # TTL values < _MIN_TTL should throw a ValueError
+    with pytest.raises(ValueError):
+        Config(token_ttl=Config._MIN_TTL - 1)
+    # TTL values > _MAX_TTL should throw a ValueError
+    with pytest.raises(ValueError):
+        Config(token_ttl=Config._MAX_TTL + 1)
+
+
+def test_token_creation():
+    token = Token(value="test-token", ttl=100)
+    assert token._value == "test-token"
+    assert token._ttl == 100
+    assert not token.is_expired()
+
+
+def test_token_expiration():
+    token = Token(value="test-token", ttl=1)
+    assert not token.is_expired()
+    time.sleep(1.1)
+    assert token.is_expired()
+
+
+async def test_token_cache_should_refresh():
+    http_client = AsyncMock()
+    config = MagicMock()
+    # A new token cache needs a refresh
+    token_cache = TokenCache(http_client, config)
+    assert token_cache._should_refresh()
+    # A token cache with an unexpired token doesn't need a refresh
+    token_cache._token = MagicMock()
+    token_cache._token.is_expired.return_value = False
+    assert not token_cache._should_refresh()
+    # A token cache with an expired token needs a refresh
+    token_cache._token.is_expired.return_value = True
+    assert token_cache._should_refresh()
+
+
+async def test_token_cache_refresh():
+    # Test that TokenCache correctly refreshes the token when needed
+    http_client = AsyncMock()
+    config = MagicMock()
+    config.token_ttl = 100
+    config.endpoint_uri.scheme = "http"
+    config.endpoint_uri.host = "169.254.169.254"
+    response_mock = AsyncMock()
+    response_mock.consume_body_async.return_value = b"new-token-value"
+    http_client.send.return_value = response_mock
+    token_cache = TokenCache(http_client, config)
+    assert token_cache._should_refresh()
+    await token_cache._refresh()
+    assert token_cache._token is not None
+    assert token_cache._token.value == "new-token-value"
+    assert token_cache._token._ttl == 100
+
+
+async def test_token_cache_get_token():
+    # Test that TokenCache correctly returns an existing token or refreshes if expired
+    http_client = AsyncMock()
+    config = MagicMock()
+    token_cache = TokenCache(http_client, config)
+    token_cache._refresh = AsyncMock()
+    token_cache._token = MagicMock()
+    token_cache._token.is_expired.return_value = False
+    token = await token_cache.get_token()
+    assert token == token_cache._token
+    token_cache._refresh.assert_not_awaited()
+    token_cache._token.is_expired.return_value = True
+    await token_cache.get_token()
+    token_cache._refresh.assert_awaited()
+
+# TODO: Add tests for EC2Metadata and IMDSCredentialsResolver

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -273,12 +273,14 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
     ) -> "crt_http.HttpClientConnection":
         # TODO: Use CRT connection pooling instead of this basic kind
         connection_key = (url.scheme, url.host, url.port)
-        if connection_key in self._connections:
-            return self._connections[connection_key]
-        else:
-            connection = await self._create_connection(url)
-            self._connections[connection_key] = connection
+        connection = self._connections.get(connection_key)
+
+        if connection and connection.is_open():
             return connection
+
+        connection = await self._create_connection(url)
+        self._connections[connection_key] = connection
+        return connection
 
     def _build_new_connection(
         self, url: core_interfaces.URI


### PR DESCRIPTION
### Summary
This PR introduces an implementation for retrieving AWS credentials from the EC2 Instance Metadata Service (IMDSv2). It includes the following:
- `Token` Class: Represents an IMDSv2 session token with a value and method for checking expiration.
- `TokenCache` Class: Manages IMDSv2 session tokens, ensuring they are refreshed when expired.
- `EC2Metadata` Class: Provides an interface to fetch instance metadata using IMDSv2 authentication.
- `IMDSCredentialsResolver` Class: Implements `IdentityResolver` to retrieve AWS credentials securely from IMDS.

### TODO
- Verify credentials can successfully be fetched using the `AWSCRTHTTPClient`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
