### PR TITLE
Split singleton headers

### DIFF
--- a/packages/smithy-http/src/smithy_http/deserializers.py
+++ b/packages/smithy-http/src/smithy_http/deserializers.py
@@ -23,6 +23,7 @@ from smithy_core.utils import ensure_utc, strict_parse_bool, strict_parse_float
 from .aio.interfaces import HTTPResponse
 from .bindings import Binding, ResponseBindingMatcher
 from .interfaces import Field, Fields
+from .utils import split_header
 
 if TYPE_CHECKING:
     from smithy_core.aio.interfaces import StreamingBlob as AsyncStreamingBlob
@@ -205,7 +206,17 @@ class HTTPHeaderListDeserializer(SpecificShapeDeserializer):
     def read_list(
         self, schema: Schema, consumer: Callable[["ShapeDeserializer"], None]
     ) -> None:
-        for value in self._field.values:
+        values = self._field.values
+        if len(values) == 1:
+            is_http_date_list = False
+            value_schema = schema.members["member"]
+            if value_schema.shape_type is ShapeType.TIMESTAMP:
+                trait = value_schema.get_trait(TimestampFormatTrait)
+                is_http_date_list = (
+                    trait is None or trait.format is TimestampFormat.HTTP_DATE
+                )
+            values = split_header(values[0], is_http_date_list)
+        for value in values:
             consumer(HTTPHeaderDeserializer(value))
 
 

--- a/packages/smithy-http/tests/unit/test_serializers.py
+++ b/packages/smithy-http/tests/unit/test_serializers.py
@@ -1250,6 +1250,90 @@ def header_cases() -> list[HTTPMessageTestCase]:
     ]
 
 
+def header_deser_cases() -> list[HTTPMessageTestCase]:
+    return [
+        HTTPMessageTestCase(
+            HTTPHeaders(string_list_member=["foo", "bar", "baz"]),
+            HTTPMessage(fields=tuples_to_fields([("stringList", "foo, bar, baz")])),
+        ),
+        HTTPMessageTestCase(
+            HTTPHeaders(string_list_member=["foo, bar", "spam", "eggs"]),
+            HTTPMessage(
+                fields=tuples_to_fields([("stringList", '"foo, bar", spam, eggs')])
+            ),
+        ),
+        HTTPMessageTestCase(
+            HTTPHeaders(
+                http_date_list_timestamp_member=[
+                    datetime.datetime(2025, 1, 1, tzinfo=UTC),
+                    datetime.datetime(2024, 1, 1, tzinfo=UTC),
+                ]
+            ),
+            HTTPMessage(
+                fields=tuples_to_fields(
+                    [
+                        (
+                            "httpDateListTimestamp",
+                            "Wed, 01 Jan 2025 00:00:00 GMT, Mon, 01 Jan 2024 00:00:00 GMT",
+                        ),
+                    ]
+                ),
+            ),
+        ),
+        HTTPMessageTestCase(
+            HTTPHeaders(
+                http_date_list_timestamp_member=[
+                    datetime.datetime(2025, 1, 1, tzinfo=UTC),
+                    datetime.datetime(2024, 1, 1, tzinfo=UTC),
+                ]
+            ),
+            HTTPMessage(
+                fields=tuples_to_fields(
+                    [
+                        (
+                            "httpDateListTimestamp",
+                            '"Wed, 01 Jan 2025 00:00:00 GMT", "Mon, 01 Jan 2024 00:00:00 GMT"',
+                        ),
+                    ]
+                ),
+            ),
+        ),
+        HTTPMessageTestCase(
+            HTTPHeaders(
+                date_time_list_timestamp_member=[
+                    datetime.datetime(2025, 1, 1, tzinfo=UTC),
+                    datetime.datetime(2024, 1, 1, tzinfo=UTC),
+                ]
+            ),
+            HTTPMessage(
+                fields=tuples_to_fields(
+                    [
+                        (
+                            "dateTimeListTimestamp",
+                            "2025-01-01T00:00:00Z, 2024-01-01T00:00:00Z",
+                        ),
+                    ]
+                ),
+            ),
+        ),
+        HTTPMessageTestCase(
+            HTTPHeaders(
+                epoch_list_timestamp_member=[
+                    datetime.datetime(2025, 1, 1, tzinfo=UTC),
+                    datetime.datetime(2024, 1, 1, tzinfo=UTC),
+                ]
+            ),
+            HTTPMessage(
+                fields=tuples_to_fields(
+                    [
+                        ("epochListTimestamp", "1735689600, 1704067200"),
+                    ]
+                ),
+            ),
+        ),
+    ]
+
+
 def empty_prefix_header_ser_cases() -> list[HTTPMessageTestCase]:
     return [
         HTTPMessageTestCase(
@@ -1714,9 +1798,9 @@ async def test_serialize_response_omitting_empty_payload() -> None:
 
 RESPONSE_DESER_CASES: list[HTTPMessageTestCase] = (
     header_cases()
+    + header_deser_cases()
     + empty_prefix_header_deser_cases()
     + payload_cases()
-    + response_payload_cases()
 )
 
 


### PR DESCRIPTION
Header lists may be serialized either as the same header multiple times, or as a comma-delimted string. This updates the header list deserializer to split a list value if there is only one. It takes care to ensure that lists of http-date headers are supported with and without quoting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
