### PR TITLE
Fix path and query serialization

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/protocols.py
+++ b/packages/smithy-http/src/smithy_http/aio/protocols.py
@@ -46,8 +46,11 @@ class HttpClientProtocol(ClientProtocol[HTTPRequest, HTTPResponse]):
         if uri.path is not None and previous.path is not None:
             path = os.path.join(uri.path, previous.path.lstrip("/"))
 
+        if path is not None and not path.startswith("/"):
+            path = "/" + path
+
         query = previous.query or uri.query
-        if uri.query is not None and previous.query is not None:
+        if uri.query and previous.query:
             query = f"{uri.query}&{previous.query}"
 
         request.destination = _URI(


### PR DESCRIPTION
This updates query serialization to no longer add an extraneous `&` as well as ensures that the path starts with `/`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
