### PR TITLE
Use Hatch Dynamic Versions

### DIFF
--- a/packages/aws-sdk-signers/pyproject.toml
+++ b/packages/aws-sdk-signers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aws-sdk-signers"
-version = "0.0.3"
+dynamic = ["version"]
 requires-python = ">=3.12"
 authors = [
   {name = "Amazon Web Services"},
@@ -34,6 +34,9 @@ classifiers = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/aws_sdk_signers/__init__.py"
 
 [tool.hatch.build]
 exclude = [

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
@@ -5,8 +5,6 @@ such as AioHTTP, Curl, Postman, Requests, urllib3, etc."""
 
 from __future__ import annotations
 
-import importlib.metadata
-
 from ._http import AWSRequest, Field, Fields, URI
 from ._identity import AWSCredentialIdentity
 from ._io import AsyncBytesReader
@@ -18,7 +16,7 @@ from .signers import (
 )
 
 __license__ = "Apache-2.0"
-__version__ = importlib.metadata.version("aws-sdk-signers")
+__version__ = "0.0.3"
 
 __all__ = (
     "URI",

--- a/packages/smithy-aws-core/pyproject.toml
+++ b/packages/smithy-aws-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smithy-aws-core"
-version = "0.0.1"
+dynamic = ["version"]
 requires-python = ">=3.12"
 authors = [
   {name = "Amazon Web Services"},
@@ -39,6 +39,9 @@ dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/smithy_aws_core/__init__.py"
 
 [project.optional-dependencies]
 eventstream = [

--- a/packages/smithy-aws-core/src/smithy_aws_core/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/__init__.py
@@ -1,6 +1,4 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-import importlib.metadata
-
-__version__: str = importlib.metadata.version("smithy-aws-core")
+__version__ = "0.0.3"

--- a/packages/smithy-aws-event-stream/pyproject.toml
+++ b/packages/smithy-aws-event-stream/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smithy-aws-event-stream"
-version = "0.0.1"
+dynamic = ["version"]
 requires-python = ">=3.12"
 authors = [
   {name = "Amazon Web Services"},
@@ -37,6 +37,9 @@ dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/smithy_aws_event_stream/__init__.py"
 
 [tool.hatch.build]
 exclude = [

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/__init__.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/__init__.py
@@ -1,6 +1,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib.metadata
-
-__version__: str = importlib.metadata.version("smithy-aws-event-stream")
+__version__ = "0.0.1"

--- a/packages/smithy-core/pyproject.toml
+++ b/packages/smithy-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smithy-core"
-version = "0.0.2"
+dynamic = ["version"]
 requires-python = ">=3.12"
 authors = [
   {name = "Amazon Web Services"},
@@ -40,6 +40,9 @@ typing = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/smithy_core/__init__.py"
 
 [tool.hatch.build]
 exclude = [

--- a/packages/smithy-core/src/smithy_core/__init__.py
+++ b/packages/smithy-core/src/smithy_core/__init__.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import importlib.metadata
 from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property

--- a/packages/smithy-core/src/smithy_core/__init__.py
+++ b/packages/smithy-core/src/smithy_core/__init__.py
@@ -9,7 +9,7 @@ from urllib.parse import urlunparse
 from . import interfaces, rfc3986
 from .exceptions import SmithyError
 
-__version__: str = importlib.metadata.version("smithy-core")
+__version__ = "0.0.2"
 
 
 class HostType(Enum):

--- a/packages/smithy-http/pyproject.toml
+++ b/packages/smithy-http/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smithy-http"
-version = "0.0.1"
+dynamic = ["version"]
 requires-python = ">=3.12"
 authors = [
   {name = "Amazon Web Services"},
@@ -46,6 +46,9 @@ aiohttp = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/smithy_http/__init__.py"
 
 [tool.hatch.build]
 exclude = [

--- a/packages/smithy-http/src/smithy_http/__init__.py
+++ b/packages/smithy-http/src/smithy_http/__init__.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import importlib.metadata
 from collections import Counter, OrderedDict
 from collections.abc import Iterable, Iterator
 

--- a/packages/smithy-http/src/smithy_http/__init__.py
+++ b/packages/smithy-http/src/smithy_http/__init__.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable, Iterator
 from . import interfaces
 from .interfaces import FieldPosition
 
-__version__: str = importlib.metadata.version("smithy-http")
+__version__ = "0.0.1"
 
 
 class Field(interfaces.Field):

--- a/packages/smithy-json/pyproject.toml
+++ b/packages/smithy-json/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smithy-json"
-version = "0.0.1"
+dynamic = ["version"]
 requires-python = ">=3.12"
 authors = [
   {name = "Amazon Web Services"},
@@ -38,6 +38,9 @@ dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/smithy_json/__init__.py"
 
 [tool.hatch.build]
 exclude = [

--- a/packages/smithy-json/src/smithy_json/__init__.py
+++ b/packages/smithy-json/src/smithy_json/__init__.py
@@ -14,7 +14,7 @@ from ._private.documents import JSONDocument
 from ._private.serializers import JSONShapeSerializer as _JSONShapeSerializer
 from .settings import JSONSettings
 
-__version__: str = importlib.metadata.version("smithy-json")
+__version__ = "0.0.1"
 __all__ = ("JSONCodec", "JSONDocument", "JSONSettings")
 
 

--- a/packages/smithy-json/src/smithy_json/__init__.py
+++ b/packages/smithy-json/src/smithy_json/__init__.py
@@ -1,6 +1,5 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-import importlib.metadata
 from io import BytesIO
 
 from smithy_core.codecs import Codec

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [manifest]
@@ -94,7 +94,6 @@ wheels = [
 
 [[package]]
 name = "aws-sdk-signers"
-version = "0.0.3"
 source = { editable = "packages/aws-sdk-signers" }
 
 [[package]]
@@ -632,7 +631,6 @@ wheels = [
 
 [[package]]
 name = "smithy-aws-core"
-version = "0.0.1"
 source = { editable = "packages/smithy-aws-core" }
 dependencies = [
     { name = "aws-sdk-signers" },
@@ -656,7 +654,6 @@ provides-extras = ["eventstream"]
 
 [[package]]
 name = "smithy-aws-event-stream"
-version = "0.0.1"
 source = { editable = "packages/smithy-aws-event-stream" }
 dependencies = [
     { name = "smithy-core" },
@@ -667,7 +664,6 @@ requires-dist = [{ name = "smithy-core", editable = "packages/smithy-core" }]
 
 [[package]]
 name = "smithy-core"
-version = "0.0.2"
 source = { editable = "packages/smithy-core" }
 
 [package.dev-dependencies]
@@ -682,7 +678,6 @@ typing = [{ name = "typing-extensions", specifier = ">=4.13.0" }]
 
 [[package]]
 name = "smithy-http"
-version = "0.0.1"
 source = { editable = "packages/smithy-http" }
 dependencies = [
     { name = "smithy-core" },
@@ -704,11 +699,10 @@ requires-dist = [
     { name = "smithy-core", editable = "packages/smithy-core" },
     { name = "yarl", marker = "extra == 'aiohttp'" },
 ]
-provides-extras = ["awscrt", "aiohttp"]
+provides-extras = ["aiohttp", "awscrt"]
 
 [[package]]
 name = "smithy-json"
-version = "0.0.1"
 source = { editable = "packages/smithy-json" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This PR adds the following:
- Moves the static package version to `__init__.py` to prevent incorrect versions when the package is installed and attempting to get the version of the local package.
- Updates the version of `smithy-aws-core` from 0.0.1 to 0.0.3

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
