### PR TITLE
Use the consider_namespace_packages so we can run pytest at the root …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,7 @@ check-py: ## Runs checks (formatting, lints, type-checking) on the python packag
 
 
 test-py: ## Runs tests for the python packages.
-    # NOTE: Due to namespace collisions with identically named test files across packages,
-    # run tests per package: uv run pytest packages/package-name/tests
-	@for pkg in packages/*/; do \
-		if [ -d "$$pkg/tests" ]; then \
-			echo "Running tests for $$pkg"; \
-			uv run pytest "$$pkg/tests" || exit 1; \
-		fi; \
-	done
+	uv run pytest packages
 
 
 build-py: ## Builds the python packages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ enableExperimentalFeatures = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto" # makes pytest run async tests without having to be marked with the @pytest.mark.asyncio decorator
 addopts = [ "--import-mode=importlib", "--cov", "--cov-report=term-missing" ]
+consider_namespace_packages = true
 
 [tool.docformatter]
 recursive = true


### PR DESCRIPTION
By setting the `consider_namespace_packages = true` pytest config, we can revert the changes to the `make test-py` command in https://github.com/smithy-lang/smithy-python/pull/521 so we're using `uv run pytest packages` again. This config prevents the namespace issues we were seeing previously.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
