### PR TITLE
Create event publishers receivers for restJson1

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
@@ -1,18 +1,58 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Final
+from collections.abc import Callable
+from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING, Any, Final
 
+from smithy_core.aio.interfaces import AsyncWriter
+from smithy_core.aio.interfaces.auth import AuthScheme
+from smithy_core.aio.interfaces.eventstream import EventPublisher, EventReceiver
+from smithy_core.aio.types import AsyncBytesReader
 from smithy_core.codecs import Codec
-from smithy_core.exceptions import DiscriminatorError
+from smithy_core.deserializers import DeserializeableShape, ShapeDeserializer
+from smithy_core.exceptions import (
+    DiscriminatorError,
+    MissingDependencyError,
+    UnsupportedStreamError,
+)
+from smithy_core.interfaces import TypedProperties
 from smithy_core.schemas import APIOperation, Schema
+from smithy_core.serializers import SerializeableShape
 from smithy_core.shapes import ShapeID, ShapeType
 from smithy_core.types import TimestampFormat
-from smithy_http.aio.interfaces import HTTPErrorIdentifier, HTTPResponse
+from smithy_http.aio.interfaces import HTTPErrorIdentifier, HTTPRequest, HTTPResponse
 from smithy_http.aio.protocols import HttpBindingClientProtocol
 from smithy_json import JSONCodec, JSONDocument
 
 from ..traits import RestJson1Trait
 from ..utils import parse_document_discriminator, parse_error_code
+
+try:
+    from smithy_aws_event_stream.aio import (
+        AWSEventPublisher,
+        AWSEventReceiver,
+        SigningConfig,
+    )
+
+    _HAS_EVENT_STREAM = True
+except ImportError:
+    _HAS_EVENT_STREAM = False  # type: ignore
+
+if TYPE_CHECKING:
+    from smithy_aws_event_stream.aio import (
+        AWSEventPublisher,
+        AWSEventReceiver,
+        SigningConfig,
+    )
+    from typing_extensions import TypeForm
+
+
+def _assert_event_stream_capable() -> None:
+    if not _HAS_EVENT_STREAM:
+        raise MissingDependencyError(
+            "Attempted to use event streams, but smithy-aws-event-stream "
+            "is not installed."
+        )
 
 
 class AWSErrorIdentifier(HTTPErrorIdentifier):
@@ -80,3 +120,67 @@ class RestJsonClientProtocol(HttpBindingClientProtocol):
     @property
     def error_identifier(self) -> HTTPErrorIdentifier:
         return self._error_identifier
+
+    def create_event_publisher[
+        OperationInput: SerializeableShape,
+        OperationOutput: DeserializeableShape,
+        Event: SerializeableShape,
+    ](
+        self,
+        *,
+        operation: "APIOperation[OperationInput, OperationOutput]",
+        request: HTTPRequest,
+        event_type: "TypeForm[Event]",
+        context: TypedProperties,
+        auth_scheme: AuthScheme[Any, Any, Any, Any] | None = None,
+    ) -> EventPublisher[Event]:
+        _assert_event_stream_capable()
+        signing_config: SigningConfig | None = None
+        if auth_scheme is not None:
+            event_signer = auth_scheme.event_signer(request=request)
+            if event_signer is not None:
+                signing_config = SigningConfig(
+                    signer=event_signer,
+                    signing_properties=auth_scheme.signer_properties(context=context),
+                    identity_resolver=auth_scheme.identity_resolver(context=context),
+                    identity_properties=auth_scheme.identity_properties(
+                        context=context
+                    ),
+                )
+
+        # The HTTP body must be an async writeable. The HTTP client bindings are
+        # responsible for ensuring this is the case. The CRT bindings, for example,
+        # will set the body to an instance of BufferableByteStream.
+        body = request.body
+        if not isinstance(body, AsyncWriter) or not iscoroutinefunction(body.write):
+            raise UnsupportedStreamError(
+                "Input streams require an async write function, but none was present "
+                "on the serialized HTTP request."
+            )
+
+        return AWSEventPublisher[Event](
+            payload_codec=self.payload_codec,
+            async_writer=body,
+            signing_config=signing_config,
+        )
+
+    def create_event_receiver[
+        OperationInput: SerializeableShape,
+        OperationOutput: DeserializeableShape,
+        Event: DeserializeableShape,
+    ](
+        self,
+        *,
+        operation: "APIOperation[OperationInput, OperationOutput]",
+        request: HTTPRequest,
+        response: HTTPResponse,
+        event_type: "TypeForm[Event]",
+        event_deserializer: Callable[[ShapeDeserializer], Event],
+        context: TypedProperties,
+    ) -> EventReceiver[Event]:
+        _assert_event_stream_capable()
+        return AWSEventReceiver(
+            payload_codec=self.payload_codec,
+            source=AsyncBytesReader(response.body),
+            deserializer=event_deserializer,
+        )

--- a/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
@@ -148,9 +148,8 @@ class RestJsonClientProtocol(HttpBindingClientProtocol):
                     ),
                 )
 
-        # The HTTP body must be an async writeable. The HTTP client bindings are
-        # responsible for ensuring this is the case. The CRT bindings, for example,
-        # will set the body to an instance of BufferableByteStream.
+        # The HTTP body must be an async writeable. The HTTP serializers are responsible
+        # for ensuring this.
         body = request.body
         if not isinstance(body, AsyncWriter) or not iscoroutinefunction(body.write):
             raise UnsupportedStreamError(

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
@@ -67,7 +67,7 @@ class AWSEventPublisher[E: SerializeableShape](EventPublisher[E]):
                 properties=self._signing_config.identity_properties
             )
             result = await self._signing_config.signer.sign(
-                event=event,
+                event=result,
                 identity=identity,
                 properties=self._signing_config.signing_properties,
             )

--- a/packages/smithy-http/src/smithy_http/deserializers.py
+++ b/packages/smithy-http/src/smithy_http/deserializers.py
@@ -89,12 +89,13 @@ class HTTPResponseDeserializer(SpecificShapeDeserializer):
                         member, HTTPResponseCodeDeserializer(self._response.status)
                     )
                 case Binding.PAYLOAD:
-                    assert binding_matcher.payload_member is not None  # noqa: S101
-                    if self._should_read_payload(binding_matcher.payload_member):
-                        deserializer = self._create_payload_deserializer(
-                            binding_matcher.payload_member
-                        )
-                        consumer(binding_matcher.payload_member, deserializer)
+                    if binding_matcher.event_stream_member is None:
+                        assert binding_matcher.payload_member is not None  # noqa: S101
+                        if self._should_read_payload(binding_matcher.payload_member):
+                            deserializer = self._create_payload_deserializer(
+                                binding_matcher.payload_member
+                            )
+                            consumer(binding_matcher.payload_member, deserializer)
                 case _:
                     pass
 


### PR DESCRIPTION
This adds creating the publisher and receiver to the protocol implementation for restJson1. It also updates the http serializers to ensure that the http body is writeable in event stream operations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
