### PR TITLE
Fix encoding of path in aiohttp requests

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/aiohttp.py
+++ b/packages/smithy-http/src/smithy_http/aio/aiohttp.py
@@ -3,7 +3,9 @@
 from copy import copy, deepcopy
 from itertools import chain
 from typing import TYPE_CHECKING, Any
-from urllib.parse import parse_qs, urlunparse
+from urllib.parse import parse_qs
+
+import yarl
 
 if TYPE_CHECKING:
     # pyright doesn't like optional imports. This is reasonable because if we use these
@@ -97,10 +99,17 @@ class AIOHTTPClient(HTTPClient):
         ) as resp:
             return await self._marshal_response(resp)
 
-    def _serialize_uri_without_query(self, uri: URI) -> str:
+    def _serialize_uri_without_query(self, uri: URI) -> yarl.URL:
         """Serialize all parts of the URI up to and including the path."""
-        components = (uri.scheme, uri.netloc, uri.path or "", "", "", "")
-        return urlunparse(components)
+        return yarl.URL.build(
+            scheme=uri.scheme or "",
+            host=uri.host,
+            port=uri.port,
+            user=uri.username,
+            password=uri.password,
+            path=uri.path or "",
+            encoded=True,
+        )
 
     async def _marshal_response(
         self, aiohttp_resp: "aiohttp.ClientResponse"


### PR DESCRIPTION
*Description of changes:*
When using a `str` for the url in aiohttp.ClientSession.request, paths will be un-uri encoded. However, when a yarl.URL is provided with `encoded=True` it will be used as is.  This matches the behavior of our CRT HTTP client.

yarl is an explicit dependency of aiohttp. The clientSession we call [request](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py#L424) on takes a "strOrUrl" and then if its a str, [uses yarl.URL to build it](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py#L416) - so by doing it explicitly, we're able to control whether the encoding is done or not

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
