### PR TITLE
Refactor core identity components to prevent circular imports

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/__init__.py
@@ -1,52 +1,26 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Protocol, TypedDict
-
-from smithy_core.aio.interfaces.identity import IdentityResolver
-from smithy_core.interfaces.identity import Identity
 from smithy_core.types import PropertyKey
 
+from .components import (
+    AWSCredentialsIdentity,
+    AWSCredentialsResolver,
+    AWSIdentityConfig,
+    AWSIdentityProperties,
+)
+from .container import ContainerCredentialResolver
+from .environment import EnvironmentCredentialsResolver
+from .imds import IMDSCredentialsResolver
+from .static import StaticCredentialsResolver
 
-@dataclass(kw_only=True)
-class AWSCredentialsIdentity(Identity):
-    access_key_id: str
-    """A unique identifier for an AWS user or role."""
-
-    secret_access_key: str
-    """A secret key used in conjunction with the access key ID to authenticate
-    programmatic access to AWS services."""
-
-    session_token: str | None = None
-    """A temporary token used to specify the current session for the supplied
-    credentials."""
-
-    expiration: datetime | None = None
-    """The expiration time of the identity.
-
-    If time zone is provided, it is updated to UTC. The value must always be in UTC.
-    """
-
-    account_id: str | None = None
-    """The AWS account's ID."""
-
-
-class AWSIdentityProperties(TypedDict, total=False):
-    access_key_id: str | None
-    secret_access_key: str | None
-    session_token: str | None
-
-
-type AWSCredentialsResolver = IdentityResolver[
-    AWSCredentialsIdentity, AWSIdentityProperties
-]
-
-
-class AWSIdentityConfig(Protocol):
-    aws_access_key_id: str | None
-    aws_secret_access_key: str | None
-    aws_session_token: str | None = None
-
+__all__ = (
+    "AWSCredentialsIdentity",
+    "AWSCredentialsResolver",
+    "AWSIdentityProperties",
+    "ContainerCredentialResolver",
+    "EnvironmentCredentialsResolver",
+    "IMDSCredentialsResolver",
+    "StaticCredentialsResolver",
+)
 
 AWS_IDENTITY_CONFIG = PropertyKey(key="config", value_type=AWSIdentityConfig)

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/chain.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/chain.py
@@ -3,9 +3,11 @@
 from smithy_core.aio.identity import ChainedIdentityResolver
 from smithy_http.aio.interfaces import HTTPClient
 
-from smithy_aws_core.identity import AWSCredentialsIdentity
-
-from . import AWSCredentialsResolver, AWSIdentityProperties
+from .components import (
+    AWSCredentialsIdentity,
+    AWSCredentialsResolver,
+    AWSIdentityProperties,
+)
 from .environment import EnvironmentCredentialsResolver
 from .imds import IMDSCredentialsResolver
 from .static import StaticCredentialsResolver

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/components.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/components.py
@@ -1,0 +1,48 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol, TypedDict
+
+from smithy_core.aio.interfaces.identity import IdentityResolver
+from smithy_core.interfaces.identity import Identity
+
+
+@dataclass(kw_only=True)
+class AWSCredentialsIdentity(Identity):
+    access_key_id: str
+    """A unique identifier for an AWS user or role."""
+
+    secret_access_key: str
+    """A secret key used in conjunction with the access key ID to authenticate
+    programmatic access to AWS services."""
+
+    session_token: str | None = None
+    """A temporary token used to specify the current session for the supplied
+    credentials."""
+
+    expiration: datetime | None = None
+    """The expiration time of the identity.
+
+    If time zone is provided, it is updated to UTC. The value must always be in UTC.
+    """
+
+    account_id: str | None = None
+    """The AWS account's ID."""
+
+
+class AWSIdentityProperties(TypedDict, total=False):
+    access_key_id: str | None
+    secret_access_key: str | None
+    session_token: str | None
+
+
+type AWSCredentialsResolver = IdentityResolver[
+    AWSCredentialsIdentity, AWSIdentityProperties
+]
+
+
+class AWSIdentityConfig(Protocol):
+    aws_access_key_id: str | None
+    aws_secret_access_key: str | None
+    aws_session_token: str | None = None

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/container.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/container.py
@@ -15,7 +15,10 @@ from smithy_http import Field, Fields
 from smithy_http.aio import HTTPRequest
 from smithy_http.aio.interfaces import HTTPClient, HTTPResponse
 
-from smithy_aws_core.identity import AWSCredentialsIdentity, AWSIdentityProperties
+from smithy_aws_core.identity.components import (
+    AWSCredentialsIdentity,
+    AWSIdentityProperties,
+)
 
 _CONTAINER_METADATA_IP = "169.254.170.2"
 _CONTAINER_METADATA_ALLOWED_HOSTS = {

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/environment.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/environment.py
@@ -5,7 +5,7 @@ import os
 from smithy_core.aio.interfaces.identity import IdentityResolver
 from smithy_core.exceptions import SmithyIdentityError
 
-from . import AWSCredentialsIdentity, AWSIdentityProperties
+from .components import AWSCredentialsIdentity, AWSIdentityProperties
 
 
 class EnvironmentCredentialsResolver(

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/imds.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/imds.py
@@ -17,7 +17,7 @@ from smithy_http.aio import HTTPRequest
 from smithy_http.aio.interfaces import HTTPClient
 
 from .. import __version__
-from ..identity import AWSCredentialsIdentity, AWSIdentityProperties
+from .components import AWSCredentialsIdentity, AWSIdentityProperties
 
 _USER_AGENT_FIELD = Field(
     name="User-Agent",

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/static.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/static.py
@@ -3,7 +3,7 @@
 from smithy_core.aio.interfaces.identity import IdentityResolver
 from smithy_core.exceptions import SmithyIdentityError
 
-from smithy_aws_core.identity import AWSCredentialsIdentity, AWSIdentityProperties
+from .components import AWSCredentialsIdentity, AWSIdentityProperties
 
 
 class StaticCredentialsResolver(


### PR DESCRIPTION
*Description of changes:*
Follow up to #515 to attempt to resurface top-level `__all__` components for identity module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
