### PR TITLE
Add operation shape generation

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonClientCodegen.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonClientCodegen.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.codegen.core.directed.GenerateErrorDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateIntEnumDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateListDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateMapDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateOperationDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateStructureDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateUnionDirective;
@@ -35,6 +36,7 @@ import software.amazon.smithy.python.codegen.generators.InitGenerator;
 import software.amazon.smithy.python.codegen.generators.IntEnumGenerator;
 import software.amazon.smithy.python.codegen.generators.ListGenerator;
 import software.amazon.smithy.python.codegen.generators.MapGenerator;
+import software.amazon.smithy.python.codegen.generators.OperationGenerator;
 import software.amazon.smithy.python.codegen.generators.ProtocolGenerator;
 import software.amazon.smithy.python.codegen.generators.SchemaGenerator;
 import software.amazon.smithy.python.codegen.generators.ServiceErrorGenerator;
@@ -132,6 +134,19 @@ final class DirectedPythonClientCodegen
         protocolGenerator.generateResponseDeserializers(directive.context());
 
         protocolGenerator.generateProtocolTests(directive.context());
+    }
+
+    @Override
+    public void generateOperation(GenerateOperationDirective<GenerationContext, PythonSettings> directive) {
+        DirectedCodegen.super.generateOperation(directive);
+
+        directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
+            OperationGenerator generator = new OperationGenerator(
+                    directive.context(),
+                    writer,
+                    directive.shape());
+            generator.run();
+        });
     }
 
     @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -255,7 +255,9 @@ public final class HttpProtocolTestGenerator implements Runnable {
                             except Exception as err:
                                 fail(f"Expected '$2L' exception to be thrown, but received {type(err).__name__}: {err}")
                             """,
-                            context.symbolProvider().toSymbol(operation),
+                            context.symbolProvider()
+                                    .toSymbol(operation)
+                                    .expectProperty(SymbolProperties.OPERATION_METHOD),
                             TEST_HTTP_SERVICE_ERR_SYMBOL,
                             testCase.getMethod(),
                             testCase.getUri(),
@@ -459,7 +461,9 @@ public final class HttpProtocolTestGenerator implements Runnable {
 
                                 ${C|}
                             """,
-                            context.symbolProvider().toSymbol(operation),
+                            context.symbolProvider()
+                                    .toSymbol(operation)
+                                    .expectProperty(SymbolProperties.OPERATION_METHOD),
                             (Runnable) () -> testCase.getParams().accept(new ValueNodeVisitor(outputShape)),
                             (Runnable) () -> assertResponseEqual(testCase, operation));
                 });
@@ -507,7 +511,9 @@ public final class HttpProtocolTestGenerator implements Runnable {
                                         if type(err).__name__ != $2S:
                                             fail(f"Expected '$2L' exception to be thrown, but received {type(err).__name__}: {err}")
                                     """,
-                            context.symbolProvider().toSymbol(operation),
+                            context.symbolProvider()
+                                    .toSymbol(operation)
+                                    .expectProperty(SymbolProperties.OPERATION_METHOD),
                             error.getId().getName());
                     // TODO: Correctly assert the status code and other values
                 });

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
@@ -276,8 +276,16 @@ public final class PythonSymbolProvider implements SymbolProvider, ShapeVisitor<
     public Symbol operationShape(OperationShape shape) {
         // Operation names are escaped like members because ultimately they're
         // properties on an object too.
-        var name = escaper.escapeMemberName(CaseUtils.toSnakeCase(shape.getId().getName(service)));
-        return createGeneratedSymbolBuilder(shape, name, "client").build();
+        var methodName = escaper.escapeMemberName(CaseUtils.toSnakeCase(shape.getId().getName(service)));
+        var methodSymbol = createGeneratedSymbolBuilder(shape, methodName, "client", false)
+                .putProperty(SymbolProperties.IMPORTABLE, false)
+                .build();
+
+        // We add a symbol for the method in the client as a property, whereas the actual
+        // operation symbol points to the generated type for it
+        return createGeneratedSymbolBuilder(shape, getDefaultShapeName(shape), SHAPES_FILE)
+                .putProperty(SymbolProperties.OPERATION_METHOD, methodSymbol)
+                .build();
     }
 
     @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
@@ -283,7 +283,8 @@ public final class PythonSymbolProvider implements SymbolProvider, ShapeVisitor<
 
         // We add a symbol for the method in the client as a property, whereas the actual
         // operation symbol points to the generated type for it
-        return createGeneratedSymbolBuilder(shape, getDefaultShapeName(shape), SHAPES_FILE)
+        var name = CaseUtils.toSnakeCase(getDefaultShapeName(shape)).toUpperCase(Locale.ENGLISH);
+        return createGeneratedSymbolBuilder(shape, name, SHAPES_FILE)
                 .putProperty(SymbolProperties.OPERATION_METHOD, methodSymbol)
                 .build();
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
@@ -73,5 +73,16 @@ public final class SymbolProperties {
      */
     public static final Property<Symbol> DESERIALIZER = Property.named("deserializer");
 
+    /**
+     * Contains a symbol pointing to an operation shape's method in the client. This is
+     * only used for operations.
+     */
+    public static final Property<Symbol> OPERATION_METHOD = Property.named("operationMethod");
+
+    /**
+     * Whether a symbol is importable (i.e. an instance method is not "importable")
+     */
+    public static final Property<Boolean> IMPORTABLE = Property.named("nonImportable");
+
     private SymbolProperties() {}
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/OperationGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/OperationGenerator.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.python.codegen.generators;
+
+import java.util.List;
+import java.util.logging.Logger;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.python.codegen.GenerationContext;
+import software.amazon.smithy.python.codegen.SymbolProperties;
+import software.amazon.smithy.python.codegen.writer.PythonWriter;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class OperationGenerator implements Runnable {
+    private static final Logger LOGGER = Logger.getLogger(OperationGenerator.class.getName());
+
+    private final GenerationContext context;
+    private final PythonWriter writer;
+    private final OperationShape shape;
+    private final SymbolProvider symbolProvider;
+    private final Model model;
+
+    public OperationGenerator(GenerationContext context, PythonWriter writer, OperationShape shape) {
+        this.context = context;
+        this.writer = writer;
+        this.shape = shape;
+        this.symbolProvider = context.symbolProvider();
+        this.model = context.model();
+    }
+
+    @Override
+    public void run() {
+        var opSymbol = symbolProvider.toSymbol(shape);
+        var inSymbol = symbolProvider.toSymbol(model.expectShape(shape.getInputShape()));
+        var outSymbol = symbolProvider.toSymbol(model.expectShape(shape.getOutputShape()));
+
+        writer.addStdlibImport("dataclasses", "dataclass");
+        writer.addImport("smithy_core.schemas", "APIOperation");
+        writer.addImport("smithy_core.type_registry", "TypeRegistry");
+
+        writer.write("""
+                @dataclass(kw_only=True, frozen=True)
+                class $1L(APIOperation["$2T", "$3T"]):
+                        input = $2T
+                        output = $3T
+                        schema = $4T
+                        input_schema = $5T
+                        output_schema = $6T
+                        error_registry = TypeRegistry({
+                            $7C
+                        })
+                        effective_auth_schemes = [
+                            $8C
+                        ]
+                """,
+                opSymbol.getName(),
+                inSymbol,
+                outSymbol,
+                opSymbol.expectProperty(SymbolProperties.SCHEMA),
+                inSymbol.expectProperty(SymbolProperties.SCHEMA),
+                outSymbol.expectProperty(SymbolProperties.SCHEMA),
+                writer.consumer(this::writeErrorTypeRegistry),
+                writer.consumer(this::writeAuthSchemes)
+        // TODO: Docs? Maybe not necessary on the operation type itself
+        // TODO: Singleton?
+        );
+    }
+
+    private void writeErrorTypeRegistry(PythonWriter writer) {
+        List<ShapeId> errors = shape.getErrors();
+        if (!errors.isEmpty()) {
+            writer.addImport("smithy_core.shapes", "ShapeID");
+        }
+        for (var error : errors) {
+            var errSymbol = symbolProvider.toSymbol(model.expectShape(error));
+            writer.write("ShapeID($S): $T,", error, errSymbol);
+        }
+    }
+
+    private void writeAuthSchemes(PythonWriter writer) {
+        var authSchemes = ServiceIndex.of(model)
+                .getEffectiveAuthSchemes(context.settings().service(),
+                        shape.getId(),
+                        ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE);
+
+        if (!authSchemes.isEmpty()) {
+            writer.addImport("smithy_core.shapes", "ShapeID");
+        }
+
+        for (var authSchemeId : authSchemes.keySet()) {
+            writer.write("ShapeID($S)", authSchemeId);
+        }
+
+    }
+}

--- a/packages/smithy-core/src/smithy_core/documents.py
+++ b/packages/smithy-core/src/smithy_core/documents.py
@@ -682,7 +682,7 @@ class TypeRegistry:
     def __contains__(self, item: object, /):
         """Check if the registry contains the given shape.
 
-        :param shape: The shape ID to check for.
+        :param item: The shape ID to check for.
         """
         return item in self._types or (
             self._sub_registry is not None and item in self._sub_registry


### PR DESCRIPTION
*Description of changes:*
- Adds operation shape code generation
- These will be used when we transition the client to use the python-based request pipeline
- This is a subset of changes from #422

example:
```
GetCity = APIOperation(
    input=GetCityInput,
    output=GetCityOutput,
    schema=_SCHEMA_GET_CITY,
    input_schema=_SCHEMA_GET_CITY_INPUT,
    output_schema=_SCHEMA_GET_CITY_OUTPUT,
    error_registry=TypeRegistry(
        {
            ShapeID("example.weather#NoSuchResource"): NoSuchResource,
        }
    ),
    effective_auth_schemes=[ShapeID("smithy.api#noAuth")],
)
```

CI run: https://github.com/smithy-lang/smithy-python/actions/runs/13866147289/job/38805575326?pr=445

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
