### PR TITLE
Create new URI when replacing

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/protocols.py
+++ b/packages/smithy-http/src/smithy_http/aio/protocols.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncIterable
 from inspect import iscoroutinefunction
 from typing import Any
 
+from smithy_core import URI as _URI
 from smithy_core.aio.interfaces import AsyncByteStream, ClientProtocol
 from smithy_core.aio.interfaces import StreamingBlob as AsyncStreamingBlob
 from smithy_core.codecs import Codec
@@ -37,17 +38,27 @@ class HttpClientProtocol(ClientProtocol[HTTPRequest, HTTPResponse]):
         endpoint: Endpoint,
     ) -> HTTPRequest:
         uri = endpoint.uri
-        uri_builder = request.destination
+        previous = request.destination
 
-        if uri.scheme:
-            uri_builder.scheme = uri.scheme
-        if uri.host:
-            uri_builder.host = uri.host
-        if uri.port and uri.port > -1:
-            uri_builder.port = uri.port
-        if uri.path:
-            uri_builder.path = os.path.join(uri.path, uri_builder.path or "")
-        # TODO: merge headers from the endpoint properties bag
+        path = previous.path or uri.path
+        if uri.path is not None and previous.path is not None:
+            path = os.path.join(uri.path, previous.path.lstrip("/"))
+
+        query = previous.query or uri.query
+        if uri.query is not None and previous.query is not None:
+            query = f"{uri.query}&{previous.query}"
+
+        request.destination = _URI(
+            scheme=uri.scheme,
+            username=uri.username or previous.username,
+            password=uri.password or previous.password,
+            host=uri.host,
+            port=uri.port or previous.port,
+            path=path,
+            query=query,
+            fragment=uri.fragment or previous.fragment,
+        )
+
         return request
 
 

--- a/packages/smithy-http/tests/unit/aio/test_protocols.py
+++ b/packages/smithy-http/tests/unit/aio/test_protocols.py
@@ -1,0 +1,137 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import pytest
+from smithy_core import URI
+from smithy_core.documents import TypeRegistry
+from smithy_core.endpoints import Endpoint
+from smithy_core.interfaces import TypedProperties
+from smithy_core.interfaces import URI as URIInterface
+from smithy_core.schemas import APIOperation
+from smithy_core.shapes import ShapeID
+from smithy_http import Fields
+from smithy_http.aio import HTTPRequest
+from smithy_http.aio.interfaces import HTTPRequest as HTTPRequestInterface
+from smithy_http.aio.interfaces import HTTPResponse as HTTPResponseInterface
+from smithy_http.aio.protocols import HttpClientProtocol
+
+
+class TestProtocol(HttpClientProtocol):
+    _id = ShapeID("ns.foo#bar")
+
+    @property
+    def id(self) -> ShapeID:
+        return self._id
+
+    def serialize_request(
+        self,
+        *,
+        operation: APIOperation[Any, Any],
+        input: Any,
+        endpoint: URIInterface,
+        context: TypedProperties,
+    ) -> HTTPRequestInterface:
+        raise Exception("This is only for tests.")
+
+    def deserialize_response(
+        self,
+        *,
+        operation: APIOperation[Any, Any],
+        request: HTTPRequestInterface,
+        response: HTTPResponseInterface,
+        error_registry: TypeRegistry,
+        context: TypedProperties,
+    ) -> Any:
+        raise Exception("This is only for tests.")
+
+
+@pytest.mark.parametrize(
+    "request_uri,endpoint_uri,expected",
+    [
+        (
+            URI(host="com.example", path="/foo"),
+            URI(host="com.example", path="/bar"),
+            URI(host="com.example", path="/bar/foo"),
+        ),
+        (
+            URI(host="com.example"),
+            URI(host="com.example", path="/bar"),
+            URI(host="com.example", path="/bar"),
+        ),
+        (
+            URI(host="com.example", path="/foo"),
+            URI(host="com.example"),
+            URI(host="com.example", path="/foo"),
+        ),
+        (
+            URI(host="com.example", scheme="http"),
+            URI(host="com.example", scheme="https"),
+            URI(host="com.example", scheme="https"),
+        ),
+        (
+            URI(host="com.example", username="name", password="password"),
+            URI(host="com.example", username="othername", password="otherpassword"),
+            URI(host="com.example", username="othername", password="otherpassword"),
+        ),
+        (
+            URI(host="com.example", username="name", password="password"),
+            URI(host="com.example"),
+            URI(host="com.example", username="name", password="password"),
+        ),
+        (
+            URI(host="com.example", port=8080),
+            URI(host="com.example", port=8000),
+            URI(host="com.example", port=8000),
+        ),
+        (
+            URI(host="com.example", port=8080),
+            URI(host="com.example"),
+            URI(host="com.example", port=8080),
+        ),
+        (
+            URI(host="com.example", query="foo=bar"),
+            URI(host="com.example"),
+            URI(host="com.example", query="foo=bar"),
+        ),
+        (
+            URI(host="com.example"),
+            URI(host="com.example", query="spam"),
+            URI(host="com.example", query="spam"),
+        ),
+        (
+            URI(host="com.example", query="foo=bar"),
+            URI(host="com.example", query="spam"),
+            URI(host="com.example", query="spam&foo=bar"),
+        ),
+        (
+            URI(host="com.example", fragment="header"),
+            URI(host="com.example", fragment="footer"),
+            URI(host="com.example", fragment="footer"),
+        ),
+        (
+            URI(host="com.example"),
+            URI(host="com.example", fragment="footer"),
+            URI(host="com.example", fragment="footer"),
+        ),
+        (
+            URI(host="com.example", fragment="header"),
+            URI(host="com.example"),
+            URI(host="com.example", fragment="header"),
+        ),
+    ],
+)
+def test_http_protocol_joins_uris(
+    request_uri: URI, endpoint_uri: URI, expected: URI
+) -> None:
+    protocol = TestProtocol()
+    request = HTTPRequest(
+        destination=request_uri,
+        method="GET",
+        fields=Fields(),
+    )
+    endpoint = Endpoint(uri=endpoint_uri)
+    updated_request = protocol.set_service_endpoint(request=request, endpoint=endpoint)
+    actual = updated_request.destination
+    assert actual == expected


### PR DESCRIPTION
This updates the uri replacement to create a new uri since the existing one may not be mutable. It also fixes the joining logic, because `.join` will discard any elements prior to one that begins with `/`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
