### PR TITLE
Copy request for each attempt / don't retry client errors

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -132,6 +132,7 @@ final class ClientGenerator implements Runnable {
         writer.addStdlibImport("typing", "Awaitable");
         writer.addStdlibImport("typing", "cast");
         writer.addStdlibImport("copy", "deepcopy");
+        writer.addStdlibImport("copy", "copy");
         writer.addStdlibImport("asyncio");
         writer.addStdlibImports("asyncio", Set.of("sleep", "Future"));
         writer.addStdlibImport("dataclasses", "replace");
@@ -395,7 +396,10 @@ final class ClientGenerator implements Runnable {
                                     output_context = await self._handle_attempt(
                                         deserialize,
                                         interceptor_chain,
-                                        request_context,
+                                        replace(
+                                          request_context,
+                                          transport_request = copy(request_context.transport_request)
+                                        ),
                                         config,
                                         operation,
                                         request_future,

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 
+from smithy_core.interfaces.retries import RetryErrorType
+
 from .exceptions import SmithyRetryException
 from .interfaces import retries as retries_interface
 
@@ -232,13 +234,18 @@ class SimpleRetryStrategy(retries_interface.RetryStrategy):
 
         :raises SmithyRetryException: If no further retry attempts are allowed.
         """
-        retry_count = token_to_renew.retry_count + 1
-        if retry_count >= self.max_attempts:
+        if error_info.error_type in [RetryErrorType.TRANSIENT, RetryErrorType.THROTTLING, RetryErrorType.SERVER_ERROR]:
+            retry_count = token_to_renew.retry_count + 1
+            if retry_count >= self.max_attempts:
+                raise SmithyRetryException(
+                    f"Reached maximum number of allowed attempts: {self.max_attempts}"
+                )
+            retry_delay = self.backoff_strategy.compute_next_backoff_delay(retry_count)
+            return SimpleRetryToken(retry_count=retry_count, retry_delay=retry_delay)
+        else:
             raise SmithyRetryException(
-                f"Reached maximum number of allowed attempts: {self.max_attempts}"
+                "Non retryable error"
             )
-        retry_delay = self.backoff_strategy.compute_next_backoff_delay(retry_count)
-        return SimpleRetryToken(retry_count=retry_count, retry_delay=retry_delay)
 
     def record_success(self, *, token: retries_interface.RetryToken) -> None:
         """Not used by this retry strategy."""

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -234,7 +234,11 @@ class SimpleRetryStrategy(retries_interface.RetryStrategy):
 
         :raises SmithyRetryException: If no further retry attempts are allowed.
         """
-        if error_info.error_type in [RetryErrorType.TRANSIENT, RetryErrorType.THROTTLING, RetryErrorType.SERVER_ERROR]:
+        if error_info.error_type in [
+            RetryErrorType.TRANSIENT,
+            RetryErrorType.THROTTLING,
+            RetryErrorType.SERVER_ERROR,
+        ]:
             retry_count = token_to_renew.retry_count + 1
             if retry_count >= self.max_attempts:
                 raise SmithyRetryException(
@@ -243,9 +247,7 @@ class SimpleRetryStrategy(retries_interface.RetryStrategy):
             retry_delay = self.backoff_strategy.compute_next_backoff_delay(retry_count)
             return SimpleRetryToken(retry_count=retry_count, retry_delay=retry_delay)
         else:
-            raise SmithyRetryException(
-                "Non retryable error"
-            )
+            raise SmithyRetryException("Non retryable error")
 
     def record_success(self, *, token: retries_interface.RetryToken) -> None:
         """Not used by this retry strategy."""

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -247,9 +247,7 @@ class SimpleRetryStrategy(retries_interface.RetryStrategy):
             retry_delay = self.backoff_strategy.compute_next_backoff_delay(retry_count)
             return SimpleRetryToken(retry_count=retry_count, retry_delay=retry_delay)
         else:
-            raise SmithyRetryException(
-                f"Error is not retryable: {error_info}"
-            )
+            raise SmithyRetryException(f"Error is not retryable: {error_info}")
 
     def record_success(self, *, token: retries_interface.RetryToken) -> None:
         """Not used by this retry strategy."""

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -247,7 +247,9 @@ class SimpleRetryStrategy(retries_interface.RetryStrategy):
             retry_delay = self.backoff_strategy.compute_next_backoff_delay(retry_count)
             return SimpleRetryToken(retry_count=retry_count, retry_delay=retry_delay)
         else:
-            raise SmithyRetryException("Non retryable error")
+            raise SmithyRetryException(
+                f"Error is not retryable: {error_info}"
+            )
 
     def record_success(self, *, token: retries_interface.RetryToken) -> None:
         """Not used by this retry strategy."""

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -234,11 +234,7 @@ class SimpleRetryStrategy(retries_interface.RetryStrategy):
 
         :raises SmithyRetryException: If no further retry attempts are allowed.
         """
-        if error_info.error_type in [
-            RetryErrorType.TRANSIENT,
-            RetryErrorType.THROTTLING,
-            RetryErrorType.SERVER_ERROR,
-        ]:
+        if error_info.error_type is not RetryErrorType.CLIENT_ERROR:
             retry_count = token_to_renew.retry_count + 1
             if retry_count >= self.max_attempts:
                 raise SmithyRetryException(

--- a/packages/smithy-core/tests/unit/test_retries.py
+++ b/packages/smithy-core/tests/unit/test_retries.py
@@ -72,3 +72,15 @@ def test_simple_retry_strategy(max_attempts: int) -> None:
         strategy.refresh_retry_token_for_retry(
             token_to_renew=token, error_info=error_info
         )
+
+def test_simple_retry_strategy_does_not_retry_client_errors() -> None:
+    strategy = SimpleRetryStrategy(
+        backoff_strategy=ExponentialRetryBackoffStrategy(backoff_scale_value=5),
+        max_attempts=2,
+    )
+    error_info = RetryErrorInfo(error_type=RetryErrorType.CLIENT_ERROR)
+    token = strategy.acquire_initial_retry_token()
+    with pytest.raises(SmithyRetryException):
+        strategy.refresh_retry_token_for_retry(
+            token_to_renew=token, error_info=error_info
+        )

--- a/packages/smithy-core/tests/unit/test_retries.py
+++ b/packages/smithy-core/tests/unit/test_retries.py
@@ -73,6 +73,7 @@ def test_simple_retry_strategy(max_attempts: int) -> None:
             token_to_renew=token, error_info=error_info
         )
 
+
 def test_simple_retry_strategy_does_not_retry_client_errors() -> None:
     strategy = SimpleRetryStrategy(
         backoff_strategy=ExponentialRetryBackoffStrategy(backoff_scale_value=5),


### PR DESCRIPTION
*Description of changes:*
In #449 the `copy` on request context when calling `_handle_attempt` was removed and the `copy` method on interceptor context was removed as well.  This breaks endpoint construction during _handle_attempt - without a copy of the request, the destination is modified for each attempt.

Additionally, this PR removes retries for client errors from the SimpleRetryStrategy. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
