### PR TITLE
Temporary signers fixes

### DIFF
--- a/packages/aws-sdk-signers/src/aws_sdk_signers/interfaces/identity.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/interfaces/identity.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 
 class Identity(Protocol):
@@ -12,6 +12,27 @@ class Identity(Protocol):
 
     # The expiration time of the identity. If time zone is provided,
     # it is updated to UTC. The value must always be in UTC.
+    expiration: datetime | None = None
+
+    @property
+    def is_expired(self) -> bool:
+        """Whether the identity is expired."""
+        ...
+
+
+@runtime_checkable
+class AWSCredentialsIdentity(Protocol):
+    """AWS Credentials Identity."""
+
+    # The access key ID.
+    access_key_id: str
+
+    # The secret access key.
+    secret_access_key: str
+
+    # The session token.
+    session_token: str | None
+
     expiration: datetime | None = None
 
     @property

--- a/packages/aws-sdk-signers/tests/unit/auth/test_sigv4.py
+++ b/packages/aws-sdk-signers/tests/unit/auth/test_sigv4.py
@@ -115,7 +115,7 @@ def _test_signature_version_4_sync(test_case_name: str, signer: SigV4Signer) -> 
     with pytest.warns(AWSSDKWarning):
         signed_request = signer.sign(
             signing_properties=signing_props,
-            request=request,
+            http_request=request,
             identity=test_case.credentials,
         )
     assert (
@@ -154,7 +154,7 @@ async def _test_signature_version_4_async(
     with pytest.warns(AWSSDKWarning):
         signed_request = await signer.sign(
             signing_properties=signing_props,
-            request=request,
+            http_request=request,
             identity=test_case.credentials,
         )
     assert (

--- a/packages/aws-sdk-signers/tests/unit/test_signers.py
+++ b/packages/aws-sdk-signers/tests/unit/test_signers.py
@@ -67,7 +67,7 @@ class TestSigV4Signer:
     ) -> None:
         signed_request = self.SIGV4_SYNC_SIGNER.sign(
             signing_properties=signing_properties,
-            request=aws_request,
+            http_request=aws_request,
             identity=aws_identity,
         )
         assert isinstance(signed_request, AWSRequest)
@@ -86,7 +86,7 @@ class TestSigV4Signer:
         with pytest.raises(ValueError):
             self.SIGV4_SYNC_SIGNER.sign(
                 signing_properties=signing_properties,
-                request=aws_request,
+                http_request=aws_request,
                 identity=identity,
             )
 
@@ -102,7 +102,7 @@ class TestSigV4Signer:
         with pytest.raises(ValueError):
             self.SIGV4_SYNC_SIGNER.sign(
                 signing_properties=signing_properties,
-                request=aws_request,
+                http_request=aws_request,
                 identity=identity,
             )
 
@@ -118,7 +118,7 @@ class TestAsyncSigV4Signer:
     ) -> None:
         signed_request = await self.SIGV4_ASYNC_SIGNER.sign(
             signing_properties=signing_properties,
-            request=aws_request,
+            http_request=aws_request,
             identity=aws_identity,
         )
         assert isinstance(signed_request, AWSRequest)
@@ -137,7 +137,7 @@ class TestAsyncSigV4Signer:
         with pytest.raises(ValueError):
             await self.SIGV4_ASYNC_SIGNER.sign(
                 signing_properties=signing_properties,
-                request=aws_request,
+                http_request=aws_request,
                 identity=identity,
             )
 
@@ -153,6 +153,6 @@ class TestAsyncSigV4Signer:
         with pytest.raises(ValueError):
             await self.SIGV4_ASYNC_SIGNER.sign(
                 signing_properties=signing_properties,
-                request=aws_request,
+                http_request=aws_request,
                 identity=identity,
             )


### PR DESCRIPTION
*Description of changes:*
These changes are temporary and should be replaced by larger signer fixes. 

Fixes 2 typing mismatches with the current signers:
* request -> http_request in the signature for `sign`.
* Adds a runtime_checkable AWSCredentialsIdentity(Protocol) to allow the instance_of check to succeed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
