### PR TITLE
Fix issue with BufferableByteStream after stream_close

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -368,8 +368,10 @@ class BufferableByteStream(BufferedIOBase):
             return b""
 
         if len(self._chunks) == 0:
-            # When the CRT recieves this, it'll try again later.
-            raise BlockingIOError("read")
+            if self._done:
+                return b""
+            else:
+                raise BlockingIOError("read")
 
         # We could compile all the chunks here instead of just returning
         # the one, BUT the CRT will keep calling read until empty bytes

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -87,6 +87,14 @@ def test_closed_stream_read() -> None:
     assert stream.read() == b""
 
 
+def test_done_stream_read() -> None:
+    stream = BufferableByteStream()
+    stream.write(b"foo")
+    stream.end_stream()
+    assert stream.read() == b"foo"
+    assert stream.read() == b""
+
+
 def test_stream_read1() -> None:
     stream = BufferableByteStream()
     stream.write(b"foo")


### PR DESCRIPTION

*Description of changes:*
The `_consume_body_async` async task calls `dest.end_stream()` which sets `_done` on the `BufferableByteStream`, however, the `read` method continues to raise the `BlockingIOError` when chunks is empty.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
