### PR TITLE
Return immediately on streaming inputs

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
@@ -4,13 +4,12 @@
  */
 package software.amazon.smithy.python.aws.codegen;
 
-import java.util.Collections;
+import static software.amazon.smithy.python.aws.codegen.AwsConfiguration.REGION;
+
 import java.util.List;
 import software.amazon.smithy.aws.traits.auth.SigV4Trait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
-import static software.amazon.smithy.python.aws.codegen.AwsConfiguration.REGION;
 import software.amazon.smithy.python.codegen.ApplicationProtocol;
 import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.ConfigProperty;
@@ -61,8 +60,7 @@ public class AwsAuthIntegration implements PythonIntegration {
                                 .build())
                         .addConfigProperty(REGION)
                         .authScheme(new Sigv4AuthScheme())
-                        .build()
-        );
+                        .build());
     }
 
     @Override
@@ -129,10 +127,8 @@ public class AwsAuthIntegration implements PythonIntegration {
                             .source(DerivedProperty.Source.CONFIG)
                             .type(Symbol.builder().name("str").build())
                             .sourcePropertyName("region")
-                            .build()
-            );
+                            .build());
         }
-
 
         @Override
         public Symbol getAuthOptionGenerator(GenerationContext context) {

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsConfiguration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsConfiguration.java
@@ -13,8 +13,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  */
 @SmithyUnstableApi
 public final class AwsConfiguration {
-    private AwsConfiguration() {
-    }
+    private AwsConfiguration() {}
 
     public static final ConfigProperty REGION = ConfigProperty.builder()
             .name("region")

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
@@ -13,8 +13,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public class AwsPythonDependency {
 
-    private AwsPythonDependency() {
-    }
+    private AwsPythonDependency() {}
 
     /**
      * The core aws smithy runtime python package.

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsStandardRegionalEndpointsIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsStandardRegionalEndpointsIntegration.java
@@ -4,12 +4,11 @@
  */
 package software.amazon.smithy.python.aws.codegen;
 
+import static software.amazon.smithy.python.aws.codegen.AwsConfiguration.REGION;
+
 import java.util.List;
 import software.amazon.smithy.aws.traits.ServiceTrait;
-import software.amazon.smithy.codegen.core.Symbol;
-import static software.amazon.smithy.python.aws.codegen.AwsConfiguration.REGION;
 import software.amazon.smithy.python.codegen.CodegenUtils;
-import software.amazon.smithy.python.codegen.ConfigProperty;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.integrations.PythonIntegration;
 import software.amazon.smithy.python.codegen.integrations.RuntimeClientPlugin;

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -409,7 +409,7 @@ final class ClientGenerator implements Runnable {
                                         retry_strategy.record_success(token=retry_token)
                                         if response_future is not None:
                                             response_future.set_result(
-                                                context_with_response.response,  # type: ignore
+                                                context_with_response.transport_response,  # type: ignore
                                             )
                                         break
                             except Exception as e:

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -120,10 +120,7 @@ final class ClientGenerator implements Runnable {
         var hasStreaming = hasEventStream();
         writer.putContext("hasEventStream", hasStreaming);
         if (hasStreaming) {
-            writer.addImports("smithy_core.deserializers",
-                    Set.of(
-                            "ShapeDeserializer",
-                            "DeserializeableShape"));
+            writer.addImport("smithy_core.deserializers", "ShapeDeserializer");
             writer.addStdlibImport("typing", "Any");
         }
 
@@ -137,7 +134,8 @@ final class ClientGenerator implements Runnable {
         writer.addStdlibImport("typing", "Awaitable");
         writer.addStdlibImport("typing", "cast");
         writer.addStdlibImport("copy", "deepcopy");
-        writer.addStdlibImport("asyncio", "sleep");
+        writer.addStdlibImport("asyncio");
+        writer.addStdlibImports("asyncio", Set.of("sleep", "Future"));
 
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
         writer.addImport("smithy_core.exceptions", "SmithyRetryException");
@@ -187,6 +185,75 @@ final class ClientGenerator implements Runnable {
                 """);
         writer.dedent();
 
+        if (hasStreaming) {
+            writer.addStdlibImports("typing", Set.of("Any", "Awaitable"));
+            writer.addStdlibImport("asyncio");
+            writer.write(
+                    """
+                            async def _input_stream(
+                                self,
+                                input: Input,
+                                plugins: list[$1T],
+                                serialize: Callable[[Input, $4T], Awaitable[$2T]],
+                                deserialize: Callable[[$3T, $4T], Awaitable[Output]],
+                                config: $4T,
+                                operation_name: str,
+                            ) -> Any:
+                                request_future = Future[$2T]()
+                                awaitable_output = asyncio.create_task(self._execute_operation(
+                                    input, plugins, serialize, deserialize, config, operation_name,
+                                    request_future=request_future
+                                ))
+                                transport_request = await request_future
+                                ${5C|}
+
+                            async def _output_stream(
+                                self,
+                                input: Input,
+                                plugins: list[$1T],
+                                serialize: Callable[[Input, $4T], Awaitable[$2T]],
+                                deserialize: Callable[[$3T, $4T], Awaitable[Output]],
+                                config: $4T,
+                                operation_name: str,
+                                event_deserializer: Callable[[ShapeDeserializer], Any],
+                            ) -> Any:
+                                response_future = Future[$3T]()
+                                output = await self._execute_operation(
+                                    input, plugins, serialize, deserialize, config, operation_name,
+                                    response_future=response_future
+                                )
+                                transport_response = await response_future
+                                ${6C|}
+
+                            async def _duplex_stream(
+                                self,
+                                input: Input,
+                                plugins: list[$1T],
+                                serialize: Callable[[Input, $4T], Awaitable[$2T]],
+                                deserialize: Callable[[$3T, $4T], Awaitable[Output]],
+                                config: $4T,
+                                operation_name: str,
+                                event_deserializer: Callable[[ShapeDeserializer], Any],
+                            ) -> Any:
+                                request_future = Future[$2T]()
+                                response_future = Future[$3T]()
+                                awaitable_output = asyncio.create_task(self._execute_operation(
+                                    input, plugins, serialize, deserialize, config, operation_name,
+                                    request_future=request_future,
+                                    response_future=response_future
+                                ))
+                                transport_request = await request_future
+                                ${7C|}
+                            """,
+                    pluginSymbol,
+                    transportRequest,
+                    transportResponse,
+                    configSymbol,
+                    writer.consumer(w -> context.protocolGenerator().wrapInputStream(context, w)),
+                    writer.consumer(w -> context.protocolGenerator().wrapOutputStream(context, w)),
+                    writer.consumer(w -> context.protocolGenerator().wrapDuplexStream(context, w)));
+        }
+
         writer.write(
                 """
                         async def _execute_operation(
@@ -197,25 +264,25 @@ final class ClientGenerator implements Runnable {
                             deserialize: Callable[[$3T, $5T], Awaitable[Output]],
                             config: $5T,
                             operation_name: str,
-                            ${?hasEventStream}
-                            has_input_stream: bool = False,
-                            event_deserializer: Callable[[ShapeDeserializer], Any] | None = None,
-                            event_response_deserializer: DeserializeableShape | None = None,
-                            ${/hasEventStream}
+                            request_future: Future[$2T] | None = None,
+                            response_future: Future[$3T] | None = None,
                         ) -> Output:
                             try:
                                 return await self._handle_execution(
                                     input, plugins, serialize, deserialize, config, operation_name,
-                                    ${?hasEventStream}
-                                    has_input_stream, event_deserializer, event_response_deserializer,
-                                    ${/hasEventStream}
+                                    request_future, response_future,
                                 )
                             except Exception as e:
+                                if request_future is not None and not request_future.done:
+                                    request_future.set_exception($4T(e))
+                                if response_future is not None and not response_future.done:
+                                    response_future.set_exception($4T(e))
+
                                 # Make sure every exception that we throw is an instance of $4T so
                                 # customers can reliably catch everything we throw.
                                 if not isinstance(e, $4T):
                                     raise $4T(e) from e
-                                raise e
+                                raise
 
                         async def _handle_execution(
                             self,
@@ -225,11 +292,8 @@ final class ClientGenerator implements Runnable {
                             deserialize: Callable[[$3T, $5T], Awaitable[Output]],
                             config: $5T,
                             operation_name: str,
-                            ${?hasEventStream}
-                            has_input_stream: bool = False,
-                            event_deserializer: Callable[[ShapeDeserializer], Any] | None = None,
-                            event_response_deserializer: DeserializeableShape | None = None,
-                            ${/hasEventStream}
+                            request_future: Future[$2T] | None,
+                            response_future: Future[$3T] | None,
                         ) -> Output:
                             logger.debug('Making request for operation "%s" with parameters: %s', operation_name, input)
                             context: InterceptorContext[Input, None, None, None] = InterceptorContext(
@@ -307,6 +371,7 @@ final class ClientGenerator implements Runnable {
                                         context_with_transport_request.copy(),
                                         config,
                                         operation_name,
+                                        request_future,
                                     )
 
                                     # We perform this type-ignored re-assignment because `context` needs
@@ -342,6 +407,10 @@ final class ClientGenerator implements Runnable {
                                     else:
                                         # Step 8: Invoke record_success
                                         retry_strategy.record_success(token=retry_token)
+                                        if response_future is not None:
+                                            response_future.set_result(
+                                                context_with_response.response,  # type: ignore
+                                            )
                                         break
                             except Exception as e:
                                 if context.response is not None:
@@ -355,16 +424,7 @@ final class ClientGenerator implements Runnable {
                             execution_context = cast(
                                 InterceptorContext[Input, Output, $2T | None, $3T | None], context
                             )
-                            ${^hasEventStream}
                             return await self._finalize_execution(interceptors, execution_context)
-                            ${/hasEventStream}
-                            ${?hasEventStream}
-                            operation_output = await self._finalize_execution(interceptors, execution_context)
-                            if has_input_stream or event_deserializer is not None:
-                                ${6C|}
-                            else:
-                                return operation_output
-                            ${/hasEventStream}
 
                         async def _handle_attempt(
                             self,
@@ -373,6 +433,7 @@ final class ClientGenerator implements Runnable {
                             context: InterceptorContext[Input, None, $2T, None],
                             config: $5T,
                             operation_name: str,
+                            request_future: Future[$2T] | None,
                         ) -> InterceptorContext[Input, Output, $2T, $3T | None]:
                             try:
                                 # assert config.interceptors is not None
@@ -385,8 +446,7 @@ final class ClientGenerator implements Runnable {
                 transportRequest,
                 transportResponse,
                 errorSymbol,
-                configSymbol,
-                writer.consumer(w -> context.protocolGenerator().wrapEventStream(context, w)));
+                configSymbol);
 
         boolean supportsAuth = !ServiceIndex.of(context.model()).getAuthSchemes(service).isEmpty();
         writer.pushState(new ResolveIdentitySection());
@@ -533,10 +593,19 @@ final class ClientGenerator implements Runnable {
                             )
                             logger.debug("HTTP request config: %s", request_config)
                             logger.debug("Sending HTTP request: %s", context_with_response.transport_request)
-                            context_with_response._transport_response = await config.http_client.send(
-                                request=context_with_response.transport_request,
-                                request_config=request_config,
-                            )
+
+                            if request_future is not None:
+                                response_task = asyncio.create_task(config.http_client.send(
+                                    request=context_with_response.transport_request,
+                                    request_config=request_config,
+                                ))
+                                request_future.set_result(context_with_response.transport_request)
+                                context_with_response._transport_response = await response_task
+                            else:
+                                context_with_response._transport_response = await config.http_client.send(
+                                    request=context_with_response.transport_request,
+                                    request_config=request_config,
+                                )
                             logger.debug("Received HTTP response: %s", context_with_response.transport_response)
 
                     """, transportRequest, transportResponse);
@@ -834,16 +903,14 @@ final class ClientGenerator implements Runnable {
                             raise NotImplementedError()
                             ${/hasProtocol}
                             ${?hasProtocol}
-                            return await self._execute_operation(
+                            return await self._duplex_stream(
                                 input=input,
                                 plugins=operation_plugins,
                                 serialize=${serSymbol:T},
                                 deserialize=${deserSymbol:T},
                                 config=self._config,
                                 operation_name=${operationName:S},
-                                has_input_stream=True,
                                 event_deserializer=$T().deserialize,
-                                event_response_deserializer=${output:T},
                             )  # type: ignore
                             ${/hasProtocol}
                         """,
@@ -862,14 +929,13 @@ final class ClientGenerator implements Runnable {
                             raise NotImplementedError()
                             ${/hasProtocol}
                             ${?hasProtocol}
-                            return await self._execute_operation(
+                            return await self._input_stream(
                                 input=input,
                                 plugins=operation_plugins,
                                 serialize=${serSymbol:T},
                                 deserialize=${deserSymbol:T},
                                 config=self._config,
                                 operation_name=${operationName:S},
-                                has_input_stream=True,
                             )  # type: ignore
                             ${/hasProtocol}
                         """, writer.consumer(w -> writeSharedOperationInit(w, operation, input)));
@@ -887,7 +953,7 @@ final class ClientGenerator implements Runnable {
                         raise NotImplementedError()
                         ${/hasProtocol}
                         ${?hasProtocol}
-                        return await self._execute_operation(
+                        return await self._output_stream(
                             input=input,
                             plugins=operation_plugins,
                             serialize=${serSymbol:T},
@@ -895,7 +961,6 @@ final class ClientGenerator implements Runnable {
                             config=self._config,
                             operation_name=${operationName:S},
                             event_deserializer=$T().deserialize,
-                            event_response_deserializer=${output:T},
                         )  # type: ignore
                         ${/hasProtocol}
                     """,

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ProtocolGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ProtocolGenerator.java
@@ -154,23 +154,9 @@ public interface ProtocolGenerator {
      */
     default void generateProtocolTests(GenerationContext context) {}
 
-    /**
-     * Generates the code to wrap an operation output into an event stream.
-     *
-     * <p>Important context variables are:
-     * <ul>
-     *     <li>execution_context - Has the context, including the transport input and output.</li>
-     *     <li>operation_output - The deserialized operation output.</li>
-     *     <li>has_input_stream - Whether or not there is an input stream.</li>
-     *     <li>event_deserializer - The deserialize method for output events, or None for no output stream.</li>
-     *     <li>event_response_deserializer - A DeserializeableShape representing the operation's output shape,
-     *         or None for no output stream. This is used when the operation sends the initial response over the
-     *         event stream.
-     *     </li>
-     * </ul>
-     *
-     * @param context Generation context.
-     * @param writer The writer to write to.
-     */
-    default void wrapEventStream(GenerationContext context, PythonWriter writer) {}
+    default void wrapInputStream(GenerationContext context, PythonWriter writer) {}
+
+    default void wrapOutputStream(GenerationContext context, PythonWriter writer) {}
+
+    default void wrapDuplexStream(GenerationContext context, PythonWriter writer) {}
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
@@ -403,7 +403,7 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                         return AWSInputEventStream[Any, Any](
                             payload_codec=codec,
                             awaitable_output=awaitable_output,
-                            async_writer=transport_request.body,  # type: ignore
+                            async_writer=request_context.transport_request.body,  # type: ignore
                         )
                         """);
     }
@@ -443,7 +443,7 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                         codec = JSONCodec(default_timestamp_format=TimestampFormat.EPOCH_SECONDS)
                         return AWSDuplexEventStream[Any, Any, Any](
                             payload_codec=codec,
-                            async_writer=transport_request.body,  # type: ignore
+                            async_writer=request_context.transport_request.body,  # type: ignore
                             awaitable_output=awaitable_output,
                             awaitable_response=response_future,
                             deserializer=event_deserializer,  # type: ignore

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
@@ -390,48 +390,64 @@ public class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void wrapEventStream(GenerationContext context, PythonWriter writer) {
+    public void wrapInputStream(GenerationContext context, PythonWriter writer) {
         writer.addDependency(SmithyPythonDependency.SMITHY_JSON);
         writer.addDependency(SmithyPythonDependency.AWS_EVENT_STREAM);
-        writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addImports("aws_event_stream.aio",
-                Set.of(
-                        "AWSDuplexEventStream",
-                        "AWSInputEventStream",
-                        "AWSOutputEventStream"));
         writer.addImport("smithy_json", "JSONCodec");
         writer.addImport("smithy_core.aio.types", "AsyncBytesReader");
         writer.addImport("smithy_core.types", "TimestampFormat");
-        writer.addStdlibImport("typing", "Any");
-
-        writer.write("""
-                codec = JSONCodec(default_timestamp_format=TimestampFormat.EPOCH_SECONDS)
-                if has_input_stream:
-                    if event_deserializer is not None:
-                        return AWSDuplexEventStream[Any, Any, Any](
+        writer.addImport("aws_event_stream.aio", "AWSInputEventStream");
+        writer.write(
+                """
+                        codec = JSONCodec(default_timestamp_format=TimestampFormat.EPOCH_SECONDS)
+                        return AWSInputEventStream[Any, Any](
                             payload_codec=codec,
-                            initial_response=operation_output,
-                            async_writer=execution_context.transport_request.body,  # type: ignore
+                            awaitable_output=awaitable_output,
+                            async_writer=transport_request.body,  # type: ignore
+                        )
+                        """);
+    }
+
+    @Override
+    public void wrapOutputStream(GenerationContext context, PythonWriter writer) {
+        writer.addDependency(SmithyPythonDependency.SMITHY_JSON);
+        writer.addDependency(SmithyPythonDependency.AWS_EVENT_STREAM);
+        writer.addImport("smithy_json", "JSONCodec");
+        writer.addImport("smithy_core.aio.types", "AsyncBytesReader");
+        writer.addImport("smithy_core.types", "TimestampFormat");
+        writer.addImport("aws_event_stream.aio", "AWSOutputEventStream");
+        writer.write(
+                """
+                        codec = JSONCodec(default_timestamp_format=TimestampFormat.EPOCH_SECONDS)
+                        return AWSOutputEventStream[Any, Any](
+                            payload_codec=codec,
+                            initial_response=output,
                             async_reader=AsyncBytesReader(
-                                execution_context.transport_response.body  # type: ignore
+                                transport_response.body  # type: ignore
                             ),
                             deserializer=event_deserializer,  # type: ignore
                         )
-                    else:
-                        return AWSInputEventStream[Any, Any](
+                        """);
+    }
+
+    @Override
+    public void wrapDuplexStream(GenerationContext context, PythonWriter writer) {
+        writer.addDependency(SmithyPythonDependency.SMITHY_JSON);
+        writer.addDependency(SmithyPythonDependency.AWS_EVENT_STREAM);
+        writer.addImport("smithy_json", "JSONCodec");
+        writer.addImport("smithy_core.aio.types", "AsyncBytesReader");
+        writer.addImport("smithy_core.types", "TimestampFormat");
+        writer.addImport("aws_event_stream.aio", "AWSDuplexEventStream");
+        writer.write(
+                """
+                        codec = JSONCodec(default_timestamp_format=TimestampFormat.EPOCH_SECONDS)
+                        return AWSDuplexEventStream[Any, Any, Any](
                             payload_codec=codec,
-                            initial_response=operation_output,
-                            async_writer=execution_context.transport_request.body,  # type: ignore
+                            async_writer=transport_request.body,  # type: ignore
+                            awaitable_output=awaitable_output,
+                            awaitable_response=response_future,
+                            deserializer=event_deserializer,  # type: ignore
                         )
-                else:
-                    return AWSOutputEventStream[Any, Any](
-                        payload_codec=codec,
-                        initial_response=operation_output,
-                        async_reader=AsyncBytesReader(
-                            execution_context.transport_response.body  # type: ignore
-                        ),
-                        deserializer=event_deserializer,  # type: ignore
-                    )
-                """);
+                        """);
     }
 }


### PR DESCRIPTION
This adds (optional) request and response futures that are plumbed through the request pipeline. These are used to return event streams immediately when events are ready to be sent.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
