### PR TITLE
Include code in unknown error messages

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/HttpProtocolGeneratorUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/HttpProtocolGeneratorUtils.java
@@ -149,7 +149,7 @@ public final class HttpProtocolGeneratorUtils {
                             ${7C|}
 
                             case _:
-                                return $5T(message)
+                                return $5T(f"{code}: {message}")
                     """,
                     errorDispatcher.getName(),
                     transportResponse,


### PR DESCRIPTION
Before:

```
aws_sdk_bedrock_runtime.models.UnknownApiError: The security token included in the request is invalid.
```

After:

```
aws_sdk_bedrock_runtime.models.UnknownApiError: UnrecognizedClientException: The security token included in the request is invalid.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
