### PR TITLE
Fix query binding

### DIFF
--- a/packages/smithy-http/src/smithy_http/serializers.py
+++ b/packages/smithy-http/src/smithy_http/serializers.py
@@ -570,12 +570,27 @@ class HTTPQueryMapSerializer(MapSerializer):
         :param query_params: The list of query param tuples to append to.
         """
         self._query_params = query_params
-        self._delegate = CapturingSerializer()
 
     def entry(self, key: str, value_writer: Callable[[ShapeSerializer], None]):
-        value_writer(self._delegate)
-        assert self._delegate.result is not None  # noqa: S101
-        self._query_params.append((key, urlquote(self._delegate.result, safe="")))
+        value_writer(HTTPQueryMapValueSerializer(key, self._query_params))
+
+
+class HTTPQueryMapValueSerializer(SpecificShapeSerializer):
+    def __init__(self, key: str,  query_params: list[tuple[str, str]]) -> None:
+        """Initialize an HTTPQueryMapValueSerializer.
+
+        :param key: The key of the query parameter.
+        :param query_params: The list of query param tuples to append to.
+        """
+        self._key = key
+        self._query_params = query_params
+
+    def write_string(self, schema: Schema, value: str) -> None:
+        self._query_params.append((self._key, urlquote(value, safe="")))
+
+    @contextmanager
+    def begin_list(self, schema: Schema, size: int) -> Iterator[ShapeSerializer]:
+        yield self
 
 
 class HostPrefixSerializer(SpecificShapeSerializer):

--- a/packages/smithy-http/src/smithy_http/serializers.py
+++ b/packages/smithy-http/src/smithy_http/serializers.py
@@ -328,7 +328,7 @@ class HTTPHeaderSerializer(SpecificShapeSerializer):
             :py:class:`HTTPHeaderTrait` will be checked instead. Required when
             collecting list entries.
         :param headers: An optional list of header tuples to append to. If not
-            set, one will be created.
+            set, one will be created. Values appended will not be escaped.
         """
         self.headers: list[tuple[str, str]] = headers if headers is not None else []
         self._key = key
@@ -486,7 +486,7 @@ class HTTPQuerySerializer(SpecificShapeSerializer):
 
     def write_string(self, schema: Schema, value: str) -> None:
         key = self._key or schema.expect_trait(HTTPQueryTrait).key
-        self.query_params.append((key, urlquote(value, safe="")))
+        self.query_params.append((key, value))
 
     def write_timestamp(self, schema: Schema, value: datetime) -> None:
         key = self._key or schema.expect_trait(HTTPQueryTrait).key
@@ -576,7 +576,7 @@ class HTTPQueryMapSerializer(MapSerializer):
 
 
 class HTTPQueryMapValueSerializer(SpecificShapeSerializer):
-    def __init__(self, key: str,  query_params: list[tuple[str, str]]) -> None:
+    def __init__(self, key: str, query_params: list[tuple[str, str]]) -> None:
         """Initialize an HTTPQueryMapValueSerializer.
 
         :param key: The key of the query parameter.
@@ -586,7 +586,8 @@ class HTTPQueryMapValueSerializer(SpecificShapeSerializer):
         self._query_params = query_params
 
     def write_string(self, schema: Schema, value: str) -> None:
-        self._query_params.append((self._key, urlquote(value, safe="")))
+        # Note: values are escaped when query params are joined
+        self._query_params.append((self._key, value))
 
     @contextmanager
     def begin_list(self, schema: Schema, size: int) -> Iterator[ShapeSerializer]:

--- a/packages/smithy-http/tests/unit/test_serializers.py
+++ b/packages/smithy-http/tests/unit/test_serializers.py
@@ -1382,6 +1382,20 @@ def query_cases() -> list[HTTPMessageTestCase]:
             ),
         ),
         HTTPMessageTestCase(
+            HTTPQuery(string_member="foo bar"),
+            HTTPMessage(destination=URI(host="", path="/", query="string=foo%20bar")),
+        ),
+        HTTPMessageTestCase(
+            HTTPQuery(string_list_member=["spam eggs", "eggs spam"]),
+            HTTPMessage(
+                destination=URI(
+                    host="",
+                    path="/",
+                    query="stringList=spam%20eggs&stringList=eggs%20spam",
+                )
+            ),
+        ),
+        HTTPMessageTestCase(
             HTTPQuery(
                 default_timestamp_member=datetime.datetime(2025, 1, 1, tzinfo=UTC)
             ),


### PR DESCRIPTION
This fixes an issue where query values were being double-encoded, and also serialization of maps of lists in the query string


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
