### PR TITLE
Close request when initial response fails and propagate error

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -286,9 +286,9 @@ final class ClientGenerator implements Runnable {
                                     request_future, response_future,
                                 )
                             except Exception as e:
-                                if request_future is not None and not request_future.done:
+                                if request_future is not None and not request_future.done():
                                     request_future.set_exception($4T(e))
-                                if response_future is not None and not response_future.done:
+                                if response_future is not None and not response_future.done():
                                     response_future.set_exception($4T(e))
 
                                 # Make sure every exception that we throw is an instance of $4T so

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -174,13 +174,13 @@ class CRTResponseFactory:
                     kind=FieldPosition.HEADER,
                 )
 
-            self._response_future.set_result(
-                AWSCRTHTTPResponse(
-                    status=status_code,
-                    fields=fields,
-                    body=self._body,
-                )
+        self._response_future.set_result(
+            AWSCRTHTTPResponse(
+                status=status_code,
+                fields=fields,
+                body=self._body,
             )
+        )
 
     async def await_response(self) -> AWSCRTHTTPResponse:
         return await asyncio.wrap_future(self._response_future)

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -174,13 +174,15 @@ class CRTResponseFactory:
                     kind=FieldPosition.HEADER,
                 )
 
-        self._response_future.set_result(
-            AWSCRTHTTPResponse(
-                status=status_code,
-                fields=fields,
-                body=self._body,
-            )
+        response = AWSCRTHTTPResponse(
+            status=status_code,
+            fields=fields,
+            body=self._body,
         )
+        if status_code != 200 and status_code >= 300:
+            self._response_future.set_exception(CRTErrorResponse(response))
+        else:
+            self._response_future.set_result(response)
 
     async def await_response(self) -> AWSCRTHTTPResponse:
         return await asyncio.wrap_future(self._response_future)
@@ -191,6 +193,18 @@ class CRTResponseFactory:
     def _cancel(self, completion_future: ConcurrentFuture[int | Exception]) -> None:
         if not self._response_future.done():
             self._response_future.cancel()
+
+
+class CRTErrorResponse(Exception):
+    def __init__(self, response: AWSCRTHTTPResponse) -> None:
+        self._status = response.status
+        self._response = response
+
+        super().__init__(f"Request failed with status code {self._status}")
+
+    @property
+    def response(self) -> AWSCRTHTTPResponse:
+        return self._response
 
 
 ConnectionPoolKey = tuple[str, str, int | None]
@@ -251,7 +265,11 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         crt_stream.completion_future.add_done_callback(
             partial(self._close_input_body, body=crt_body)
         )
-        return await response_factory.await_response()
+        try:
+            return await response_factory.await_response()
+        except CRTErrorResponse as e:
+            await close(crt_body)
+            return e.response
 
     def _close_input_body(
         self, future: ConcurrentFuture[int], *, body: "BufferableByteStream | BytesIO"


### PR DESCRIPTION

*Description of changes:*
This fixes an issue where event stream initial response failures cause the stream to hang.  There are two issues:
1.  The response body will not be closed until the request body gets closed (because the h2 streams will be left open).  To signal the server to close the connection, we need to also close the request body to end it.  This is accomplished by checking for error status codes and setting the response future to an exception.  If the response is not closed, the deserialize_error methods will hang forever trying to read the body.
2. We were incorrectly not calling the `done` method on the asyncio response_future and so were not setting the exception in it correclty.

There may be better ways to ensure the request body gets closed on an error in initial request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
