### PR TITLE
Ensure streams get closed and don't wait on concurrent futures in crt

### DIFF
--- a/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
@@ -50,7 +50,9 @@ class AWSAsyncEventReceiver[E: DeserializeableShape](AsyncEventReceiver[E]):
             event = await Event.decode_async(self._source)
         except Exception as e:
             await self.close()
-            raise IOError("Failed to read from stream.") from e
+            if not isinstance(e, EventError):
+                raise IOError("Failed to read from stream.") from e
+            raise
 
         if event is None:
             return None

--- a/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
@@ -50,8 +50,11 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
         self._serializer = EventSerializer(
             payload_codec=payload_codec, is_client_mode=is_client_mode
         )
+        self._closed = False
 
     async def send(self, event: E) -> None:
+        if self._closed:
+            raise IOError("Attempted to write to closed stream.")
         event.serialize(self._serializer)
         result = self._serializer.get_result()
         if result is None:
@@ -60,12 +63,26 @@ class AWSAsyncEventPublisher[E: SerializeableShape](AsyncEventPublisher[E]):
             )
         if self._signer is not None:
             result = self._signer(result)
-        await self._writer.write(result.encode())
+
+        encoded_result = result.encode()
+        try:
+            await self._writer.write(encoded_result)
+        except Exception as e:
+            await self.close()
+            raise IOError("Failed to write to stream.") from e
 
     async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
         if (close := getattr(self._writer, "close", None)) is not None:
             if asyncio.iscoroutine(result := close()):
                 await result
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
 
 
 class EventSerializer(SpecificShapeSerializer):

--- a/packages/aws-event-stream/tests/unit/_private/test_serializers.py
+++ b/packages/aws-event-stream/tests/unit/_private/test_serializers.py
@@ -1,10 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+from typing import Any
+
 import pytest
 from smithy_core.serializers import SerializeableShape
+from smithy_core.aio.types import AsyncBytesProvider
 from smithy_json import JSONCodec
 
-from aws_event_stream._private.serializers import EventSerializer
+from aws_event_stream._private.serializers import (
+    EventSerializer,
+    AWSAsyncEventPublisher,
+)
 from aws_event_stream.events import EventMessage
 
 from . import EVENT_STREAM_SERDE_CASES, INITIAL_REQUEST_CASE, INITIAL_RESPONSE_CASE
@@ -36,3 +42,41 @@ def test_serialize_initial_request():
 
 def test_serialize_initial_response():
     test_event_serializer_server_mode(*INITIAL_RESPONSE_CASE)
+
+
+async def test_publisher_closes_reader():
+    writer = AsyncBytesProvider()
+    publisher: AWSAsyncEventPublisher[Any] = AWSAsyncEventPublisher(
+        payload_codec=JSONCodec(), async_writer=writer
+    )
+
+    assert not publisher.closed
+    assert not writer.closed
+    await publisher.close()
+    assert publisher.closed
+    assert writer.closed
+
+
+async def test_send_after_close():
+    writer = AsyncBytesProvider()
+    publisher: AWSAsyncEventPublisher[Any] = AWSAsyncEventPublisher(
+        payload_codec=JSONCodec(), async_writer=writer
+    )
+
+    await publisher.close()
+    assert publisher.closed
+    with pytest.raises(IOError):
+        await publisher.send(EVENT_STREAM_SERDE_CASES[0][0])
+
+
+async def test_send_to_closed_writer():
+    writer = AsyncBytesProvider()
+    publisher: AWSAsyncEventPublisher[Any] = AWSAsyncEventPublisher(
+        payload_codec=JSONCodec(), async_writer=writer
+    )
+
+    await writer.close()
+    with pytest.raises(IOError):
+        await publisher.send(EVENT_STREAM_SERDE_CASES[0][0])
+
+    assert publisher.closed

--- a/packages/smithy-core/src/smithy_core/aio/types.py
+++ b/packages/smithy-core/src/smithy_core/aio/types.py
@@ -114,12 +114,12 @@ class AsyncBytesReader:
 
     async def close(self) -> None:
         """Closes the stream, as well as the underlying stream where possible."""
+        self._closed = True
         if (close := getattr(self._data, "close", None)) is not None:
             if asyncio.iscoroutine(result := close()):
                 await result
 
         self._data = None
-        self._closed = True
 
 
 class SeekableAsyncBytesReader:

--- a/packages/smithy-core/src/smithy_core/aio/utils.py
+++ b/packages/smithy-core/src/smithy_core/aio/utils.py
@@ -1,18 +1,16 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from asyncio import sleep
+from asyncio import sleep, iscoroutine
 from collections.abc import AsyncIterable, Iterable
-from typing import TypeVar
+from typing import Any
 
 from ..exceptions import AsyncBodyException
 from ..interfaces import BytesReader
 from ..interfaces import StreamingBlob as SyncStreamingBlob
 from .interfaces import AsyncByteStream, StreamingBlob
 
-_ListEl = TypeVar("_ListEl")
 
-
-async def async_list(lst: Iterable[_ListEl]) -> AsyncIterable[_ListEl]:
+async def async_list[E](lst: Iterable[E]) -> AsyncIterable[E]:
     """Turn an Iterable into an AsyncIterable."""
     for x in lst:
         await sleep(0)
@@ -53,3 +51,10 @@ def read_streaming_blob(body: StreamingBlob) -> bytes:
             raise AsyncBodyException(
                 f"Expected type {SyncStreamingBlob}, but was {type(body)}"
             )
+
+
+async def close(stream: Any) -> None:
+    """Close a stream, awaiting it if it's async."""
+    if (close := getattr(stream, "close", None)) is not None:
+        if iscoroutine(result := close()):
+            await result

--- a/packages/smithy-core/tests/unit/aio/test_utils.py
+++ b/packages/smithy-core/tests/unit/aio/test_utils.py
@@ -1,0 +1,24 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from io import BytesIO
+
+from smithy_core.aio.types import AsyncBytesProvider
+from smithy_core.aio.utils import close
+
+
+async def test_close_sync_closeable() -> None:
+    stream = BytesIO()
+    assert not stream.closed
+    await close(stream)
+    assert stream.closed
+
+
+async def test_close_async_closeable() -> None:
+    stream = AsyncBytesProvider()
+    assert not stream.closed
+    await close(stream)
+    assert stream.closed
+
+
+async def test_close_non_closeable() -> None:
+    await close(b"foo")

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -7,6 +7,7 @@ from concurrent.futures import Future as ConcurrentFuture
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterable
 from copy import deepcopy
+from functools import partial
 from io import BytesIO, BufferedIOBase
 from typing import TYPE_CHECKING, Any
 
@@ -231,7 +232,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         :param request: The request including destination URI, fields, payload.
         :param request_config: Configuration specific to this request.
         """
-        crt_request = await self._marshal_request(request)
+        crt_request, crt_body = await self._marshal_request(request)
         connection = await self._get_connection(request.destination)
         response_body = CRTResponseBody()
         response_factory = CRTResponseFactory(response_body)
@@ -242,7 +243,16 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         )
         response_factory.set_done_callback(crt_stream)
         response_body.set_stream(crt_stream)
+        crt_stream.completion_future.add_done_callback(
+            partial(self._close_input_body, body=crt_body)
+        )
         return await response_factory.await_response()
+
+    def _close_input_body(
+        self, future: ConcurrentFuture[int], *, body: "BufferableByteStream | BytesIO"
+    ) -> None:
+        if future.exception(timeout=0):
+            body.close()
 
     async def _create_connection(
         self, url: core_interfaces.URI
@@ -314,7 +324,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     async def _marshal_request(
         self, request: http_aio_interfaces.HTTPRequest
-    ) -> "crt_http.HttpRequest":
+    ) -> tuple["crt_http.HttpRequest", "BufferableByteStream | BytesIO"]:
         """Create :py:class:`awscrt.http.HttpRequest` from
         :py:class:`smithy_http.aio.HTTPRequest`"""
         headers_list = []
@@ -343,13 +353,11 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             crt_body = BytesIO(body)
         else:
             # If the body is async, or potentially very large, start up a task to read
-            # it into the BytesIO object that CRT needs. By using asyncio.create_task
-            # we'll start the coroutine without having to explicitly await it.
+            # it into the intermediate object that CRT needs. By using
+            # asyncio.create_task we'll start the coroutine without having to
+            # explicitly await it.
             crt_body = BufferableByteStream()
-            if not isinstance(body, AsyncIterable):
-                # If the body isn't already an async iterable, wrap it in one. Objects
-                # with read methods will be read in chunks so as not to exhaust memory.
-                body = AsyncBytesReader(body)
+            body = AsyncBytesReader(body)
 
             # Start the read task in the background.
             read_task = asyncio.create_task(self._consume_body_async(body, crt_body))
@@ -365,13 +373,19 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             headers=headers,
             body_stream=crt_body,
         )
-        return crt_request
+        return crt_request, crt_body
 
     async def _consume_body_async(
-        self, source: AsyncIterable[bytes], dest: "BufferableByteStream"
+        self, source: AsyncBytesReader, dest: "BufferableByteStream"
     ) -> None:
-        async for chunk in source:
-            dest.write(chunk)
+        try:
+            async for chunk in source:
+                dest.write(chunk)
+        except Exception:
+            dest.close()
+            raise
+        finally:
+            await source.close()
         dest.end_stream()
 
     def __deepcopy__(self, memo: Any) -> "AWSCRTHTTPClient":

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -26,7 +26,7 @@ async def test_client_marshal_request() -> None:
         body=BytesIO(),
         fields=Fields(),
     )
-    crt_request = await client._marshal_request(request)  # type: ignore
+    crt_request, _ = await client._marshal_request(request)  # type: ignore
     assert crt_request.headers.get("host") == "example.com"  # type: ignore
     assert crt_request.headers.get("accept") == "*/*"  # type: ignore
     assert crt_request.method == "GET"  # type: ignore


### PR DESCRIPTION



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
