### PR TITLE
Support empty restJson1 trait

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/traits.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/traits.py
@@ -26,14 +26,15 @@ class RestJson1Trait(Trait, id=ShapeID("aws.protocols#restJson1")):
 
     def __init__(self, value: DocumentValue | DynamicTrait = None):
         super().__init__(value)
-        assert isinstance(self.document_value, Mapping)
+        document_value = value or {}
+        assert isinstance(document_value, Mapping)
 
-        http_versions = self.document_value["http"]
+        http_versions = document_value.get("http", ["http/1.1"])
         assert isinstance(http_versions, Sequence)
         for val in http_versions:
             assert isinstance(val, str)
         object.__setattr__(self, "http", tuple(http_versions))
-        event_stream_http_versions = self.document_value.get("eventStreamHttp")
+        event_stream_http_versions = document_value.get("eventStreamHttp")
         if not event_stream_http_versions:
             object.__setattr__(self, "event_stream_http", self.http)
         else:

--- a/packages/smithy-aws-core/tests/unit/test_traits.py
+++ b/packages/smithy-aws-core/tests/unit/test_traits.py
@@ -1,0 +1,9 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from smithy_aws_core.traits import RestJson1Trait
+
+
+def test_allows_empty_restjson1_value() -> None:
+    trait = RestJson1Trait(None)
+    assert trait.http == ("http/1.1",)


### PR DESCRIPTION
The properties of the restJson1 trait are all optional, so this updates the trait implementation to reflect that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
