### PR TITLE
Normalize package names to match project hyphenation

### DIFF
--- a/packages/aws-sdk-signers/pyproject.toml
+++ b/packages/aws-sdk-signers/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "aws_sdk_signers"
+name = "aws-sdk-signers"
 version = "0.0.2"
 requires-python = ">=3.12"
 authors = [

--- a/packages/smithy-core/pyproject.toml
+++ b/packages/smithy-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "smithy_core"
+name = "smithy-core"
 version = "0.0.1"
 description = "Core components for implementing Smithy tooling in Python."
 readme = "README.md"

--- a/packages/smithy-http/pyproject.toml
+++ b/packages/smithy-http/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "smithy_http"
+name = "smithy-http"
 version = "0.0.1"
 description = "HTTP components for Smithy tooling."
 readme = "README.md"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR addresses a callout from #470 that our project names in some of the packages is not consistent. This normalizes the project name to being hyphenated while the package directory is snake case as is the current convention.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
