### PR TITLE
Add AWS static config

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
@@ -32,6 +32,9 @@ public class AwsAuthIntegration implements PythonIntegration {
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins(GenerationContext context) {
+        if (!hasSigV4Auth(context)) {
+            return List.of();
+        }
         return List.of(
                 RuntimeClientPlugin.builder()
                         .servicePredicate((model, service) -> service.hasTrait(SigV4Trait.class))
@@ -61,6 +64,24 @@ public class AwsAuthIntegration implements PythonIntegration {
                                 .nullable(true)
                                 .build())
                         .addConfigProperty(REGION)
+                        .addConfigProperty(ConfigProperty.builder()
+                                .name("aws_access_key_id")
+                                .type(Symbol.builder().name("str").build())
+                                .documentation("The identifier for a secret access key.")
+                                .nullable(true)
+                                .build())
+                        .addConfigProperty(ConfigProperty.builder()
+                                .name("aws_secret_access_key")
+                                .type(Symbol.builder().name("str").build())
+                                .nullable(true)
+                                .documentation("A secret access key that can be used to sign requests.")
+                                .build())
+                        .addConfigProperty(ConfigProperty.builder()
+                                .name("aws_session_token")
+                                .type(Symbol.builder().name("str").build())
+                                .documentation("An access key ID that identifies temporary security credentials.")
+                                .nullable(true)
+                                .build())
                         .authScheme(new Sigv4AuthScheme())
                         .build());
     }

--- a/packages/smithy-aws-core/src/smithy_aws_core/auth/sigv4.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/auth/sigv4.py
@@ -73,9 +73,9 @@ class SigV4AuthScheme(
     ) -> AWSIdentityProperties:
         config = context[AWS_IDENTITY_CONFIG]
         return {
-            "access_key_id": config.access_key_id,
-            "secret_access_key": config.secret_access_key,
-            "session_token": config.session_token,
+            "access_key_id": config.aws_access_key_id,
+            "secret_access_key": config.aws_secret_access_key,
+            "session_token": config.aws_session_token,
         }
 
     def identity_resolver(self, *, context: _TypedProperties) -> AWSCredentialsResolver:

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/__init__.py
@@ -44,9 +44,9 @@ type AWSCredentialsResolver = IdentityResolver[
 
 
 class AWSIdentityConfig(Protocol):
-    access_key_id: str | None
-    secret_access_key: str | None
-    session_token: str | None = None
+    aws_access_key_id: str | None
+    aws_secret_access_key: str | None
+    aws_session_token: str | None = None
 
 
 AWS_IDENTITY_CONFIG = PropertyKey(key="config", value_type=AWSIdentityConfig)


### PR DESCRIPTION
This adds three top-level config options when sigv4 auth is enabled:

* `aws_access_key_id`
* `aws_secret_access_key`
* `aws_session_token`

These are used for static credentials. Names are identical to botocore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
