### PR TITLE
Use base ruff config for all projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ test-protocols: ## Generates and runs the restJson1 protocol tests.
 
 lint-py: ## Runs linters and formatters on the python packages.
 	uv run docformatter packages --in-place || true
-	uv run ruff check packages --fix
-	uv run ruff format packages
+	uv run ruff check packages --fix --config pyproject.toml
+	uv run ruff format packages --config pyproject.toml
 
 
 check-py: ## Runs checks (formatting, lints, type-checking) on the python packages.
 	uv run docformatter packages
-	uv run ruff check packages
-	uv run ruff format --check
+	uv run ruff check packages --config pyproject.toml
+	uv run ruff format --check --config pyproject.toml
 	uv run pyright packages
 
 

--- a/packages/aws-event-stream/src/aws_event_stream/_private/__init__.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/__init__.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from smithy_core.schemas import Schema
-
 from smithy_core.traits import EventPayloadTrait
 
 INITIAL_REQUEST_EVENT_TYPE = "initial-request"

--- a/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/deserializers.py
@@ -11,6 +11,7 @@ from smithy_core.deserializers import (
 )
 from smithy_core.schemas import Schema
 from smithy_core.shapes import ShapeType
+from smithy_core.traits import EventHeaderTrait
 from smithy_core.utils import expect_type
 
 from ..events import HEADERS_DICT, Event
@@ -20,7 +21,6 @@ from . import (
     INITIAL_RESPONSE_EVENT_TYPE,
     get_payload_member,
 )
-from smithy_core.traits import EventHeaderTrait
 
 logger = logging.getLogger(__name__)
 

--- a/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
+++ b/packages/aws-event-stream/src/aws_event_stream/_private/serializers.py
@@ -15,15 +15,15 @@ from smithy_core.serializers import (
     SpecificShapeSerializer,
 )
 from smithy_core.shapes import ShapeType
+from smithy_core.traits import ErrorTrait, EventHeaderTrait, MediaTypeTrait
 
-from ..events import EventHeaderEncoder, EventMessage, HEADER_VALUE, Short, Byte, Long
+from ..events import HEADER_VALUE, Byte, EventHeaderEncoder, EventMessage, Long, Short
 from ..exceptions import InvalidHeaderValue
 from . import (
     INITIAL_REQUEST_EVENT_TYPE,
     INITIAL_RESPONSE_EVENT_TYPE,
     get_payload_member,
 )
-from smithy_core.traits import ErrorTrait, EventHeaderTrait, MediaTypeTrait
 
 logger = logging.getLogger(__name__)
 

--- a/packages/aws-event-stream/tests/unit/_private/__init__.py
+++ b/packages/aws-event-stream/tests/unit/_private/__init__.py
@@ -4,6 +4,7 @@ import datetime
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, Self
 
+from aws_event_stream.events import Byte, EventMessage, Long, Short
 from smithy_core.deserializers import ShapeDeserializer
 from smithy_core.exceptions import SmithyException
 from smithy_core.prelude import (
@@ -20,14 +21,12 @@ from smithy_core.schemas import Schema
 from smithy_core.serializers import ShapeSerializer
 from smithy_core.shapes import ShapeID, ShapeType
 from smithy_core.traits import (
+    ErrorTrait,
     EventHeaderTrait,
     EventPayloadTrait,
-    ErrorTrait,
     RequiredTrait,
     StreamingTrait,
 )
-
-from aws_event_stream.events import Byte, EventMessage, Long, Short
 
 EVENT_HEADER_TRAIT = EventHeaderTrait()
 EVENT_PAYLOAD_TRAIT = EventPayloadTrait()

--- a/packages/aws-event-stream/tests/unit/_private/test_deserializers.py
+++ b/packages/aws-event-stream/tests/unit/_private/test_deserializers.py
@@ -4,14 +4,13 @@ from io import BytesIO
 from typing import Any
 
 import pytest
+from aws_event_stream._private.deserializers import EventDeserializer
+from aws_event_stream.aio import AWSEventReceiver
+from aws_event_stream.events import Event, EventMessage
+from aws_event_stream.exceptions import UnmodeledEventError
 from smithy_core.aio.types import AsyncBytesReader
 from smithy_core.deserializers import DeserializeableShape
 from smithy_json import JSONCodec
-
-from aws_event_stream.aio import AWSEventReceiver
-from aws_event_stream._private.deserializers import EventDeserializer
-from aws_event_stream.events import Event, EventMessage
-from aws_event_stream.exceptions import UnmodeledEventError
 
 from . import (
     EVENT_STREAM_SERDE_CASES,

--- a/packages/aws-event-stream/tests/unit/_private/test_serializers.py
+++ b/packages/aws-event-stream/tests/unit/_private/test_serializers.py
@@ -3,13 +3,12 @@
 from typing import Any
 
 import pytest
-from smithy_core.serializers import SerializeableShape
-from smithy_core.aio.types import AsyncBytesProvider
-from smithy_json import JSONCodec
-
-from aws_event_stream.aio import AWSEventPublisher
 from aws_event_stream._private.serializers import EventSerializer
+from aws_event_stream.aio import AWSEventPublisher
 from aws_event_stream.events import EventMessage
+from smithy_core.aio.types import AsyncBytesProvider
+from smithy_core.serializers import SerializeableShape
+from smithy_json import JSONCodec
 
 from . import EVENT_STREAM_SERDE_CASES, INITIAL_REQUEST_CASE, INITIAL_RESPONSE_CASE
 

--- a/packages/aws-event-stream/tests/unit/test_events.py
+++ b/packages/aws-event-stream/tests/unit/test_events.py
@@ -6,8 +6,6 @@ import uuid
 from io import BytesIO
 
 import pytest
-from smithy_core.aio.types import AsyncBytesReader
-
 from aws_event_stream.events import (
     MAX_HEADER_VALUE_BYTE_LENGTH,
     MAX_HEADERS_LENGTH,
@@ -31,6 +29,7 @@ from aws_event_stream.exceptions import (
     InvalidIntegerValue,
     InvalidPayloadLength,
 )
+from smithy_core.aio.types import AsyncBytesReader
 
 EMPTY_MESSAGE = (
     (

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import importlib.metadata
 
-from ._http import URI, AWSRequest, Field, Fields
+from ._http import AWSRequest, Field, Fields, URI
 from ._identity import AWSCredentialIdentity
 from ._io import AsyncBytesReader
 from .signers import (

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
@@ -4,14 +4,15 @@
 such as AioHTTP, Curl, Postman, Requests, urllib3, etc."""
 
 from __future__ import annotations
+
 import importlib.metadata
 
 from ._http import URI, AWSRequest, Field, Fields
 from ._identity import AWSCredentialIdentity
 from ._io import AsyncBytesReader
 from .signers import (
-    AsyncSigV4Signer,
     AsyncEventSigner,
+    AsyncSigV4Signer,
     SigV4Signer,
     SigV4SigningProperties,
 )
@@ -20,14 +21,14 @@ __license__ = "Apache-2.0"
 __version__ = importlib.metadata.version("aws-sdk-signers")
 
 __all__ = (
-    "AsyncBytesReader",
-    "AsyncSigV4Signer",
-    "AsyncEventSigner",
+    "URI",
     "AWSCredentialIdentity",
     "AWSRequest",
+    "AsyncBytesReader",
+    "AsyncEventSigner",
+    "AsyncSigV4Signer",
     "Field",
     "Fields",
     "SigV4Signer",
     "SigV4SigningProperties",
-    "URI",
 )

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/_http.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/_http.py
@@ -39,7 +39,7 @@ class Field(interfaces_http.Field):
         kind: interfaces_http.FieldPosition = interfaces_http.FieldPosition.HEADER,
     ):
         self.name = name
-        self.values: list[str] = [val for val in values] if values is not None else []
+        self.values: list[str] = list(values) if values is not None else []
         self.kind = kind
 
     def add(self, value: str) -> None:
@@ -114,7 +114,7 @@ class Fields(interfaces_http.Fields):
         :param encoding: The string encoding to be used when converting the ``Field``
         name and value from ``str`` to ``bytes`` for transmission.
         """
-        init_fields = [fld for fld in initial] if initial is not None else []
+        init_fields = list(initial) if initial is not None else []
         init_field_names = [self._normalize_field_name(fld.name) for fld in init_fields]
         fname_counter = Counter(init_field_names)
         repeated_names_exist = (

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/exceptions.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/exceptions.py
@@ -8,10 +8,6 @@ class AWSSDKWarning(UserWarning): ...
 class BaseAWSSDKException(Exception):
     """Top-level exception to capture SDK-related errors."""
 
-    ...
-
 
 class MissingExpectedParameterException(BaseAWSSDKException, ValueError):
     """Some APIs require specific signing properties to be present."""
-
-    ...

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/interfaces/events.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/interfaces/events.py
@@ -8,7 +8,6 @@ import uuid
 from collections.abc import Mapping
 from typing import Protocol
 
-
 type HEADER_VALUE = bool | int | bytes | str | datetime.datetime | uuid.UUID
 """A union of valid value types for event headers."""
 

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
@@ -14,7 +14,7 @@ from hashlib import sha256
 from typing import TYPE_CHECKING, Required, TypedDict
 from urllib.parse import parse_qsl, quote
 
-from ._http import URI, AWSRequest, Field
+from ._http import AWSRequest, Field, URI
 from ._identity import AWSCredentialIdentity
 from ._io import AsyncBytesReader
 from .exceptions import AWSSDKWarning, MissingExpectedParameterException

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
+# ruff: noqa: S101
 import asyncio
 import datetime
 import hmac
@@ -11,18 +11,18 @@ from binascii import hexlify
 from collections.abc import AsyncIterable, Iterable
 from copy import deepcopy
 from hashlib import sha256
-from typing import Required, TypedDict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Required, TypedDict
 from urllib.parse import parse_qsl, quote
 
-from .interfaces.io import AsyncSeekable, Seekable
 from ._http import URI, AWSRequest, Field
 from ._identity import AWSCredentialIdentity
-from .interfaces.identity import AWSCredentialsIdentity as _AWSCredentialsIdentity
 from ._io import AsyncBytesReader
 from .exceptions import AWSSDKWarning, MissingExpectedParameterException
+from .interfaces.identity import AWSCredentialsIdentity as _AWSCredentialsIdentity
+from .interfaces.io import AsyncSeekable, Seekable
 
 if TYPE_CHECKING:
-    from .interfaces.events import EventMessage, EventHeaderEncoder
+    from .interfaces.events import EventHeaderEncoder, EventMessage
 
 HEADERS_EXCLUDED_FROM_SIGNING: tuple[str, ...] = (
     "accept",

--- a/packages/aws-sdk-signers/tests/unit/auth/test_sigv4.py
+++ b/packages/aws-sdk-signers/tests/unit/auth/test_sigv4.py
@@ -8,12 +8,12 @@ from io import BytesIO
 
 import pytest
 from aws_sdk_signers import (
-    URI,
     AsyncBytesReader,
     AWSCredentialIdentity,
     AWSRequest,
     Field,
     Fields,
+    URI,
 )
 from aws_sdk_signers.exceptions import AWSSDKWarning
 from aws_sdk_signers.signers import (

--- a/packages/aws-sdk-signers/tests/unit/test_signers.py
+++ b/packages/aws-sdk-signers/tests/unit/test_signers.py
@@ -9,13 +9,13 @@ from io import BytesIO
 
 import pytest
 from aws_sdk_signers import (
-    URI,
     AsyncSigV4Signer,
     AWSCredentialIdentity,
     AWSRequest,
     Fields,
     SigV4Signer,
     SigV4SigningProperties,
+    URI,
 )
 
 SIGV4_RE = re.compile(

--- a/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
@@ -1,10 +1,11 @@
 from typing import Final
 
-from smithy_aws_core.traits import RestJson1Trait
-from smithy_http.aio.protocols import HttpBindingClientProtocol
 from smithy_core.codecs import Codec
 from smithy_core.shapes import ShapeID
+from smithy_http.aio.protocols import HttpBindingClientProtocol
 from smithy_json import JSONCodec
+
+from ..traits import RestJson1Trait
 
 
 class RestJsonClientProtocol(HttpBindingClientProtocol):

--- a/packages/smithy-aws-core/src/smithy_aws_core/auth/sigv4.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/auth/sigv4.py
@@ -3,12 +3,13 @@
 from dataclasses import dataclass
 from typing import Protocol
 
-from smithy_aws_core.identity import AWSCredentialsIdentity
+from aws_sdk_signers import AsyncSigV4Signer, SigV4SigningProperties
 from smithy_core.aio.interfaces.identity import IdentityResolver
 from smithy_core.exceptions import SmithyIdentityException
 from smithy_core.interfaces.identity import IdentityProperties
 from smithy_http.aio.interfaces.auth import HTTPAuthScheme, HTTPSigner
-from aws_sdk_signers import SigV4SigningProperties, AsyncSigV4Signer
+
+from ..identity import AWSCredentialsIdentity
 
 
 class SigV4Config(Protocol):

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/__init__.py
@@ -1,11 +1,11 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 from .environment import EnvironmentCredentialsResolver
-from .static import StaticCredentialsResolver
 from .imds import IMDSCredentialsResolver
+from .static import StaticCredentialsResolver
 
 __all__ = (
     "EnvironmentCredentialsResolver",
-    "StaticCredentialsResolver",
     "IMDSCredentialsResolver",
+    "StaticCredentialsResolver",
 )

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/environment.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/environment.py
@@ -2,10 +2,11 @@
 #  SPDX-License-Identifier: Apache-2.0
 import os
 
-from smithy_aws_core.identity import AWSCredentialsIdentity
 from smithy_core.aio.interfaces.identity import IdentityResolver
 from smithy_core.exceptions import SmithyIdentityException
 from smithy_core.interfaces.identity import IdentityProperties
+
+from ..identity import AWSCredentialsIdentity
 
 
 class EnvironmentCredentialsResolver(

--- a/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/static.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/credentials_resolvers/static.py
@@ -1,8 +1,9 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from smithy_aws_core.identity import AWSCredentialsIdentity
 from smithy_core.aio.interfaces.identity import IdentityResolver
 from smithy_core.interfaces.identity import IdentityProperties
+
+from smithy_aws_core.identity import AWSCredentialsIdentity
 
 
 class StaticCredentialsResolver(

--- a/packages/smithy-aws-core/src/smithy_aws_core/interceptors/user_agent.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/interceptors/user_agent.py
@@ -3,11 +3,12 @@
 # pyright: reportMissingTypeStubs=false
 from typing import Any
 
-import smithy_aws_core
 import smithy_core
 from smithy_core.interceptors import Interceptor, RequestContext
 from smithy_http.interceptors.user_agent import USER_AGENT
-from smithy_http.user_agent import UserAgentComponent, RawStringUserAgentComponent
+from smithy_http.user_agent import RawStringUserAgentComponent, UserAgentComponent
+
+from .. import __version__
 
 _USERAGENT_SDK_NAME = "aws-sdk-python"
 
@@ -57,7 +58,7 @@ class UserAgentInterceptor(Interceptor[Any, Any, Any, Any]):
 
     def _build_sdk_metadata(self) -> list[UserAgentComponent]:
         return [
-            UserAgentComponent(_USERAGENT_SDK_NAME, smithy_aws_core.__version__),
+            UserAgentComponent(_USERAGENT_SDK_NAME, __version__),
             UserAgentComponent("md", "smithy-core", smithy_core.__version__),
             *self._crt_version(),
         ]

--- a/packages/smithy-aws-core/src/smithy_aws_core/traits.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/traits.py
@@ -7,11 +7,11 @@
 # they're correct regardless, so it's okay if the checks are stripped out.
 # ruff: noqa: S101
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Mapping, Sequence
 
 from smithy_core.shapes import ShapeID
-from smithy_core.traits import Trait, DocumentValue, DynamicTrait
+from smithy_core.traits import DocumentValue, DynamicTrait, Trait
 
 
 @dataclass(init=False, frozen=True)

--- a/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_environment_credentials_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_environment_credentials_resolver.py
@@ -2,7 +2,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from smithy_aws_core.credentials_resolvers import EnvironmentCredentialsResolver
 from smithy_core.exceptions import SmithyIdentityException
 from smithy_core.interfaces.identity import IdentityProperties

--- a/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_imds.py
+++ b/packages/smithy-aws-core/tests/unit/credentials_resolvers/test_imds.py
@@ -3,20 +3,21 @@
 
 # pyright: reportPrivateUsage=false
 import json
-import pytest
 import time
-from datetime import datetime, timezone
-from smithy_core.retries import SimpleRetryStrategy
-from smithy_core import URI
-from smithy_http.aio import HTTPRequest
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 from smithy_aws_core.credentials_resolvers.imds import (
     Config,
-    Token,
-    TokenCache,
     EC2Metadata,
     IMDSCredentialsResolver,
+    Token,
+    TokenCache,
 )
-from unittest.mock import MagicMock, AsyncMock
+from smithy_core import URI
+from smithy_core.retries import SimpleRetryStrategy
+from smithy_http.aio import HTTPRequest
 
 
 def test_config_defaults():
@@ -174,7 +175,5 @@ async def test_imds_credentials_resolver():
     assert credentials.secret_access_key == "test-secret-key"
     assert credentials.session_token == "test-session-token"
     assert credentials.account_id == "test-account"
-    assert credentials.expiration == datetime(
-        2025, 3, 13, 7, 28, 47, tzinfo=timezone.utc
-    )
+    assert credentials.expiration == datetime(2025, 3, 13, 7, 28, 47, tzinfo=UTC)
     ec2_metadata.get.assert_awaited()

--- a/packages/smithy-aws-core/tests/unit/endpoints/test_standard_regional.py
+++ b/packages/smithy-aws-core/tests/unit/endpoints/test_standard_regional.py
@@ -5,16 +5,14 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
-
-from smithy_core import URI
-from smithy_core.endpoints import EndpointResolverParams
-from smithy_core.types import TypedProperties
-from smithy_core.exceptions import EndpointResolutionError
-
 from smithy_aws_core.endpoints import REGIONAL_ENDPOINT_CONFIG
 from smithy_aws_core.endpoints.standard_regional import (
     StandardRegionalEndpointsResolver,
 )
+from smithy_core import URI
+from smithy_core.endpoints import EndpointResolverParams
+from smithy_core.exceptions import EndpointResolutionError
+from smithy_core.types import TypedProperties
 
 
 @dataclass

--- a/packages/smithy-core/src/smithy_core/__init__.py
+++ b/packages/smithy-core/src/smithy_core/__init__.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import importlib.metadata
 from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property
@@ -7,8 +8,6 @@ from urllib.parse import urlunparse
 
 from . import interfaces, rfc3986
 from .exceptions import SmithyException
-
-import importlib.metadata
 
 __version__: str = importlib.metadata.version("smithy-core")
 

--- a/packages/smithy-core/src/smithy_core/aio/endpoints.py
+++ b/packages/smithy-core/src/smithy_core/aio/endpoints.py
@@ -2,10 +2,10 @@
 #  SPDX-License-Identifier: Apache-2.0
 from typing import Any
 
-from .interfaces import EndpointResolver
-from ..endpoints import EndpointResolverParams, Endpoint, resolve_static_uri
+from ..endpoints import Endpoint, EndpointResolverParams, resolve_static_uri
 from ..exceptions import EndpointResolutionError
 from ..interfaces import Endpoint as _Endpoint
+from .interfaces import EndpointResolver
 
 
 class StaticEndpointResolver(EndpointResolver):

--- a/packages/smithy-core/src/smithy_core/aio/eventstream.py
+++ b/packages/smithy-core/src/smithy_core/aio/eventstream.py
@@ -5,7 +5,6 @@ from typing import Any, Self
 
 from ..deserializers import DeserializeableShape
 from ..serializers import SerializeableShape
-
 from .interfaces.eventstream import EventPublisher, EventReceiver
 
 

--- a/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
+++ b/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
@@ -1,22 +1,20 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from collections.abc import AsyncIterable
-from typing import Protocol, runtime_checkable, TYPE_CHECKING, Callable, Any
+from collections.abc import AsyncIterable, Callable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from ...documents import TypeRegistry
+from ...endpoints import EndpointResolverParams
 from ...exceptions import UnsupportedStreamException
 from ...interfaces import URI, Endpoint, TypedProperties
 from ...interfaces import StreamingBlob as SyncStreamingBlob
-from ...documents import TypeRegistry
-from ...endpoints import EndpointResolverParams
-
 from .eventstream import EventPublisher, EventReceiver
 
-
 if TYPE_CHECKING:
-    from ...schemas import APIOperation
-    from ...shapes import ShapeID
-    from ...serializers import SerializeableShape
     from ...deserializers import DeserializeableShape, ShapeDeserializer
+    from ...schemas import APIOperation
+    from ...serializers import SerializeableShape
+    from ...shapes import ShapeID
 
 
 @runtime_checkable

--- a/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
+++ b/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from ...documents import TypeRegistry
 from ...endpoints import EndpointResolverParams
 from ...exceptions import UnsupportedStreamException
-from ...interfaces import URI, Endpoint, TypedProperties
+from ...interfaces import Endpoint, TypedProperties, URI
 from ...interfaces import StreamingBlob as SyncStreamingBlob
 from .eventstream import EventPublisher, EventReceiver
 

--- a/packages/smithy-core/src/smithy_core/aio/utils.py
+++ b/packages/smithy-core/src/smithy_core/aio/utils.py
@@ -1,6 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from asyncio import sleep, iscoroutine
+from asyncio import iscoroutine, sleep
 from collections.abc import AsyncIterable, Iterable
 from typing import Any
 

--- a/packages/smithy-core/src/smithy_core/deserializers.py
+++ b/packages/smithy-core/src/smithy_core/deserializers.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING, Never, Protocol, Self, runtime_checkable
 from .exceptions import SmithyException, UnsupportedStreamException
 
 if TYPE_CHECKING:
+    from .aio.interfaces import StreamingBlob as _Stream
     from .documents import Document
     from .schemas import Schema
-    from .aio.interfaces import StreamingBlob as _Stream
 
 
 @runtime_checkable

--- a/packages/smithy-core/src/smithy_core/endpoints.py
+++ b/packages/smithy-core/src/smithy_core/endpoints.py
@@ -1,17 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Protocol
 from dataclasses import dataclass, field
+from typing import Any, Protocol
 from urllib.parse import urlparse
 
 from . import URI
-from .serializers import SerializeableShape
-from .schemas import APIOperation
-from .interfaces import TypedProperties as _TypedProperties
-from .interfaces import Endpoint as _Endpoint
-from .interfaces import URI as _URI
-from .types import TypedProperties, PropertyKey
 from .exceptions import EndpointResolutionError
+from .interfaces import URI as _URI
+from .interfaces import Endpoint as _Endpoint
+from .interfaces import TypedProperties as _TypedProperties
+from .schemas import APIOperation
+from .serializers import SerializeableShape
+from .types import PropertyKey, TypedProperties
 
 
 @dataclass(kw_only=True)

--- a/packages/smithy-core/src/smithy_core/endpoints.py
+++ b/packages/smithy-core/src/smithy_core/endpoints.py
@@ -6,9 +6,9 @@ from urllib.parse import urlparse
 
 from . import URI
 from .exceptions import EndpointResolutionError
-from .interfaces import URI as _URI
 from .interfaces import Endpoint as _Endpoint
 from .interfaces import TypedProperties as _TypedProperties
+from .interfaces import URI as _URI
 from .schemas import APIOperation
 from .serializers import SerializeableShape
 from .types import PropertyKey, TypedProperties

--- a/packages/smithy-core/src/smithy_core/interceptors.py
+++ b/packages/smithy-core/src/smithy_core/interceptors.py
@@ -1,11 +1,12 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
+from collections.abc import Sequence
 from dataclasses import dataclass, replace
-from typing import Any, Sequence
+from typing import Any
 
+from .deserializers import DeserializeableShape
 from .interfaces import TypedProperties
 from .serializers import SerializeableShape
-from .deserializers import DeserializeableShape
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)

--- a/packages/smithy-core/src/smithy_core/interfaces/__init__.py
+++ b/packages/smithy-core/src/smithy_core/interfaces/__init__.py
@@ -1,16 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from asyncio import iscoroutinefunction
+from collections.abc import ItemsView, Iterator, KeysView, ValuesView
 from typing import (
-    Protocol,
-    runtime_checkable,
     Any,
+    Protocol,
     TypeGuard,
     overload,
-    Iterator,
-    KeysView,
-    ValuesView,
-    ItemsView,
+    runtime_checkable,
 )
 
 
@@ -127,7 +124,7 @@ class PropertyKey[T](Protocol):
 
         UNION_PROPERTY: PropertyKey[str | int] = PropertyKey(
             key="union",
-            value_type=str | int  # type: ignore
+            value_type=str | int,  # type: ignore
         )
 
     Type checkers will be able to use such a property as expected.
@@ -179,7 +176,7 @@ class TypedProperties(Protocol):
 
         UNION_PROPERTY: PropertyKey[str | int] = PropertyKey(
             key="union",
-            value_type=str | int  # type: ignore
+            value_type=str | int,  # type: ignore
         )
 
         properties = TypedProperties()

--- a/packages/smithy-core/src/smithy_core/prelude.py
+++ b/packages/smithy-core/src/smithy_core/prelude.py
@@ -6,7 +6,6 @@ from .schemas import Schema
 from .shapes import ShapeID, ShapeType
 from .traits import DefaultTrait, UnitTypeTrait
 
-
 BLOB = Schema(
     id=ShapeID("smithy.api#Blob"),
     shape_type=ShapeType.BLOB,

--- a/packages/smithy-core/src/smithy_core/schemas.py
+++ b/packages/smithy-core/src/smithy_core/schemas.py
@@ -2,16 +2,16 @@
 #  SPDX-License-Identifier: Apache-2.0
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
-from typing import NotRequired, Required, Self, TypedDict, overload, Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, NotRequired, Required, Self, TypedDict, overload
 
 from .exceptions import ExpectationNotMetException, SmithyException
 from .shapes import ShapeID, ShapeType
-from .traits import Trait, DynamicTrait, IdempotencyTokenTrait, StreamingTrait
+from .traits import DynamicTrait, IdempotencyTokenTrait, StreamingTrait, Trait
 
 if TYPE_CHECKING:
+    from .deserializers import DeserializeableShape
     from .documents import TypeRegistry
     from .serializers import SerializeableShape
-    from .deserializers import DeserializeableShape
 
 
 @dataclass(kw_only=True, frozen=True, init=False)

--- a/packages/smithy-core/src/smithy_core/serializers.py
+++ b/packages/smithy-core/src/smithy_core/serializers.py
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING, Never, Protocol, runtime_checkable
 from .exceptions import SmithyException, UnsupportedStreamException
 
 if TYPE_CHECKING:
+    from .aio.interfaces import StreamingBlob as _Stream
     from .documents import Document
     from .schemas import Schema
-    from .aio.interfaces import StreamingBlob as _Stream
 
 
 @runtime_checkable

--- a/packages/smithy-core/src/smithy_core/traits.py
+++ b/packages/smithy-core/src/smithy_core/traits.py
@@ -7,12 +7,13 @@
 # they're correct regardless, so it's okay if the checks are stripped out.
 # ruff: noqa: S101
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, ClassVar, Mapping
+from typing import TYPE_CHECKING, ClassVar
 
-from .types import TimestampFormat, PathPattern
 from .shapes import ShapeID
+from .types import PathPattern, TimestampFormat
 
 if TYPE_CHECKING:
     from .documents import DocumentValue

--- a/packages/smithy-core/src/smithy_core/types.py
+++ b/packages/smithy-core/src/smithy_core/types.py
@@ -5,13 +5,15 @@ import re
 import sys
 from collections import UserDict
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime
 from email.utils import format_datetime, parsedate_to_datetime
 from enum import Enum
 from typing import Any, overload
-from dataclasses import dataclass
 
 from .exceptions import ExpectationNotMetException
+from .interfaces import PropertyKey as _PropertyKey
+from .interfaces import TypedProperties as _TypedProperties
 from .utils import (
     ensure_utc,
     epoch_seconds_to_datetime,
@@ -19,8 +21,6 @@ from .utils import (
     serialize_epoch_seconds,
     serialize_rfc3339,
 )
-from .interfaces import PropertyKey as _PropertyKey
-from .interfaces import TypedProperties as _TypedProperties
 
 _GREEDY_LABEL_RE = re.compile(r"\{(\w+)\+\}")
 
@@ -173,7 +173,7 @@ class PropertyKey[T](_PropertyKey[T]):
 
         UNION_PROPERTY: PropertyKey[str | int] = PropertyKey(
             key="union",
-            value_type=str | int  # type: ignore
+            value_type=str | int,  # type: ignore
         )
 
     Type checkers will be able to use such a property as expected.
@@ -223,7 +223,7 @@ class TypedProperties(UserDict[str, Any], _TypedProperties):
 
         UNION_PROPERTY: PropertyKey[str | int] = PropertyKey(
             key="union",
-            value_type=str | int  # type: ignore
+            value_type=str | int,  # type: ignore
         )
 
         properties = TypedProperties()

--- a/packages/smithy-core/tests/unit/aio/test_endpoints.py
+++ b/packages/smithy-core/tests/unit/aio/test_endpoints.py
@@ -3,10 +3,11 @@
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import Mock
-from smithy_core.types import TypedProperties
-from smithy_core.endpoints import EndpointResolverParams, STATIC_ENDPOINT_CONFIG
-from smithy_core.aio.endpoints import StaticEndpointResolver
+
 from smithy_core import URI
+from smithy_core.aio.endpoints import StaticEndpointResolver
+from smithy_core.endpoints import STATIC_ENDPOINT_CONFIG, EndpointResolverParams
+from smithy_core.types import TypedProperties
 
 
 @dataclass

--- a/packages/smithy-core/tests/unit/aio/test_types.py
+++ b/packages/smithy-core/tests/unit/aio/test_types.py
@@ -6,7 +6,6 @@ from typing import Self
 from unittest.mock import Mock
 
 import pytest
-
 from smithy_core.aio.types import (
     AsyncBytesProvider,
     AsyncBytesReader,

--- a/packages/smithy-core/tests/unit/test_documents.py
+++ b/packages/smithy-core/tests/unit/test_documents.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from typing import Any, Self, cast
 
 import pytest
-
 from smithy_core.deserializers import ShapeDeserializer
 from smithy_core.documents import (
     Document,
@@ -27,7 +26,6 @@ from smithy_core.prelude import (
 from smithy_core.schemas import Schema
 from smithy_core.serializers import ShapeSerializer
 from smithy_core.shapes import ShapeID, ShapeType
-
 from smithy_core.traits import SparseTrait
 
 

--- a/packages/smithy-core/tests/unit/test_identity.py
+++ b/packages/smithy-core/tests/unit/test_identity.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 from freezegun import freeze_time
-
 from smithy_core.identity import Identity
 
 

--- a/packages/smithy-core/tests/unit/test_retries.py
+++ b/packages/smithy-core/tests/unit/test_retries.py
@@ -2,7 +2,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from smithy_core.exceptions import SmithyRetryException
 from smithy_core.interfaces.retries import RetryErrorInfo, RetryErrorType
 from smithy_core.retries import ExponentialBackoffJitterType as EBJT

--- a/packages/smithy-core/tests/unit/test_schemas.py
+++ b/packages/smithy-core/tests/unit/test_schemas.py
@@ -1,15 +1,13 @@
 from dataclasses import replace
-
-import pytest
-
 from typing import Any
 
+import pytest
 from smithy_core.exceptions import ExpectationNotMetException
 from smithy_core.schemas import Schema
 from smithy_core.shapes import ShapeID, ShapeType
 from smithy_core.traits import (
-    InternalTrait,
     DynamicTrait,
+    InternalTrait,
     SensitiveTrait,
 )
 

--- a/packages/smithy-core/tests/unit/test_shapes.py
+++ b/packages/smithy-core/tests/unit/test_shapes.py
@@ -1,5 +1,4 @@
 import pytest
-
 from smithy_core.exceptions import ExpectationNotMetException, SmithyException
 from smithy_core.shapes import ShapeID
 

--- a/packages/smithy-core/tests/unit/test_traits.py
+++ b/packages/smithy-core/tests/unit/test_traits.py
@@ -2,16 +2,15 @@
 #  SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
 
+import pytest
+from smithy_core.shapes import ShapeID
 from smithy_core.traits import (
     DynamicTrait,
-    Trait,
-    ErrorTrait,
     ErrorFault,
+    ErrorTrait,
     JSONNameTrait,
+    Trait,
 )
-from smithy_core.shapes import ShapeID
-
-import pytest
 
 
 def test_trait_factory_constructs_dynamic_trait():

--- a/packages/smithy-core/tests/unit/test_type_registry.py
+++ b/packages/smithy-core/tests/unit/test_type_registry.py
@@ -1,8 +1,8 @@
+import pytest
 from smithy_core.deserializers import DeserializeableShape, ShapeDeserializer
 from smithy_core.documents import Document, TypeRegistry
 from smithy_core.schemas import Schema
 from smithy_core.shapes import ShapeID, ShapeType
-import pytest
 
 
 def test_get():

--- a/packages/smithy-core/tests/unit/test_types.py
+++ b/packages/smithy-core/tests/unit/test_types.py
@@ -6,14 +6,13 @@ from datetime import UTC, datetime
 from typing import Any, assert_type
 
 import pytest
-
 from smithy_core.exceptions import ExpectationNotMetException
 from smithy_core.types import (
     JsonBlob,
     JsonString,
-    TimestampFormat,
     PathPattern,
     PropertyKey,
+    TimestampFormat,
     TypedProperties,
 )
 

--- a/packages/smithy-core/tests/unit/test_uri.py
+++ b/packages/smithy-core/tests/unit/test_uri.py
@@ -1,7 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 import pytest
-from smithy_core import URI, HostType
+from smithy_core import HostType, URI
 from smithy_core.exceptions import SmithyException
 
 

--- a/packages/smithy-core/tests/unit/test_uri.py
+++ b/packages/smithy-core/tests/unit/test_uri.py
@@ -1,7 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 import pytest
-
 from smithy_core import URI, HostType
 from smithy_core.exceptions import SmithyException
 

--- a/packages/smithy-core/tests/unit/test_utils.py
+++ b/packages/smithy-core/tests/unit/test_utils.py
@@ -11,7 +11,6 @@ from typing import Any, NamedTuple
 from unittest.mock import Mock
 
 import pytest
-
 from smithy_core.exceptions import ExpectationNotMetException
 from smithy_core.utils import (
     ensure_utc,

--- a/packages/smithy-http/src/smithy_http/__init__.py
+++ b/packages/smithy-http/src/smithy_http/__init__.py
@@ -1,12 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import importlib.metadata
 from collections import Counter, OrderedDict
 from collections.abc import Iterable, Iterator
 
 from . import interfaces
 from .interfaces import FieldPosition
-
-import importlib.metadata
 
 __version__: str = importlib.metadata.version("smithy-http")
 

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -4,26 +4,25 @@
 #  flake8: noqa: F811
 import asyncio
 from asyncio import Future as AsyncFuture
-from concurrent.futures import Future as ConcurrentFuture
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterable
+from concurrent.futures import Future as ConcurrentFuture
 from copy import deepcopy
 from functools import partial
-from io import BytesIO, BufferedIOBase
+from io import BufferedIOBase, BytesIO
 from typing import TYPE_CHECKING, Any
 
-
 if TYPE_CHECKING:
+    # Both of these are types that essentially are "castable to bytes/memoryview"
+    # Unfortunately they're not exposed anywhere so we have to import them from
+    # _typeshed.
+    from _typeshed import ReadableBuffer, WriteableBuffer
+
     # pyright doesn't like optional imports. This is reasonable because if we use these
     # in type hints then they'd result in runtime errors.
     # TODO: add integ tests that import these without the dependendency installed
     from awscrt import http as crt_http
     from awscrt import io as crt_io
-
-    # Both of these are types that essentially are "castable to bytes/memoryview"
-    # Unfortunately they're not exposed anywhere so we have to import them from
-    # _typeshed.
-    from _typeshed import WriteableBuffer, ReadableBuffer
 
 try:
     from awscrt import http as crt_http
@@ -106,7 +105,7 @@ class AWSCRTHTTPResponse(http_aio_interfaces.HTTPResponse):
 
 class CRTResponseBody:
     def __init__(self) -> None:
-        self._stream: "crt_http.HttpClientStream | None" = None
+        self._stream: crt_http.HttpClientStream | None = None
         self._completion_future: AsyncFuture[int] | None = None
         self._chunk_futures: deque[ConcurrentFuture[bytes]] = deque()
 
@@ -469,7 +468,7 @@ class BufferableByteStream(BufferedIOBase):
             )
 
         if self._closed:
-            raise IOError("Stream is completed and doesn't support further writes.")
+            raise OSError("Stream is completed and doesn't support further writes.")
 
         if buffer:
             self._chunks.append(buffer)

--- a/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
+++ b/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
@@ -2,7 +2,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 from typing import Protocol
 
-from smithy_core.aio.interfaces import Request, Response, ClientTransport
+from smithy_core.aio.interfaces import ClientTransport, Request, Response
 from smithy_core.aio.utils import read_streaming_blob, read_streaming_blob_async
 
 from ...interfaces import (

--- a/packages/smithy-http/src/smithy_http/aio/protocols.py
+++ b/packages/smithy-http/src/smithy_http/aio/protocols.py
@@ -7,10 +7,11 @@ from smithy_core.codecs import Codec
 from smithy_core.deserializers import DeserializeableShape
 from smithy_core.documents import TypeRegistry
 from smithy_core.exceptions import ExpectationNotMetException
-from smithy_core.interfaces import Endpoint, TypedProperties, URI
+from smithy_core.interfaces import URI, Endpoint, TypedProperties
 from smithy_core.schemas import APIOperation
 from smithy_core.serializers import SerializeableShape
-from smithy_core.traits import HTTPTrait, EndpointTrait
+from smithy_core.traits import EndpointTrait, HTTPTrait
+
 from smithy_http.aio.interfaces import HTTPRequest, HTTPResponse
 from smithy_http.deserializers import HTTPResponseDeserializer
 from smithy_http.serializers import HTTPRequestSerializer
@@ -46,12 +47,12 @@ class HttpBindingClientProtocol(HttpClientProtocol):
     @property
     def payload_codec(self) -> Codec:
         """The codec used for the serde of input and output payloads."""
-        ...
+        raise NotImplementedError()
 
     @property
     def content_type(self) -> str:
         """The media type of the http payload."""
-        ...
+        raise NotImplementedError()
 
     def serialize_request[
         OperationInput: "SerializeableShape",

--- a/packages/smithy-http/src/smithy_http/aio/protocols.py
+++ b/packages/smithy-http/src/smithy_http/aio/protocols.py
@@ -7,7 +7,7 @@ from smithy_core.codecs import Codec
 from smithy_core.deserializers import DeserializeableShape
 from smithy_core.documents import TypeRegistry
 from smithy_core.exceptions import ExpectationNotMetException
-from smithy_core.interfaces import URI, Endpoint, TypedProperties
+from smithy_core.interfaces import Endpoint, TypedProperties, URI
 from smithy_core.schemas import APIOperation
 from smithy_core.serializers import SerializeableShape
 from smithy_core.traits import EndpointTrait, HTTPTrait

--- a/packages/smithy-http/src/smithy_http/deserializers.py
+++ b/packages/smithy-http/src/smithy_http/deserializers.py
@@ -1,34 +1,33 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from collections.abc import Callable
-from typing import TYPE_CHECKING
-from decimal import Decimal
 import datetime
+from collections.abc import Callable
+from decimal import Decimal
+from typing import TYPE_CHECKING
 
-from smithy_core.deserializers import ShapeDeserializer, SpecificShapeDeserializer
 from smithy_core.codecs import Codec
-from smithy_core.schemas import Schema
-from smithy_core.traits import (
-    HTTPTrait,
-    HTTPHeaderTrait,
-    HTTPPrefixHeadersTrait,
-    HTTPPayloadTrait,
-    HTTPResponseCodeTrait,
-    TimestampFormatTrait,
-)
-from smithy_core.utils import strict_parse_bool, strict_parse_float, ensure_utc
-from smithy_core.types import TimestampFormat
-from smithy_core.shapes import ShapeType
+from smithy_core.deserializers import ShapeDeserializer, SpecificShapeDeserializer
 from smithy_core.exceptions import UnsupportedStreamException
 from smithy_core.interfaces import is_bytes_reader, is_streaming_blob
+from smithy_core.schemas import Schema
+from smithy_core.shapes import ShapeType
+from smithy_core.traits import (
+    HTTPHeaderTrait,
+    HTTPPayloadTrait,
+    HTTPPrefixHeadersTrait,
+    HTTPResponseCodeTrait,
+    HTTPTrait,
+    TimestampFormatTrait,
+)
+from smithy_core.types import TimestampFormat
+from smithy_core.utils import ensure_utc, strict_parse_bool, strict_parse_float
 
 from .aio.interfaces import HTTPResponse
-
 from .interfaces import Field, Fields
 
 if TYPE_CHECKING:
-    from smithy_core.interfaces import StreamingBlob as SyncStreamingBlob
     from smithy_core.aio.interfaces import StreamingBlob as AsyncStreamingBlob
+    from smithy_core.interfaces import StreamingBlob as SyncStreamingBlob
 
 
 __all__ = ["HTTPResponseDeserializer"]

--- a/packages/smithy-http/src/smithy_http/endpoints.py
+++ b/packages/smithy-http/src/smithy_http/endpoints.py
@@ -3,8 +3,8 @@
 from dataclasses import dataclass
 
 from smithy_core.endpoints import Endpoint
-from smithy_core.interfaces import URI
 from smithy_core.interfaces import TypedProperties as _TypedProperties
+from smithy_core.interfaces import URI
 from smithy_core.types import PropertyKey, TypedProperties
 
 from . import Fields, interfaces

--- a/packages/smithy-http/src/smithy_http/endpoints.py
+++ b/packages/smithy-http/src/smithy_http/endpoints.py
@@ -2,13 +2,12 @@
 #  SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
 
+from smithy_core.endpoints import Endpoint
 from smithy_core.interfaces import URI
 from smithy_core.interfaces import TypedProperties as _TypedProperties
-from smithy_core.endpoints import Endpoint
 from smithy_core.types import PropertyKey, TypedProperties
 
 from . import Fields, interfaces
-
 
 HEADERS = PropertyKey(key="headers", value_type=interfaces.Fields)
 """An Endpoint property indicating the given fields MUST be added to the request."""

--- a/packages/smithy-http/src/smithy_http/interceptors/user_agent.py
+++ b/packages/smithy-http/src/smithy_http/interceptors/user_agent.py
@@ -1,11 +1,12 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 import platform
-from typing import Self, Any
+from typing import Any, Self
 
 import smithy_core
-from smithy_core.interceptors import Interceptor, InputContext, RequestContext
+from smithy_core.interceptors import InputContext, Interceptor, RequestContext
 from smithy_core.types import PropertyKey
+
 from smithy_http import Field
 from smithy_http.aio.interfaces import HTTPRequest
 from smithy_http.user_agent import UserAgent, UserAgentComponent

--- a/packages/smithy-http/src/smithy_http/plugins/__init__.py
+++ b/packages/smithy-http/src/smithy_http/plugins/__init__.py
@@ -1,8 +1,9 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from typing import Protocol, Any
+from typing import Any, Protocol
 
 from smithy_core.interceptors import Interceptor
+
 from smithy_http.interceptors.user_agent import UserAgentInterceptor
 
 

--- a/packages/smithy-http/src/smithy_http/serializers.py
+++ b/packages/smithy-http/src/smithy_http/serializers.py
@@ -1,47 +1,46 @@
+from asyncio import iscoroutinefunction
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from decimal import Decimal
 from io import BytesIO
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote as urlquote
-from asyncio import iscoroutinefunction
 
+from smithy_core import URI
+from smithy_core.codecs import Codec
+from smithy_core.schemas import Schema
 from smithy_core.serializers import (
+    InterceptingSerializer,
     MapSerializer,
     ShapeSerializer,
     SpecificShapeSerializer,
-    InterceptingSerializer,
 )
-from smithy_core.codecs import Codec
-from smithy_core.types import TimestampFormat, PathPattern
-from smithy_core.schemas import Schema
+from smithy_core.shapes import ShapeType
 from smithy_core.traits import (
-    HTTPTrait,
-    HTTPPayloadTrait,
+    EndpointTrait,
+    HostLabelTrait,
+    HTTPErrorTrait,
     HTTPHeaderTrait,
+    HTTPLabelTrait,
+    HTTPPayloadTrait,
     HTTPPrefixHeadersTrait,
     HTTPQueryParamsTrait,
     HTTPQueryTrait,
-    HTTPLabelTrait,
     HTTPResponseCodeTrait,
-    HostLabelTrait,
-    TimestampFormatTrait,
-    EndpointTrait,
-    HTTPErrorTrait,
+    HTTPTrait,
     MediaTypeTrait,
     StreamingTrait,
+    TimestampFormatTrait,
 )
-from smithy_core.shapes import ShapeType
+from smithy_core.types import PathPattern, TimestampFormat
 from smithy_core.utils import serialize_float
 
+from . import tuples_to_fields
 from .aio import HTTPRequest as _HTTPRequest
 from .aio import HTTPResponse as _HTTPResponse
 from .aio.interfaces import HTTPRequest, HTTPResponse
-from smithy_core import URI
-from . import tuples_to_fields
 from .utils import join_query_params
-
 
 if TYPE_CHECKING:
     from smithy_core.aio.interfaces import StreamingBlob as AsyncStreamingBlob
@@ -299,7 +298,7 @@ class RawPayloadSerializer(SpecificShapeSerializer):
 
     def __init__(self) -> None:
         """Initialize a RawPayloadSerializer."""
-        self.payload: "AsyncStreamingBlob | None" = None
+        self.payload: AsyncStreamingBlob | None = None
 
     def write_string(self, schema: Schema, value: str) -> None:
         self.payload = value.encode("utf-8")
@@ -408,7 +407,7 @@ class HTTPHeaderMapSerializer(MapSerializer):
 
     def entry(self, key: str, value_writer: Callable[[ShapeSerializer], None]):
         value_writer(self._delegate)
-        assert self._delegate.result is not None
+        assert self._delegate.result is not None  # noqa: S101
         self._headers.append((self._prefix + key, self._delegate.result))
 
 
@@ -575,7 +574,7 @@ class HTTPQueryMapSerializer(MapSerializer):
 
     def entry(self, key: str, value_writer: Callable[[ShapeSerializer], None]):
         value_writer(self._delegate)
-        assert self._delegate.result is not None
+        assert self._delegate.result is not None  # noqa: S101
         self._query_params.append((key, urlquote(self._delegate.result, safe="")))
 
 

--- a/packages/smithy-http/tests/integration/aio/conftest.py
+++ b/packages/smithy-http/tests/integration/aio/conftest.py
@@ -4,7 +4,6 @@
 import pytest
 from smithy_core import URI
 from smithy_core.aio.utils import async_list
-
 from smithy_http import Field, Fields
 from smithy_http.aio import HTTPRequest
 

--- a/packages/smithy-http/tests/integration/aio/test_aiohttp.py
+++ b/packages/smithy-http/tests/integration/aio/test_aiohttp.py
@@ -1,7 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 import pytest
-
 from smithy_http.aio import HTTPRequest
 from smithy_http.aio.aiohttp import AIOHTTPClient, AIOHTTPClientConfig
 

--- a/packages/smithy-http/tests/integration/aio/test_crt.py
+++ b/packages/smithy-http/tests/integration/aio/test_crt.py
@@ -1,7 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 import pytest
-
 from smithy_http.aio import HTTPRequest
 from smithy_http.aio.crt import AWSCRTHTTPClient, AWSCRTHTTPClientConfig
 

--- a/packages/smithy-http/tests/unit/aio/auth/test_apikey.py
+++ b/packages/smithy-http/tests/unit/aio/auth/test_apikey.py
@@ -8,7 +8,6 @@ from smithy_core import URI
 from smithy_core.aio.interfaces.identity import IdentityResolver
 from smithy_core.exceptions import SmithyIdentityException
 from smithy_core.interfaces.identity import IdentityProperties
-
 from smithy_http import Field, Fields
 from smithy_http.aio import HTTPRequest
 from smithy_http.aio.auth.apikey import (

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -1,14 +1,13 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 import asyncio
+from concurrent.futures import Future as ConcurrentFuture
 from copy import deepcopy
 from io import BytesIO
 from unittest.mock import Mock
-from concurrent.futures import Future as ConcurrentFuture
 
 import pytest
 from awscrt.http import HttpClientStream  # type: ignore
-
 from smithy_core import URI
 from smithy_http import Fields
 from smithy_http.aio import HTTPRequest

--- a/packages/smithy-http/tests/unit/aio/test_http.py
+++ b/packages/smithy-http/tests/unit/aio/test_http.py
@@ -2,7 +2,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 from smithy_core import URI
 from smithy_core.aio.utils import async_list
-
 from smithy_http import Field, Fields
 from smithy_http.aio import HTTPRequest, HTTPResponse
 

--- a/packages/smithy-http/tests/unit/aio/test_restjson.py
+++ b/packages/smithy-http/tests/unit/aio/test_restjson.py
@@ -7,7 +7,6 @@ from collections.abc import AsyncIterator
 import pytest
 from smithy_core.aio.utils import async_list
 from smithy_core.documents import DocumentValue
-
 from smithy_http import tuples_to_fields
 from smithy_http.aio import HTTPResponse
 from smithy_http.aio.restjson import parse_rest_json_error_info

--- a/packages/smithy-http/tests/unit/test_fields.py
+++ b/packages/smithy-http/tests/unit/test_fields.py
@@ -5,7 +5,6 @@
 # mypy: allow-incomplete-defs
 
 import pytest
-
 from smithy_http import Field, Fields
 from smithy_http.interfaces import FieldPosition
 

--- a/packages/smithy-http/tests/unit/test_serializers.py
+++ b/packages/smithy-http/tests/unit/test_serializers.py
@@ -2,50 +2,49 @@
 #  SPDX-License-Identifier: Apache-2.0
 import datetime
 from asyncio import iscoroutinefunction
-from decimal import Decimal
 from dataclasses import dataclass, field
-from typing import ClassVar, Self, Any, Protocol
 from datetime import UTC
+from decimal import Decimal
 from io import BytesIO
+from typing import Any, ClassVar, Protocol, Self
 
 import pytest
-
 from smithy_core import URI
 from smithy_core.aio.interfaces import StreamingBlob
-from smithy_core.shapes import ShapeID, ShapeType
-from smithy_core.traits import (
-    HTTPLabelTrait,
-    TimestampFormatTrait,
-    HTTPPayloadTrait,
-    StreamingTrait,
-    HTTPHeaderTrait,
-    HTTPResponseCodeTrait,
-    HTTPPrefixHeadersTrait,
-    Trait,
-    HTTPQueryTrait,
-    HTTPQueryParamsTrait,
-    HTTPTrait,
-    HostLabelTrait,
-    EndpointTrait,
-)
-from smithy_core.schemas import Schema
-from smithy_core.serializers import ShapeSerializer, SerializeableShape
-from smithy_core.deserializers import ShapeDeserializer, DeserializeableShape
+from smithy_core.aio.types import AsyncBytesReader
+from smithy_core.deserializers import DeserializeableShape, ShapeDeserializer
 from smithy_core.prelude import (
-    BLOB,
-    STRING,
-    INTEGER,
-    FLOAT,
     BIG_DECIMAL,
+    BLOB,
     BOOLEAN,
+    FLOAT,
+    INTEGER,
+    STRING,
     TIMESTAMP,
 )
-from smithy_core.aio.types import AsyncBytesReader
-from smithy_http.deserializers import HTTPResponseDeserializer
-from smithy_json import JSONCodec
+from smithy_core.schemas import Schema
+from smithy_core.serializers import SerializeableShape, ShapeSerializer
+from smithy_core.shapes import ShapeID, ShapeType
+from smithy_core.traits import (
+    EndpointTrait,
+    HostLabelTrait,
+    HTTPHeaderTrait,
+    HTTPLabelTrait,
+    HTTPPayloadTrait,
+    HTTPPrefixHeadersTrait,
+    HTTPQueryParamsTrait,
+    HTTPQueryTrait,
+    HTTPResponseCodeTrait,
+    HTTPTrait,
+    StreamingTrait,
+    TimestampFormatTrait,
+    Trait,
+)
+from smithy_http import Field, Fields, tuples_to_fields
 from smithy_http.aio import HTTPResponse as _HTTPResponse
-from smithy_http import tuples_to_fields, Field, Fields
+from smithy_http.deserializers import HTTPResponseDeserializer
 from smithy_http.serializers import HTTPRequestSerializer, HTTPResponseSerializer
+from smithy_json import JSONCodec
 
 # TODO: empty header prefix, query map
 
@@ -1103,7 +1102,7 @@ class HostLabel:
 @dataclass
 class HTTPMessage:
     method: str = "POST"
-    destination: URI = URI(host="", path="/")
+    destination: URI = field(default_factory=lambda: URI(host="", path="/"))
     fields: Fields = field(default_factory=Fields)
     body: StreamingBlob = field(repr=False, default=b"")
     status: int = 200
@@ -1116,7 +1115,9 @@ class Shape(SerializeableShape, DeserializeableShape, Protocol): ...
 class HTTPMessageTestCase:
     shape: Shape
     request: HTTPMessage
-    http_trait: HTTPTrait = HTTPTrait({"method": "POST", "code": 200, "uri": "/"})
+    http_trait: HTTPTrait = field(
+        default_factory=lambda: HTTPTrait({"method": "POST", "code": 200, "uri": "/"})
+    )
     endpoint_trait: EndpointTrait | None = None
 
 

--- a/packages/smithy-http/tests/unit/test_user_agent.py
+++ b/packages/smithy-http/tests/unit/test_user_agent.py
@@ -1,10 +1,9 @@
 import pytest
-
 from smithy_http.user_agent import (
-    sanitize_user_agent_string_component,
-    UserAgentComponent,
     RawStringUserAgentComponent,
     UserAgent,
+    UserAgentComponent,
+    sanitize_user_agent_string_component,
 )
 
 

--- a/packages/smithy-http/tests/unit/test_utils.py
+++ b/packages/smithy-http/tests/unit/test_utils.py
@@ -2,7 +2,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 import pytest
 from smithy_core.exceptions import SmithyException
-
 from smithy_http.utils import join_query_params, split_header
 
 

--- a/packages/smithy-json/src/smithy_json/__init__.py
+++ b/packages/smithy-json/src/smithy_json/__init__.py
@@ -1,5 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
+import importlib.metadata
 from io import BytesIO
 
 from smithy_core.codecs import Codec
@@ -10,8 +11,6 @@ from smithy_core.types import TimestampFormat
 
 from ._private.deserializers import JSONShapeDeserializer as _JSONShapeDeserializer
 from ._private.serializers import JSONShapeSerializer as _JSONShapeSerializer
-
-import importlib.metadata
 
 __version__: str = importlib.metadata.version("smithy-json")
 

--- a/packages/smithy-json/src/smithy_json/_private/deserializers.py
+++ b/packages/smithy-json/src/smithy_json/_private/deserializers.py
@@ -15,10 +15,10 @@ from smithy_core.exceptions import SmithyException
 from smithy_core.interfaces import BytesReader
 from smithy_core.schemas import Schema
 from smithy_core.shapes import ShapeID, ShapeType
+from smithy_core.traits import JSONNameTrait, TimestampFormatTrait
 from smithy_core.types import TimestampFormat
 
 from .documents import JSONDocument
-from smithy_core.traits import TimestampFormatTrait, JSONNameTrait
 
 # TODO: put these type hints in a pyi somewhere. There here because ijson isn't
 # typed.

--- a/packages/smithy-json/src/smithy_json/_private/documents.py
+++ b/packages/smithy-json/src/smithy_json/_private/documents.py
@@ -10,10 +10,9 @@ from smithy_core.documents import Document, DocumentValue
 from smithy_core.prelude import DOCUMENT
 from smithy_core.schemas import Schema
 from smithy_core.shapes import ShapeType
+from smithy_core.traits import JSONNameTrait, TimestampFormatTrait
 from smithy_core.types import TimestampFormat
 from smithy_core.utils import expect_type
-
-from smithy_core.traits import JSONNameTrait, TimestampFormatTrait
 
 
 class JSONDocument(Document):

--- a/packages/smithy-json/src/smithy_json/_private/serializers.py
+++ b/packages/smithy-json/src/smithy_json/_private/serializers.py
@@ -18,8 +18,8 @@ from smithy_core.serializers import (
     MapSerializer,
     ShapeSerializer,
 )
+from smithy_core.traits import JSONNameTrait, TimestampFormatTrait
 from smithy_core.types import TimestampFormat
-from smithy_core.traits import TimestampFormatTrait, JSONNameTrait
 
 from . import Flushable
 

--- a/packages/smithy-json/tests/unit/__init__.py
+++ b/packages/smithy-json/tests/unit/__init__.py
@@ -18,9 +18,7 @@ from smithy_core.prelude import (
 from smithy_core.schemas import Schema
 from smithy_core.serializers import ShapeSerializer
 from smithy_core.shapes import ShapeID, ShapeType
-
-from smithy_core.traits import TimestampFormatTrait, JSONNameTrait, SparseTrait
-
+from smithy_core.traits import JSONNameTrait, SparseTrait, TimestampFormatTrait
 
 STRING_LIST_SCHEMA = Schema.collection(
     id=ShapeID("smithy.example#StringList"),

--- a/packages/smithy-json/tests/unit/test_deserializers.py
+++ b/packages/smithy-json/tests/unit/test_deserializers.py
@@ -14,7 +14,6 @@ from smithy_core.prelude import (
     STRING,
     TIMESTAMP,
 )
-
 from smithy_json import JSONCodec
 
 from . import (

--- a/packages/smithy-json/tests/unit/test_serializers.py
+++ b/packages/smithy-json/tests/unit/test_serializers.py
@@ -14,7 +14,6 @@ from smithy_core.prelude import (
     STRING,
     TIMESTAMP,
 )
-
 from smithy_json import JSONCodec
 
 from . import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ target-version = "py312"
 select = [ "ASYNC", "C4", "E1", "E4", "E7", "E9", "F", "FURB", "G", "I", "LOG", "PIE", "RUF", "S", "T", "UP" ]
 exclude = [ "packages/smithy-core/src/smithy_core/rfc3986.py" ]
 
+[tool.ruff.lint.isort]
+classes = ["URI"]
+
 [tool.ruff.lint.per-file-ignores]
 "**/{tests}/*" = ["S"]
 


### PR DESCRIPTION
I noticed we weren't sorting imports despite having that configured in our `pyproject.toml`. Turns out ruff wasn't using the top-level config at all. So I fixed it. There were a few minor manual fixes that had to be made too, and a few noqa's had to be added.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
