### PR TITLE
Standardize metadata for packages pyproject.toml files

### DIFF
--- a/packages/aws-sdk-signers/pyproject.toml
+++ b/packages/aws-sdk-signers/pyproject.toml
@@ -21,9 +21,15 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Libraries"
 ]
+
+[project.urls]
+"Changelog" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/aws-sdk-signers/CHANGES.md"
+"Code" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/aws-sdk-signers/"
+"Issue tracker" = "https://github.com/smithy-lang/smithy-python/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/smithy-aws-core/pyproject.toml
+++ b/packages/smithy-aws-core/pyproject.toml
@@ -1,14 +1,40 @@
 [project]
 name = "smithy-aws-core"
 version = "0.0.1"
+requires-python = ">=3.12"
+authors = [
+  {name = "Amazon Web Services"},
+]
 description = "Core Smithy components for AWS services and protocols."
 readme = "README.md"
-requires-python = ">=3.12"
+license = {text = "Apache License 2.0"}
+keywords = ["aws", "sdk", "amazon", "smithy"]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "Natural Language :: English",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Topic :: Software Development :: Libraries"
+]
 dependencies = [
     "smithy-core",
     "smithy-http",
     "aws-sdk-signers"
 ]
+
+[project.urls]
+"Changelog" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-aws-core/CHANGES.md"
+"Code" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-aws-core/"
+"Issue tracker" = "https://github.com/smithy-lang/smithy-python/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/smithy-aws-event-stream/pyproject.toml
+++ b/packages/smithy-aws-event-stream/pyproject.toml
@@ -1,12 +1,38 @@
 [project]
 name = "smithy-aws-event-stream"
 version = "0.0.1"
+requires-python = ">=3.12"
+authors = [
+  {name = "Amazon Web Services"},
+]
 description = "Smithy components for Amazon Event Streams."
 readme = "README.md"
-requires-python = ">=3.12"
+license = {text = "Apache License 2.0"}
+keywords = ["aws", "sdk", "amazon", "smithy", "eventstream"]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "Natural Language :: English",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Topic :: Software Development :: Libraries"
+]
 dependencies = [
     "smithy-core",
 ]
+
+[project.urls]
+"Changelog" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-aws-event-stream/CHANGES.md"
+"Code" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-aws-event-stream/"
+"Issue tracker" = "https://github.com/smithy-lang/smithy-python/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/smithy-core/pyproject.toml
+++ b/packages/smithy-core/pyproject.toml
@@ -1,10 +1,36 @@
 [project]
 name = "smithy-core"
 version = "0.0.2"
+requires-python = ">=3.12"
+authors = [
+  {name = "Amazon Web Services"},
+]
 description = "Core components for implementing Smithy tooling in Python."
 readme = "README.md"
-requires-python = ">=3.12"
+license = {text = "Apache License 2.0"}
+keywords = ["smithy", "sdk"]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "Natural Language :: English",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Topic :: Software Development :: Libraries"
+]
 dependencies = []
+
+[project.urls]
+"Changelog" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-core/CHANGES.md"
+"Code" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-core/"
+"Issue tracker" = "https://github.com/smithy-lang/smithy-python/issues"
 
 [dependency-groups]
 typing = [

--- a/packages/smithy-http/pyproject.toml
+++ b/packages/smithy-http/pyproject.toml
@@ -1,12 +1,38 @@
 [project]
 name = "smithy-http"
 version = "0.0.1"
+requires-python = ">=3.12"
+authors = [
+  {name = "Amazon Web Services"},
+]
 description = "HTTP components for Smithy tooling."
 readme = "README.md"
-requires-python = ">=3.12"
+license = {text = "Apache License 2.0"}
+keywords = ["smithy", "sdk", "http"]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "Natural Language :: English",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Topic :: Software Development :: Libraries"
+]
 dependencies = [
     "smithy-core",
 ]
+
+[project.urls]
+"Changelog" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-http/CHANGES.md"
+"Code" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-http/"
+"Issue tracker" = "https://github.com/smithy-lang/smithy-python/issues"
 
 [project.optional-dependencies]
 awscrt = [

--- a/packages/smithy-json/pyproject.toml
+++ b/packages/smithy-json/pyproject.toml
@@ -1,13 +1,39 @@
 [project]
 name = "smithy-json"
 version = "0.0.1"
+requires-python = ">=3.12"
+authors = [
+  {name = "Amazon Web Services"},
+]
 description = "JSON serialization and deserialization support for Smithy tooling."
 readme = "README.md"
-requires-python = ">=3.12"
+license = {text = "Apache License 2.0"}
+keywords = ["smithy", "sdk", "json"]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "Natural Language :: English",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Topic :: Software Development :: Libraries"
+]
 dependencies = [
     "ijson>=3.3.0",
     "smithy-core",
 ]
+
+[project.urls]
+"Changelog" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-json/CHANGES.md"
+"Code" = "https://github.com/smithy-lang/smithy-python/blob/develop/packages/smithy-json/"
+"Issue tracker" = "https://github.com/smithy-lang/smithy-python/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
*Description of changes:*
This PR started as adding a proper trove classifier for Python 3.14 but revealed a number of issues in our current package metadata including a lack of standardization. To get us started on the right track, I've included a base set of information for each project so it renders as expected on PyPI.

## Added Fields
### Project Metadata
* Authors
* License
* Keywords
* Classifiers

### Project URLs
* Changelog
* Code
* Issue Tracker

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
