### PR TITLE
Add required trait to docs when relevant

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -24,11 +24,13 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
 import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.InputTrait;
 import software.amazon.smithy.model.traits.OutputTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.python.codegen.CodegenUtils;
@@ -316,8 +318,14 @@ public final class StructureGenerator implements Runnable {
 
     private void writeMemberDocs(MemberShape member) {
         member.getMemberTrait(model, DocumentationTrait.class).ifPresent(trait -> {
+            String descriptionPrefix = "";
+            if (member.hasTrait(RequiredTrait.class) && !member.hasTrait(ClientOptionalTrait.class)) {
+                descriptionPrefix = "**[Required]** - ";
+            }
+
             String memberName = symbolProvider.toMemberName(member);
-            String docs = writer.formatDocs(String.format(":param %s: %s", memberName, trait.getValue()));
+            String docs = writer.formatDocs(String.format(":param %s: %s%s",
+                    memberName, descriptionPrefix, trait.getValue()));
             writer.write(docs);
         });
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownToRstDocConverter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownToRstDocConverter.java
@@ -6,6 +6,8 @@ package software.amazon.smithy.python.codegen.writer;
 
 import static org.jsoup.nodes.Document.OutputSettings.Syntax.html;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.commonmark.node.BlockQuote;
 import org.commonmark.node.FencedCodeBlock;
 import org.commonmark.node.Heading;
@@ -52,8 +54,11 @@ public class MarkdownToRstDocConverter {
     }
 
     public String convertCommonmarkToRst(String commonmark) {
-        String html =
-                HtmlRenderer.builder().escapeHtml(false).build().render(MARKDOWN_PARSER.parse(commonmark));
+        String html = HtmlRenderer.builder().escapeHtml(false).build().render(MARKDOWN_PARSER.parse(commonmark));
+        //Replace the outer HTML paragraph tag with a div tag
+        Pattern pattern = Pattern.compile("^<p>(.*)</p>$", Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(html);
+        html = matcher.replaceAll("<div>$1</div>");
         Document document = Jsoup.parse(html);
         RstNodeVisitor visitor = new RstNodeVisitor();
         document.body().traverse(visitor);
@@ -75,7 +80,7 @@ public class MarkdownToRstDocConverter {
                         int secondColonIndex = text.indexOf(':',  1);
                         writer.write(text.substring(0, secondColonIndex + 1));
                         //TODO right now the code generator gives us a mixture of
-                        // commonmark and HTML (for instance :param xyz: <p> docs
+                        // RST and HTML (for instance :param xyz: <p> docs
                         // </p>).  Since we standardize to html above, that <p> tag
                         // starts a newline.  We account for that with this if/else
                         // statement, but we should refactor this in the future to


### PR DESCRIPTION
Smithy-python generates all input members as nullable.  For discoverability of required attributes, docs references are needed.  

This update prepends `[REQUIRED] - ` in bold before required attributes.  This does have the side effect of adding it on output shapes as well, which will be addressed in a follow up PR.  