### PR TITLE
Stop iterating fields once we find a match

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/restjson.py
+++ b/packages/smithy-http/src/smithy_http/aio/restjson.py
@@ -30,6 +30,7 @@ async def parse_rest_json_error_info(
     for field in http_response.fields:
         if field.name.lower() == _REST_JSON_CODE_HEADER:
             code = field.values[0]
+            break
 
     if check_body:
         if body := await http_response.consume_body_async():


### PR DESCRIPTION
Caught while running the debugger, we can find the match early and then go through all the other headers before moving on. Same class of issue as we found in the user agent PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
