### PR TITLE
Handle AWS error codes in documents

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
@@ -39,7 +39,7 @@ class AWSJSONDocument(JSONDocument):
         parsed = parse_document_discriminator(self, self._settings.default_namespace)
         if parsed is None:
             raise DiscriminatorError(
-                f"Unable to parse discriminator for {self.shape_type} docuemnt."
+                f"Unable to parse discriminator for {self.shape_type} document."
             )
         return parsed
 

--- a/packages/smithy-aws-core/src/smithy_aws_core/utils.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/utils.py
@@ -1,0 +1,32 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from smithy_core.documents import Document
+from smithy_core.shapes import ShapeID, ShapeType
+
+
+def parse_document_discriminator(
+    document: Document, default_namespace: str | None
+) -> ShapeID | None:
+    if document.shape_type is ShapeType.MAP:
+        map_document = document.as_map()
+        code = map_document.get("__type")
+        if code is None:
+            code = map_document.get("code")
+        if code is not None and code.shape_type is ShapeType.STRING:
+            return parse_error_code(code.as_string(), default_namespace)
+
+    return None
+
+
+def parse_error_code(code: str, default_namespace: str | None) -> ShapeID | None:
+    if not code:
+        return None
+
+    code = code.split(":")[0]
+    if "#" in code:
+        return ShapeID(code)
+
+    if not code or not default_namespace:
+        return None
+
+    return ShapeID.from_parts(name=code, namespace=default_namespace)

--- a/packages/smithy-aws-core/tests/unit/test_utils.py
+++ b/packages/smithy-aws-core/tests/unit/test_utils.py
@@ -1,0 +1,78 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from smithy_aws_core.utils import parse_document_discriminator, parse_error_code
+from smithy_core.documents import Document
+from smithy_core.shapes import ShapeID
+
+
+@pytest.mark.parametrize(
+    "document, expected",
+    [
+        ({"__type": "FooError"}, "com.test#FooError"),
+        ({"__type": "com.test#FooError"}, "com.test#FooError"),
+        (
+            {
+                "__type": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
+            },
+            "com.test#FooError",
+        ),
+        (
+            {
+                "__type": "com.test#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate"
+            },
+            "com.test#FooError",
+        ),
+        ({"code": "FooError"}, "com.test#FooError"),
+        ({"code": "com.test#FooError"}, "com.test#FooError"),
+        (
+            {
+                "code": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/"
+            },
+            "com.test#FooError",
+        ),
+        (
+            {
+                "code": "com.test#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate"
+            },
+            "com.test#FooError",
+        ),
+        ({"__type": "FooError", "code": "BarError"}, "com.test#FooError"),
+        ("FooError", None),
+        ({"__type": None}, None),
+        ({"__type": ""}, None),
+        ({"__type": ":"}, None),
+    ],
+)
+def test_aws_json_document_discriminator(
+    document: dict[str, str], expected: ShapeID | None
+) -> None:
+    actual = parse_document_discriminator(Document(document), "com.test")
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("FooError", "com.test#FooError"),
+        (
+            "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
+            "com.test#FooError",
+        ),
+        (
+            "com.test#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate",
+            "com.test#FooError",
+        ),
+        ("", None),
+        (":", None),
+    ],
+)
+def test_parse_error_code(code: str, expected: ShapeID | None) -> None:
+    actual = parse_error_code(code, "com.test")
+    assert actual == expected
+
+
+def test_parse_error_code_without_default_namespace() -> None:
+    actual = parse_error_code("FooError", None)
+    assert actual is None

--- a/packages/smithy-core/src/smithy_core/documents.py
+++ b/packages/smithy-core/src/smithy_core/documents.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import TypeGuard, override
 
 from .deserializers import DeserializeableShape, ShapeDeserializer
-from .exceptions import ExpectationNotMetError, SmithyError
+from .exceptions import DiscriminatorError, ExpectationNotMetError, SmithyError
 from .schemas import Schema
 from .serializers import (
     InterceptingSerializer,
@@ -146,7 +146,9 @@ class Document:
     @property
     def discriminator(self) -> ShapeID:
         """The shape ID that corresponds to the contents of the document."""
-        return self._schema.id
+        if self._type is ShapeType.STRUCTURE:
+            return self._schema.id
+        raise DiscriminatorError(f"{self._type} document has no discriminator.")
 
     def is_none(self) -> bool:
         """Indicates whether the document contains a null value."""

--- a/packages/smithy-core/src/smithy_core/exceptions.py
+++ b/packages/smithy-core/src/smithy_core/exceptions.py
@@ -65,6 +65,11 @@ class SerializationError(SmithyError):
     """Base exception type for exceptions raised during serialization."""
 
 
+class DiscriminatorError(SmithyError):
+    """Exception indicating something went wrong when attempting to find the
+    discriminator in a document."""
+
+
 class RetryError(SmithyError):
     """Base exception type for all exceptions raised in retry strategies."""
 

--- a/packages/smithy-core/tests/unit/test_documents.py
+++ b/packages/smithy-core/tests/unit/test_documents.py
@@ -12,7 +12,7 @@ from smithy_core.documents import (
     _DocumentDeserializer,
     _DocumentSerializer,
 )
-from smithy_core.exceptions import ExpectationNotMetError
+from smithy_core.exceptions import DiscriminatorError, ExpectationNotMetError
 from smithy_core.prelude import (
     BIG_DECIMAL,
     BLOB,
@@ -938,3 +938,13 @@ def test_document_deserializer(given: Document, expected: Any):
             actual = given.as_shape(DocumentSerdeShape)
         case _:
             raise Exception(f"Unexpected type: {type(given)}")
+
+
+def test_document_has_no_discriminator_by_default() -> None:
+    with pytest.raises(DiscriminatorError):
+        Document().discriminator
+
+
+def test_struct_document_has_discriminator() -> None:
+    document = Document({"integerMember": 1}, schema=SCHEMA)
+    assert document.discriminator == SCHEMA.id

--- a/packages/smithy-core/tests/unit/test_type_registry.py
+++ b/packages/smithy-core/tests/unit/test_type_registry.py
@@ -1,8 +1,10 @@
 import pytest
 from smithy_core.deserializers import DeserializeableShape, ShapeDeserializer
 from smithy_core.documents import Document, TypeRegistry
+from smithy_core.prelude import STRING
 from smithy_core.schemas import Schema
-from smithy_core.shapes import ShapeID, ShapeType
+from smithy_core.shapes import ShapeID
+from smithy_core.traits import RequiredTrait
 
 
 def test_get():
@@ -59,11 +61,16 @@ def test_deserialize():
 
 class TestShape(DeserializeableShape):
     __test__ = False
-    schema = Schema(id=ShapeID("com.example#Test"), shape_type=ShapeType.STRING)
+    schema = Schema.collection(
+        id=ShapeID("com.example#Test"),
+        members={"value": {"index": 0, "target": STRING, "traits": [RequiredTrait()]}},
+    )
 
     def __init__(self, value: str):
         self.value = value
 
     @classmethod
     def deserialize(cls, deserializer: ShapeDeserializer) -> "TestShape":
-        return TestShape(deserializer.read_string(schema=TestShape.schema))
+        return TestShape(
+            value=deserializer.read_string(schema=cls.schema.members["value"])
+        )

--- a/packages/smithy-json/src/smithy_json/__init__.py
+++ b/packages/smithy-json/src/smithy_json/__init__.py
@@ -9,11 +9,13 @@ from smithy_core.interfaces import BytesReader, BytesWriter
 from smithy_core.serializers import ShapeSerializer
 from smithy_core.types import TimestampFormat
 
-from ._private import JSONSettings as _JSONSettings
 from ._private.deserializers import JSONShapeDeserializer as _JSONShapeDeserializer
+from ._private.documents import JSONDocument
 from ._private.serializers import JSONShapeSerializer as _JSONShapeSerializer
+from .settings import JSONSettings
 
 __version__: str = importlib.metadata.version("smithy-json")
+__all__ = ("JSONCodec", "JSONDocument", "JSONSettings")
 
 
 class JSONCodec(Codec):
@@ -25,6 +27,7 @@ class JSONCodec(Codec):
         use_timestamp_format: bool = True,
         default_timestamp_format: TimestampFormat = TimestampFormat.DATE_TIME,
         default_namespace: str | None = None,
+        document_class: type[JSONDocument] = JSONDocument,
     ) -> None:
         """Initializes a JSONCodec.
 
@@ -34,11 +37,16 @@ class JSONCodec(Codec):
             `smithy.api#timestampFormat` trait, if present.
         :param default_timestamp_format: The default timestamp format to use if the
             `smithy.api#timestampFormat` trait is not enabled or not present.
+        :param default_namespace: The default namespace to use when determining a
+            document's discriminator.
+        :param document_class: The document class to deserialize to.
         """
-        self._settings = _JSONSettings(
+        self._settings = JSONSettings(
             use_json_name=use_json_name,
             use_timestamp_format=use_timestamp_format,
             default_timestamp_format=default_timestamp_format,
+            default_namespace=default_namespace,
+            document_class=document_class,
         )
 
     @property

--- a/packages/smithy-json/src/smithy_json/_private/__init__.py
+++ b/packages/smithy-json/src/smithy_json/_private/__init__.py
@@ -1,10 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-
-from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
-
-from smithy_core.types import TimestampFormat
 
 
 @runtime_checkable
@@ -12,10 +8,3 @@ class Flushable(Protocol):
     """A protocol for objects that can be flushed."""
 
     def flush(self) -> None: ...
-
-
-@dataclass
-class JSONSettings:
-    use_json_name: bool = True
-    use_timestamp_format: bool = True
-    default_timestamp_format: TimestampFormat = TimestampFormat.DATE_TIME

--- a/packages/smithy-json/src/smithy_json/_private/__init__.py
+++ b/packages/smithy-json/src/smithy_json/_private/__init__.py
@@ -1,7 +1,10 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
+
+from smithy_core.types import TimestampFormat
 
 
 @runtime_checkable
@@ -9,3 +12,10 @@ class Flushable(Protocol):
     """A protocol for objects that can be flushed."""
 
     def flush(self) -> None: ...
+
+
+@dataclass
+class JSONSettings:
+    use_json_name: bool = True
+    use_timestamp_format: bool = True
+    default_timestamp_format: TimestampFormat = TimestampFormat.DATE_TIME

--- a/packages/smithy-json/src/smithy_json/_private/serializers.py
+++ b/packages/smithy-json/src/smithy_json/_private/serializers.py
@@ -21,18 +21,17 @@ from smithy_core.serializers import (
 from smithy_core.traits import JSONNameTrait, TimestampFormatTrait
 from smithy_core.types import TimestampFormat
 
-from . import Flushable, JSONSettings
+from ..settings import JSONSettings
+from . import Flushable
 
 _INF: float = float("inf")
 _NEG_INF: float = float("-inf")
 
 
 class JSONShapeSerializer(ShapeSerializer):
-    def __init__(
-        self, sink: BytesWriter, *, settings: JSONSettings | None = None
-    ) -> None:
+    def __init__(self, sink: BytesWriter, settings: JSONSettings) -> None:
         self._stream = StreamingJSONEncoder(sink)
-        self._settings = settings or JSONSettings()
+        self._settings = settings
 
     def begin_struct(
         self, schema: "Schema"

--- a/packages/smithy-json/src/smithy_json/settings.py
+++ b/packages/smithy-json/src/smithy_json/settings.py
@@ -1,0 +1,31 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from smithy_core.types import TimestampFormat
+
+if TYPE_CHECKING:
+    from ._private.documents import JSONDocument
+
+
+@dataclass(slots=True)
+class JSONSettings:
+    """Settings for the JSON codec."""
+
+    document_class: type["JSONDocument"]
+    """The document class to deserialize to."""
+
+    use_json_name: bool = True
+    """Whether the codec should use `smithy.api#jsonName` trait, if present."""
+
+    use_timestamp_format: bool = True
+    """Whether the codec should use the `smithy.api#timestampFormat` trait, if
+    present."""
+
+    default_timestamp_format: TimestampFormat = TimestampFormat.DATE_TIME
+    """The default timestamp format to use if the `smithy.api#timestampFormat` trait is
+    not enabled or not present."""
+
+    default_namespace: str | None = None
+    """The default namespace to use when determining a document's discriminator."""

--- a/packages/smithy-json/tests/unit/test_deserializers.py
+++ b/packages/smithy-json/tests/unit/test_deserializers.py
@@ -9,12 +9,13 @@ from smithy_core.prelude import (
     BIG_DECIMAL,
     BLOB,
     BOOLEAN,
+    DOCUMENT,
     FLOAT,
     INTEGER,
     STRING,
     TIMESTAMP,
 )
-from smithy_json import JSONCodec
+from smithy_json import JSONCodec, JSONDocument
 
 from . import (
     JSON_SERDE_CASES,
@@ -88,3 +89,13 @@ def test_json_deserializer(expected: Any, given: bytes) -> None:
         assert actual_value == expected_value
     else:
         assert actual == expected
+
+
+class CustomDocument(JSONDocument):
+    pass
+
+
+def test_uses_custom_document() -> None:
+    codec = JSONCodec(document_class=CustomDocument)
+    actual = codec.create_deserializer(b'{"foo": "bar"}').read_document(DOCUMENT)
+    assert isinstance(actual, CustomDocument)


### PR DESCRIPTION
This ensures that error codes in documents (i.e. the bodies of the http response) can be mapped to shape ids.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
