### PR TITLE
Add yarl + upper bound aiohttp

### DIFF
--- a/packages/smithy-http/pyproject.toml
+++ b/packages/smithy-http/pyproject.toml
@@ -13,7 +13,8 @@ awscrt = [
     "awscrt>=0.23.10",
 ]
 aiohttp = [
-    "aiohttp>=3.11.12",
+    "aiohttp>=3.11.12, <4.0",
+    "yarl"
 ]
 
 [build-system]


### PR DESCRIPTION
*Description of changes:*
#461 used yarl directly in our code.  While yarl is a direct dependency of aiohttp we want to ensure that we don't break if its removed.  

This also adds an upper bound on aiohttp.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
