### PR TITLE
Check unknown error content type before read

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/protocols.py
+++ b/packages/smithy-http/src/smithy_http/aio/protocols.py
@@ -183,7 +183,7 @@ class HttpBindingClientProtocol(HttpClientProtocol):
             operation=operation, response=response
         )
 
-        if error_id is None:
+        if error_id is None and self._matches_content_type(response):
             if isinstance(response_body, bytearray):
                 response_body = bytes(response_body)
             deserializer = self.payload_codec.create_deserializer(source=response_body)
@@ -227,3 +227,8 @@ class HttpBindingClientProtocol(HttpClientProtocol):
             is_throttling_error=is_throttle,
             is_retry_safe=is_throttle or None,
         )
+
+    def _matches_content_type(self, response: HTTPResponse) -> bool:
+        if "content-type" not in response.fields:
+            return False
+        return response.fields["content-type"].as_string() == self.content_type


### PR DESCRIPTION
This updates the error deserializer to check that the content type of a response matches the protocol's content type before it tries searching the payload for a shape id.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
