### PR TITLE
Remove use of thread locks in crt bindings

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -156,7 +156,6 @@ class CRTResponseFactory:
     def on_response(
         self, status_code: int, headers: list[tuple[str, str]], **kwargs: Any
     ) -> None:  # pragma: crt-callback
-        print("on-response")
         fields = Fields()
         for header_name, header_val in headers:
             try:

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -176,7 +176,6 @@ class CRTResponseFactory:
         )
 
     async def await_response(self) -> AWSCRTHTTPResponse:
-        print(f"Initial status: {self._response_future._state}")
         return await asyncio.wrap_future(self._response_future)
 
     def set_done_callback(self, stream: "crt_http.HttpClientStream") -> None:


### PR DESCRIPTION
This primarily serves the purpose of removing thread-based locks from the CRT bindings, but it also ensures that the status code and headers have been received before returning from send.

Thread-based `Lock`s will deadlock if acquired twice by the same thread, so it's likely to happen in async code that runs multiple coroutines in one thread. And also, `deque`s are already thread-safe so there's no need to protect them further.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
