### PR TITLE
Fix incorrect interceptor chain calls

### DIFF
--- a/packages/smithy-core/CHANGES.md
+++ b/packages/smithy-core/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-* <Add new items here>
+### Bugfixes
+
+* Fixed incorrect interceptors for `modify_before_signing` and `modify_before_transmit`.
 
 ## v0.0.1
 

--- a/packages/smithy-core/src/smithy_core/interceptors.py
+++ b/packages/smithy-core/src/smithy_core/interceptors.py
@@ -577,7 +577,7 @@ class InterceptorChain(AnyInterceptor):
     def modify_before_signing(self, context: RequestContext[Any, Any]) -> Any:
         transport_request = context.transport_request
         for interceptor in self._chain:
-            transport_request = interceptor.modify_before_retry_loop(context)
+            transport_request = interceptor.modify_before_signing(context)
         return transport_request
 
     def read_before_signing(self, context: RequestContext[Any, Any]) -> None:
@@ -591,7 +591,7 @@ class InterceptorChain(AnyInterceptor):
     def modify_before_transmit(self, context: RequestContext[Any, Any]) -> Any:
         transport_request = context.transport_request
         for interceptor in self._chain:
-            transport_request = interceptor.modify_before_retry_loop(context)
+            transport_request = interceptor.modify_before_transmit(context)
         return transport_request
 
     def read_before_transmit(self, context: RequestContext[Any, Any]) -> None:


### PR DESCRIPTION
*Description of changes:*

During the refactor for #449 we accidentally moved a couple calls to the wrong interceptor hook. That's resulting in the user-agent not being correctly appended in current aws-sdk clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
