### PR TITLE
Suffix clients with Client after service name

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
@@ -33,7 +33,7 @@ public final class AwsServiceIdIntegration implements PythonIntegration {
             Symbol symbol = this.delegate.toSymbol(shape);
             if (shape.isServiceShape() && shape.hasTrait(ServiceTrait.class)) {
                 var serviceTrait = shape.expectTrait(ServiceTrait.class);
-                var serviceName = StringUtils.capitalize(serviceTrait.getSdkId()).replace(" ", "");
+                var serviceName = StringUtils.capitalize(serviceTrait.getSdkId() + "Client").replace(" ", "");
                 symbol = symbol.toBuilder().name(serviceName).build();
             }
             return symbol;


### PR DESCRIPTION
*Description of changes:*
This is a proposal for adding `Client` to the end of our generated service clients. While these all originated from the generated namespace `from service_name.client import ServiceName`, it reads a bit oddly in isolated code snippets.

Prior art from recent SDKs is showing 3 out of the 5 existing Smithy SDKs all suffix with Client to reduce ambiguity. I don't think there's a lot of standing precedent in Python itself for which direction to go. I'm adding this PR as a talking point for if we feel this is necessary.

I don't think it hurts to add this for the moment, but we'll need to decide if we bias one way now, are we're willing to break that based on feedback later?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
