### PR TITLE
Wrap http bodies in async readable

### DIFF
--- a/packages/aws-sdk-signers/src/aws_sdk_signers/interfaces/io.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/interfaces/io.py
@@ -34,3 +34,14 @@ class AsyncSeekable(Protocol):
     async def seek(self, offset: int, whence: int = 0, /) -> int: ...
 
     def tell(self) -> int: ...
+
+
+@runtime_checkable
+class ConditionallySeekable:
+    """A file-like object that is conditionally seekable.
+
+    This is separate from Seekable and AsyncSeekable as seekable objects may not define
+    this method.
+    """
+
+    def seekable(self) -> bool: ...

--- a/packages/smithy-core/src/smithy_core/aio/utils.py
+++ b/packages/smithy-core/src/smithy_core/aio/utils.py
@@ -60,8 +60,13 @@ async def close(stream: Any) -> None:
             await result
 
 
-async def seek(stream: Any, to: int) -> None:
+async def seek(stream: Any, offset: int, whence: int = 0) -> int | None:
     """Seek a stream to a specified point."""
+    if (seekable := getattr(stream, "seekable", None)) is not None and not seekable():
+        return
+
     if (seek := getattr(stream, "seek", None)) is not None:
-        if iscoroutine(result := seek(to)):
-            await result
+        result = seek(offset, whence)
+        if iscoroutine(result):
+            return await result
+        return result

--- a/packages/smithy-core/tests/unit/aio/test_utils.py
+++ b/packages/smithy-core/tests/unit/aio/test_utils.py
@@ -3,7 +3,7 @@
 from io import BytesIO
 
 from smithy_core.aio.types import AsyncBytesProvider
-from smithy_core.aio.utils import close
+from smithy_core.aio.utils import close, seek
 
 
 async def test_close_sync_closeable() -> None:
@@ -22,3 +22,53 @@ async def test_close_async_closeable() -> None:
 
 async def test_close_non_closeable() -> None:
     await close(b"foo")
+
+
+async def test_seek_sync_seekable() -> None:
+    stream = BytesIO(b"foo")
+    assert stream.seekable()
+    assert stream.tell() == 0
+    stream.read()
+    assert stream.tell() == 3
+    assert await seek(stream, 0, 0) == 0
+    assert stream.tell() == 0
+
+
+class ThinAsyncSeekableWrapper:
+    def __init__(self, stream: BytesIO, seekable: bool = True) -> None:
+        self._stream = stream
+        self._seekable = seekable
+
+    async def read(self, n: int = -1, /) -> bytes:
+        return self._stream.read(n)
+
+    async def seek(self, offset: int, whence: int = 0, /):
+        return self._stream.seek(offset, whence)
+
+    def seekable(self) -> bool:
+        return self._seekable
+
+    def tell(self) -> int:
+        return self._stream.tell()
+
+
+async def test_seek_async_seekable() -> None:
+    source = BytesIO(b"foo")
+    stream = ThinAsyncSeekableWrapper(source)
+    assert stream.seekable()
+    assert stream.tell() == 0
+    await stream.read()
+    assert stream.tell() == 3
+    assert await seek(stream, 0, 0) == 0
+    assert stream.tell() == 0
+
+
+async def test_seek_respects_seekable_function() -> None:
+    source = BytesIO(b"foo")
+    stream = ThinAsyncSeekableWrapper(source, seekable=False)
+    assert not stream.seekable()
+    assert source.tell() == 0
+    await stream.read()
+    assert source.tell() == 3
+    assert await seek(stream, 0, 0) is None
+    assert source.tell() == 3

--- a/packages/smithy-http/src/smithy_http/serializers.py
+++ b/packages/smithy-http/src/smithy_http/serializers.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import quote as urlquote
 
 from smithy_core import URI
+from smithy_core.aio.types import AsyncBytesReader
 from smithy_core.codecs import Codec
 from smithy_core.exceptions import SerializationError
 from smithy_core.schemas import Schema
@@ -32,7 +33,6 @@ from smithy_core.traits import (
     TimestampFormatTrait,
 )
 from smithy_core.types import PathPattern, TimestampFormat
-from smithy_core.aio.types import AsyncBytesReader
 from smithy_core.utils import serialize_float
 
 from . import Field, tuples_to_fields

--- a/packages/smithy-http/src/smithy_http/serializers.py
+++ b/packages/smithy-http/src/smithy_http/serializers.py
@@ -32,6 +32,7 @@ from smithy_core.traits import (
     TimestampFormatTrait,
 )
 from smithy_core.types import PathPattern, TimestampFormat
+from smithy_core.aio.types import AsyncBytesReader
 from smithy_core.utils import serialize_float
 
 from . import Field, tuples_to_fields
@@ -188,7 +189,7 @@ class HTTPRequestSerializer(SpecificShapeSerializer):
                 ),
             ),
             fields=fields,
-            body=payload,
+            body=AsyncBytesReader(payload),
         )
 
 
@@ -363,7 +364,7 @@ class HTTPResponseSerializer(SpecificShapeSerializer):
 
         self.result = _HTTPResponse(
             fields=tuples_to_fields(binding_serializer.header_serializer.headers),
-            body=payload,
+            body=AsyncBytesReader(payload),
             status=status,
         )
 


### PR DESCRIPTION
This wraps http bodies in an async readable. It modifies `AsyncBytesReader` to be seekable if the underlying stream is and uses that. The `SeekableAsyncBytesReader` isn't used because it buffers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
