### PR TITLE
Avoid logging schemas

### DIFF
--- a/packages/smithy-core/src/smithy_core/aio/client.py
+++ b/packages/smithy-core/src/smithy_core/aio/client.py
@@ -5,7 +5,7 @@ import logging
 from asyncio import Future, sleep
 from collections.abc import Awaitable, Callable, Sequence
 from copy import copy
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
 from .. import URI
@@ -56,7 +56,7 @@ class ClientCall[I: SerializeableShape, O: DeserializeableShape]:
     input: I
     """The input of the operation."""
 
-    operation: APIOperation[I, O]
+    operation: APIOperation[I, O] = field(repr=False)
     """The schema of the operation."""
 
     context: TypedProperties

--- a/packages/smithy-core/src/smithy_core/auth.py
+++ b/packages/smithy-core/src/smithy_core/auth.py
@@ -19,7 +19,7 @@ class AuthParams[I: SerializeableShape, O: DeserializeableShape]:
     protocol_id: ShapeID
     """The ID of the protocol being used for the operation invocation."""
 
-    operation: APIOperation[I, O]
+    operation: APIOperation[I, O] = field(repr=False)
     """The schema and associated information about the operation being invoked."""
 
     context: _TypedProperties

--- a/packages/smithy-core/src/smithy_core/endpoints.py
+++ b/packages/smithy-core/src/smithy_core/endpoints.py
@@ -33,7 +33,7 @@ class Endpoint(_Endpoint):
 class EndpointResolverParams[I: SerializeableShape]:
     """Parameters passed into an Endpoint Resolver's resolve_endpoint method."""
 
-    operation: APIOperation[I, Any]
+    operation: APIOperation[I, Any] = field(repr=False)
     """The operation to resolve an endpoint for."""
 
     input: I

--- a/packages/smithy-core/src/smithy_core/schemas.py
+++ b/packages/smithy-core/src/smithy_core/schemas.py
@@ -288,13 +288,13 @@ class APIOperation[I: "SerializeableShape", O: "DeserializeableShape"]:
     output: type[O]
     """The output type of the operation."""
 
-    schema: Schema
+    schema: Schema = field(repr=False)
     """The schema of the operation."""
 
-    input_schema: Schema
+    input_schema: Schema = field(repr=False)
     """The schema of the operation's input shape."""
 
-    output_schema: Schema
+    output_schema: Schema = field(repr=False)
     """The schema of the operation's output shape."""
 
     error_registry: "TypeRegistry"


### PR DESCRIPTION
This updates several dataclasses to avoid including schemas in their default `repr` so that they don't get logged without deliberate intent. Logging schemas can be very messy as they are huge.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
