### PR TITLE
Add accept header when unset to crt request

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -11,6 +11,7 @@ from io import BytesIO, BufferedIOBase
 from threading import Lock
 from typing import TYPE_CHECKING, Any
 
+
 if TYPE_CHECKING:
     # pyright doesn't like optional imports. This is reasonable because if we use these
     # in type hints then they'd result in runtime errors.
@@ -292,10 +293,13 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         """Create :py:class:`awscrt.http.HttpRequest` from
         :py:class:`smithy_http.aio.HTTPRequest`"""
         headers_list = []
-        if "Host" not in request.fields:
+        if "host" not in request.fields:
             request.fields.set_field(
-                Field(name="Host", values=[request.destination.host])
+                Field(name="host", values=[request.destination.host])
             )
+
+        if "accept" not in request.fields:
+            request.fields.set_field(Field(name="accept", values=["*/*"]))
 
         for fld in request.fields.entries.values():
             # TODO: Use literal values for "header"/"trailer".

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -28,6 +28,7 @@ async def test_client_marshal_request() -> None:
     )
     crt_request = await client._marshal_request(request)  # type: ignore
     assert crt_request.headers.get("host") == "example.com"  # type: ignore
+    assert crt_request.headers.get("accept") == "*/*"  # type: ignore
     assert crt_request.method == "GET"  # type: ignore
     assert crt_request.path == "/path?key1=value1&key2=value2"  # type: ignore
 


### PR DESCRIPTION

*Description of changes:*
The aiohttp client adds the `accept` header, but the crt client does not.  This seems to be important for having signatures correctly match.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
