### PR TITLE
Clear env before running env resolver tests

### DIFF
--- a/packages/smithy-aws-core/tests/unit/identity/test_environment_credentials_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/identity/test_environment_credentials_resolver.py
@@ -6,6 +6,14 @@ from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 from smithy_core.exceptions import SmithyIdentityError
 
 
+@pytest.fixture(autouse=True)
+def clear_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AWS_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+
+
 async def test_no_values_set():
     with pytest.raises(SmithyIdentityError):
         await EnvironmentCredentialsResolver().get_identity(properties={})


### PR DESCRIPTION
This updates the env credential resolver tests to clear the targeted variables before any tests are run so that if they happen to be set already they don't affect the tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
