### PR TITLE
Update test-py command and fix broken test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,14 @@ check-py: ## Runs checks (formatting, lints, type-checking) on the python packag
 
 
 test-py: ## Runs tests for the python packages.
-	uv run pytest packages
+    # NOTE: Due to namespace collisions with identically named test files across packages,
+    # run tests per package: uv run pytest packages/package-name/tests
+	@for pkg in packages/*/; do \
+		if [ -d "$$pkg/tests" ]; then \
+			echo "Running tests for $$pkg"; \
+			uv run pytest "$$pkg/tests" || exit 1; \
+		fi; \
+	done
 
 
 build-py: ## Builds the python packages.

--- a/packages/smithy-core/src/smithy_core/interfaces/identity.py
+++ b/packages/smithy-core/src/smithy_core/interfaces/identity.py
@@ -3,6 +3,8 @@
 from datetime import UTC, datetime
 from typing import Protocol, runtime_checkable
 
+from ..utils import ensure_utc
+
 
 @runtime_checkable
 class Identity(Protocol):
@@ -16,7 +18,7 @@ class Identity(Protocol):
 
     def __post_init__(self) -> None:
         if self.expiration is not None:
-            self.expiration = self.expiration.astimezone(UTC)
+            self.expiration = ensure_utc(self.expiration)
 
     @property
     def is_expired(self) -> bool:

--- a/packages/smithy-core/src/smithy_core/interfaces/identity.py
+++ b/packages/smithy-core/src/smithy_core/interfaces/identity.py
@@ -14,6 +14,10 @@ class Identity(Protocol):
     If time zone is provided, it is updated to UTC. The value must always be in UTC.
     """
 
+    def __post_init__(self) -> None:
+        if self.expiration is not None:
+            self.expiration = self.expiration.astimezone(UTC)
+
     @property
     def is_expired(self) -> bool:
         """Whether the identity is expired."""


### PR DESCRIPTION
## Summary

This PR addresses and prevents namespace collisions when running `uv run pytest` at the root of the project (current behavior for `make test-py`).

## Problem
The `packages` directory in this repo contains a collection of smithy and aws packages that are managed using uv workspaces. 

Because the `smithy-core` and `aws-sdk-signers` packages both contain a `tests/unit/test_identity.py` file, this is resulting in a namespace collision and only running tests for `aws-sdk-signers`. As a result there are bad tests in `smithy-core` that were never run/caught.

## Solution
Instead of running `uv run pytest` at the root of the repo, we'll instead iterate over each package in `packages` and run `uv run pytest packages/package-name/tests`.

### Alternative
- Name each test file uniquely using some prefix (e.g. `test_aws_core_identity.py` instead of `test_identity.py`). These leaves us susceptible to future issues if the naming convention isn't upheld.
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
