### PR TITLE
Close crt bridge stream on end_stream if empty

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -369,8 +369,10 @@ class BufferableByteStream(BufferedIOBase):
 
         if len(self._chunks) == 0:
             if self._done:
+                self.close()
                 return b""
             else:
+                # When the CRT recieves this, it'll try again
                 raise BlockingIOError("read")
 
         # We could compile all the chunks here instead of just returning
@@ -429,4 +431,7 @@ class BufferableByteStream(BufferedIOBase):
 
     def end_stream(self) -> None:
         """End the stream, letting any remaining chunks be read before it is closed."""
-        self._done = True
+        if len(self._chunks) == 0:
+            self.close()
+        else:
+            self._done = True

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -95,6 +95,12 @@ def test_done_stream_read() -> None:
     assert stream.read() == b""
 
 
+def test_end_empty_stream() -> None:
+    stream = BufferableByteStream()
+    stream.end_stream()
+    assert stream.read() == b""
+
+
 def test_stream_read1() -> None:
     stream = BufferableByteStream()
     stream.write(b"foo")


### PR DESCRIPTION
This is a followup to #432. I think the issue was that end_stream was getting called when the buffer was already empty, which would put it in an incomplete state. Unfortunately that fix also left it in an incomplete (but now working) state. This make sure it doesn't get into that incomplete state and adds a failing test for that case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
