### PR TITLE
Move dev dependencies under "[dependency-groups]" in pyproject.toml

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
@@ -157,7 +157,7 @@ public final class SetupGenerator {
             }
 
             testDeps.ifPresent(deps -> {
-                writer.openBlock("tests = [", "]\n", () -> writeDependencyList(writer, deps));
+                writer.openBlock("test = [", "]\n", () -> writeDependencyList(writer, deps));
             });
 
             docsDeps.ifPresent(deps -> {

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
@@ -153,7 +153,7 @@ public final class SetupGenerator {
                             .map(Map::values);
 
             if (testDeps.isPresent() || docsDeps.isPresent()) {
-                writer.write("[project.optional-dependencies]");
+                writer.write("[dependency-groups]");
             }
 
             testDeps.ifPresent(deps -> {

--- a/packages/aws-sdk-signers/pyproject.toml
+++ b/packages/aws-sdk-signers/pyproject.toml
@@ -34,14 +34,6 @@ exclude = [
  "tests",
 ]
 
-[dependency-groups]
-dev = [
-    "freezegun",
-    "pytest",
-    "pytest-asyncio",
-    "mypy",
-    "ruff",
-]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/aws-sdk-signers/pyproject.toml
+++ b/packages/aws-sdk-signers/pyproject.toml
@@ -34,8 +34,8 @@ exclude = [
  "tests",
 ]
 
-[project.optional-dependencies]
-test = [
+[dependency-groups]
+dev = [
     "freezegun",
     "pytest",
     "pytest-asyncio",

--- a/packages/smithy-core/pyproject.toml
+++ b/packages/smithy-core/pyproject.toml
@@ -7,9 +7,8 @@ requires-python = ">=3.12"
 dependencies = []
 
 [dependency-groups]
-dev = [
-    "freezegun>=1.5.1",
-    "typing_extensions>=4.13.0"
+typing = [
+    "typing_extensions>=4.13.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,19 +7,25 @@ requires-python = ">=3.12"
 dependencies = []
 
 [dependency-groups]
-dev = [
-    "black>=25.1.0",
-    "docformatter>=1.7.5",
-    "pyright>=1.1.400",
+test = [
     "pytest>=8.3.4",
     "pytest-asyncio>=0.25.3",
     "pytest-cov>=6.0.0",
+    "freezegun>=1.5.1",
+]
+lint = [
+    "black>=25.1.0",
     "ruff>=0.9.7",
+    "docformatter>=1.7.5",
+]
+typing = [
+    "pyright>=1.1.400",
 ]
 
 [tool.uv]
 required-version = ">=0.7.2"
 package = false
+default-groups = ["test", "lint", "typing"]
 
 [tool.uv.workspace]
 members = ["packages/*"]

--- a/uv.lock
+++ b/uv.lock
@@ -97,8 +97,8 @@ name = "aws-sdk-signers"
 version = "0.0.3"
 source = { editable = "packages/aws-sdk-signers" }
 
-[package.optional-dependencies]
-test = [
+[package.dev-dependencies]
+dev = [
     { name = "freezegun" },
     { name = "mypy" },
     { name = "pytest" },
@@ -107,14 +107,15 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "freezegun", marker = "extra == 'test'" },
-    { name = "mypy", marker = "extra == 'test'" },
-    { name = "pytest", marker = "extra == 'test'" },
-    { name = "pytest-asyncio", marker = "extra == 'test'" },
-    { name = "ruff", marker = "extra == 'test'" },
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "freezegun" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
-provides-extras = ["test"]
 
 [[package]]
 name = "awscrt"

--- a/uv.lock
+++ b/uv.lock
@@ -97,26 +97,6 @@ name = "aws-sdk-signers"
 version = "0.0.3"
 source = { editable = "packages/aws-sdk-signers" }
 
-[package.dev-dependencies]
-dev = [
-    { name = "freezegun" },
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "freezegun" },
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
-]
-
 [[package]]
 name = "awscrt"
 version = "0.26.1"
@@ -441,31 +421,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717, upload-time = "2025-02-05T03:50:34.655Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd", size = 10793981, upload-time = "2025-02-05T03:50:28.25Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f", size = 9749175, upload-time = "2025-02-05T03:50:13.411Z" },
-    { url = "https://files.pythonhosted.org/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464", size = 11455675, upload-time = "2025-02-05T03:50:31.421Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee", size = 12410020, upload-time = "2025-02-05T03:48:48.705Z" },
-    { url = "https://files.pythonhosted.org/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e", size = 12498582, upload-time = "2025-02-05T03:49:03.628Z" },
-    { url = "https://files.pythonhosted.org/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22", size = 9366614, upload-time = "2025-02-05T03:50:00.313Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/9b/fd2e05d6ffff24d912f150b87db9e364fa8282045c875654ce7e32fffa66/mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445", size = 10788592, upload-time = "2025-02-05T03:48:55.789Z" },
-    { url = "https://files.pythonhosted.org/packages/74/37/b246d711c28a03ead1fd906bbc7106659aed7c089d55fe40dd58db812628/mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d", size = 9753611, upload-time = "2025-02-05T03:48:44.581Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/ac/395808a92e10cfdac8003c3de9a2ab6dc7cde6c0d2a4df3df1b815ffd067/mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5", size = 11438443, upload-time = "2025-02-05T03:49:25.514Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/8b/801aa06445d2de3895f59e476f38f3f8d610ef5d6908245f07d002676cbf/mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036", size = 12402541, upload-time = "2025-02-05T03:49:57.623Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/67/5a4268782eb77344cc613a4cf23540928e41f018a9a1ec4c6882baf20ab8/mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357", size = 12494348, upload-time = "2025-02-05T03:48:52.361Z" },
-    { url = "https://files.pythonhosted.org/packages/83/3e/57bb447f7bbbfaabf1712d96f9df142624a386d98fb026a761532526057e/mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf", size = 9373648, upload-time = "2025-02-05T03:49:11.395Z" },
-    { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777, upload-time = "2025-02-05T03:50:08.348Z" },
-]
-
-[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -716,18 +671,14 @@ version = "0.0.2"
 source = { editable = "packages/smithy-core" }
 
 [package.dev-dependencies]
-dev = [
-    { name = "freezegun" },
+typing = [
     { name = "typing-extensions" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "freezegun", specifier = ">=1.5.1" },
-    { name = "typing-extensions", specifier = ">=4.13.0" },
-]
+typing = [{ name = "typing-extensions", specifier = ">=4.13.0" }]
 
 [[package]]
 name = "smithy-http"
@@ -776,28 +727,36 @@ version = "0.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]
-dev = [
+lint = [
     { name = "black" },
     { name = "docformatter" },
-    { name = "pyright" },
+    { name = "ruff" },
+]
+test = [
+    { name = "freezegun" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
-    { name = "ruff" },
+]
+typing = [
+    { name = "pyright" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [
+lint = [
     { name = "black", specifier = ">=25.1.0" },
     { name = "docformatter", specifier = ">=1.7.5" },
-    { name = "pyright", specifier = ">=1.1.400" },
+    { name = "ruff", specifier = ">=0.9.7" },
+]
+test = [
+    { name = "freezegun", specifier = ">=1.5.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "ruff", specifier = ">=0.9.7" },
 ]
+typing = [{ name = "pyright", specifier = ">=1.1.400" }]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## Summary

In `aws-sdk-signers` and the code generator that is used to build the AWS clients in [aws-sdk-python](https://github.com/awslabs/aws-sdk-python/tree/develop/clients), we're defining optional dependencies in pyproject.toml for test and docs dependencies as shown below:

```
[project.optional-dependencies]
foo = [ .. ]
bar = [ ... ]
```

This PR moves these under `[dependency-groups]` ([ref](https://packaging.python.org/en/latest/specifications/dependency-groups/)):

> This specification defines Dependency Groups, a mechanism for storing package requirements in pyproject.toml files such that they are not included in project metadata when it is built.
>
> Dependency Groups are suitable for internal development use-cases like linting and testing, as well as for projects which are not built for distribution, like collections of related scripts.
>
> Fundamentally, Dependency Groups should be thought of as being a standardized subset of the capabilities of requirements.txt files (which are pip-specific).
>
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
