### PR TITLE
Update dependency ranges for generated clients

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
@@ -22,8 +22,7 @@ public class AwsPythonDependency {
      */
     public static final PythonDependency SMITHY_AWS_CORE = new PythonDependency(
             "smithy_aws_core",
-            // You'll need to locally install this before we publish
-            "==0.0.1",
+            "<0.1.0",
             PythonDependency.Type.DEPENDENCY,
             false);
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -22,8 +22,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_CORE = new PythonDependency(
             "smithy_core",
-            // You'll need to locally install this before we publish
-            "==0.0.1",
+            "<0.1.0",
             Type.DEPENDENCY,
             false);
 
@@ -34,8 +33,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_HTTP = new PythonDependency(
             "smithy_http",
-            // You'll need to locally install this before we publish
-            "==0.0.1",
+            "<0.1.0",
             Type.DEPENDENCY,
             false);
 
@@ -62,7 +60,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_JSON = new PythonDependency(
             "smithy_json",
-            "==0.0.1",
+            "<0.1.0",
             Type.DEPENDENCY,
             false);
 
@@ -71,7 +69,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_AWS_EVENT_STREAM = new PythonDependency(
             "smithy_aws_event_stream",
-            "==0.0.1",
+            "<0.1.0",
             Type.DEPENDENCY,
             false);
 

--- a/packages/smithy-core/pyproject.toml
+++ b/packages/smithy-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smithy-core"
-version = "0.0.1"
+version = "0.0.2"
 description = "Core components for implementing Smithy tooling in Python."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "aws-sdk-signers"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "packages/aws-sdk-signers" }
 
 [package.optional-dependencies]
@@ -662,7 +662,7 @@ requires-dist = [{ name = "smithy-core", editable = "packages/smithy-core" }]
 
 [[package]]
 name = "smithy-core"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "packages/smithy-core" }
 
 [package.dev-dependencies]


### PR DESCRIPTION
*Description of changes:*
This PR changes the supported version ranges on generated clients to the anything in the current minor version. This is intended to avoid having to re-release clients every time we make a bug fix in core tooling. The current thought process is this will be the least disruptive to customers avoiding unnecessary noise in the top level client.

If that proves to be wrong, we can go back to strict pinning, but that's going to lead to issues long term once we start generating multiple clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
