### PR TITLE
Add error serde to http-binding client protocols

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/aio/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/aio/__init__.py
@@ -1,2 +1,14 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
+from smithy_core.shapes import ShapeID
+from smithy_http.aio.interfaces import ErrorExtractor, HTTPResponse
+
+
+class AmznErrorExtractor(ErrorExtractor):
+    """Attempts to extract the Amazon-specific 'X-Amzn-Errortype' error header from a
+    response."""
+
+    def get_error(self, response: HTTPResponse):
+        if "x-amzn-errortype" in response.fields:
+            val = response.fields["x-amzn-errortype"].values[0]
+            return ShapeID(val)

--- a/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
@@ -2,10 +2,12 @@ from typing import Final
 
 from smithy_core.codecs import Codec
 from smithy_core.shapes import ShapeID
+from smithy_http.aio.interfaces import ErrorExtractor
 from smithy_http.aio.protocols import HttpBindingClientProtocol
 from smithy_json import JSONCodec
 
 from ..traits import RestJson1Trait
+from . import AmznErrorExtractor
 
 
 class RestJsonClientProtocol(HttpBindingClientProtocol):
@@ -13,7 +15,8 @@ class RestJsonClientProtocol(HttpBindingClientProtocol):
 
     _id: ShapeID = RestJson1Trait.id
     _codec: JSONCodec = JSONCodec()
-    _contentType: Final = "application/json"
+    _content_type: Final = "application/json"
+    _error_extractor: ErrorExtractor = AmznErrorExtractor()
 
     @property
     def id(self) -> ShapeID:
@@ -25,4 +28,8 @@ class RestJsonClientProtocol(HttpBindingClientProtocol):
 
     @property
     def content_type(self) -> str:
-        return self._contentType
+        return self._content_type
+
+    @property
+    def error_extractor(self) -> ErrorExtractor:
+        return self._error_extractor

--- a/packages/smithy-core/src/smithy_core/errors.py
+++ b/packages/smithy-core/src/smithy_core/errors.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from smithy_core.deserializers import DeserializeableShape
+
+type Fault = Literal["client", "server", "other"]
+
+
+@dataclass(kw_only=True, frozen=True)
+class CallException(RuntimeError):
+    """The top-level exception that should be used to throw application-level errors
+    from clients and servers.
+
+    This should be used in protocol error deserialization, throwing errors based on
+    protocol-hints, network errors, and shape validation errors. It should not be used
+    for illegal arguments, null argument validation, or other kinds of logic errors
+    sufficiently covered by the Java standard library.
+    """
+
+    fault: Fault = "other"
+    """The party that is at fault for the error, if any."""
+
+    message: str = ""
+    """The error message."""
+
+    # TODO: retry-ability and associated information (throttling, duration, etc.), perhaps 'Retryability' dataclass?
+
+
+@dataclass(kw_only=True, frozen=True)
+class ModeledException(CallException, DeserializeableShape):
+    """The top-level exception that should be used to throw modeled errors from clients
+    and servers."""

--- a/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
+++ b/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
@@ -4,6 +4,7 @@ from typing import Protocol
 
 from smithy_core.aio.interfaces import ClientTransport, Request, Response
 from smithy_core.aio.utils import read_streaming_blob, read_streaming_blob_async
+from smithy_core.shapes import ShapeID
 
 from ...interfaces import (
     Fields,
@@ -81,5 +82,20 @@ class HTTPClient(ClientTransport[HTTPRequest, HTTPResponse], Protocol):
 
         :param request: The request including destination URI, fields, payload.
         :param request_config: Configuration specific to this request.
+        """
+        ...
+
+
+class ErrorExtractor(Protocol):
+    """Extract error shape IDs from an HTTP response."""
+
+    def get_error(
+        self,
+        response: HTTPResponse,
+    ) -> ShapeID | None:
+        """Get the shape id for an error by using information (such as headers) from a
+        response.
+
+        :param response: The response object to derive an error shape from.
         """
         ...

--- a/uv.lock
+++ b/uv.lock
@@ -686,6 +686,7 @@ dependencies = [
 [package.optional-dependencies]
 aiohttp = [
     { name = "aiohttp" },
+    { name = "yarl" },
 ]
 awscrt = [
     { name = "awscrt" },
@@ -693,9 +694,10 @@ awscrt = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.11.12" },
+    { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.11.12,<4.0" },
     { name = "awscrt", marker = "extra == 'awscrt'", specifier = ">=0.23.10" },
     { name = "smithy-core", editable = "packages/smithy-core" },
+    { name = "yarl", marker = "extra == 'aiohttp'" },
 ]
 provides-extras = ["awscrt", "aiohttp"]
 


### PR DESCRIPTION
*Description of changes:*
- Adds error serde and handling in http binding client protocols
  - Adds amzn header extractor and adds it to the rest json client protocol
- Adds new exceptions, CallException and ModeledException, which are meant to be used when code-generating the error shapes
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
