### PR TITLE
Don't assert PropertyKey types

### DIFF
--- a/packages/smithy-core/src/smithy_core/interfaces/__init__.py
+++ b/packages/smithy-core/src/smithy_core/interfaces/__init__.py
@@ -132,9 +132,7 @@ class PropertyKey[T](Protocol):
             value_type=str | int  # type: ignore
         )
 
-    Type checkers will be able to use such a property as expected, and the
-    ``value_type`` property may still be used in ``isinstance`` checks since it also
-    supports union types as of Python 3.10.
+    Type checkers will be able to use such a property as expected.
     """
 
     key: str
@@ -191,9 +189,7 @@ class TypedProperties(Protocol):
 
         assert assert_type(properties[UNION_PROPERTY], str | int) == "foo"
 
-    Type checkers will be able to use such a property as expected, and the
-    ``value_type`` property may still be used in ``isinstance`` checks since it also
-    supports union types as of Python 3.10.
+    Type checkers will be able to use such a property as expected.
     """
 
     @overload

--- a/packages/smithy-core/src/smithy_core/types.py
+++ b/packages/smithy-core/src/smithy_core/types.py
@@ -176,9 +176,7 @@ class PropertyKey[T](_PropertyKey[T]):
             value_type=str | int  # type: ignore
         )
 
-    Type checkers will be able to use such a property as expected, and the
-    ``value_type`` property may still be used in ``isinstance`` checks since it also
-    supports union types as of Python 3.10.
+    Type checkers will be able to use such a property as expected.
     """
 
     key: str
@@ -203,6 +201,8 @@ class TypedProperties(UserDict[str, Any], _TypedProperties):
     Letting the value be either a string or PropertyKey allows consumers who care about
     typing to get it, and those who don't care about typing to not have to think about
     it.
+
+    No runtime type assertion is performed.
 
     ..code-block:: python
 
@@ -231,9 +231,7 @@ class TypedProperties(UserDict[str, Any], _TypedProperties):
 
         assert assert_type(properties[UNION_PROPERTY], str | int) == "foo"
 
-    Type checkers will be able to use such a property as expected, and the
-    ``value_type`` property may still be used in ``isinstance`` checks since it also
-    supports union types as of Python 3.10.
+    Type checkers will be able to use such a property as expected.
     """
 
     @overload
@@ -248,13 +246,7 @@ class TypedProperties(UserDict[str, Any], _TypedProperties):
     @overload
     def __setitem__(self, key: str, value: Any) -> None: ...
     def __setitem__(self, key: str | _PropertyKey[Any], value: Any) -> None:
-        if isinstance(key, _PropertyKey):
-            if not isinstance(value, key.value_type):
-                raise ValueError(
-                    f"Expected value type of {key.value_type}, but was {type(value)}"
-                )
-            key = key.key
-        self.data[key] = value
+        self.data[key if isinstance(key, str) else key.key] = value
 
     def __delitem__(self, key: str | _PropertyKey[Any]) -> None:
         del self.data[key if isinstance(key, str) else key.key]

--- a/packages/smithy-core/tests/unit/test_types.py
+++ b/packages/smithy-core/tests/unit/test_types.py
@@ -262,9 +262,6 @@ def test_properties_typed_set() -> None:
     properties[foo_key] = "foo"
     assert properties.data["foo"] == "foo"
 
-    with pytest.raises(ValueError):
-        properties[foo_key] = b"foo"  # type: ignore
-
 
 def test_properties_del() -> None:
     foo_key = PropertyKey(key="foo", value_type=str)
@@ -348,5 +345,10 @@ def test_union_property() -> None:
     properties[union] = 1
     assert assert_type(properties.pop(union, b"bar"), str | int | bytes) == 1
 
-    with pytest.raises(ValueError):
-        properties[union] = b"bar"  # type: ignore
+
+def test_parametric_property() -> None:
+    properties = TypedProperties()
+    parametric = PropertyKey(key="parametric", value_type=dict[str, str])
+    properties[parametric] = {"foo": "bar"}
+
+    assert assert_type(properties[parametric], dict[str, str]) == {"foo": "bar"}


### PR DESCRIPTION
This removes runtime type assertions when inserting typed values into TypedProperties. It only would work on generic-less values, so it isn't worth the effort. Normal typing also has no runtime guarantees, so this isn't exactly a change of behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
