### PR TITLE
Use ShapeID instead of string literal

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
@@ -100,12 +100,13 @@ public class AwsAuthIntegration implements PythonIntegration {
             writer.addDependency(SmithyPythonDependency.SMITHY_HTTP);
             writer.addImport("smithy_core.interfaces.auth", "AuthOption", "AuthOptionProtocol");
             writer.addImports("smithy_core.auth", Set.of("AuthOption", "AuthParams"));
+            writer.addImport("smithy_core.shapes", "ShapeID");
             writer.pushState();
 
             writer.write("""
                     def $1L(auth_params: AuthParams[Any, Any]) -> AuthOptionProtocol | None:
                         return AuthOption(
-                            scheme_id=$2S,
+                            scheme_id=ShapeID($2S),
                             identity_properties={},  # type: ignore
                             signer_properties={}  # type: ignore
                         )


### PR DESCRIPTION
Fixes the following type checking errors when trying to build the `aws_sdk_bedrock_runtime` client:

```
Projection client failed: software.amazon.smithy.codegen.core.CodegenException: Command `python3 -m pyright .` failed with output:

/Users/gytndd/dev/new-bedrock/build/smithy/client/python-client-codegen/src/aws_sdk_bedrock_runtime/auth.py
  /Users/gytndd/dev/new-bedrock/build/smithy/client/python-client-codegen/src/aws_sdk_bedrock_runtime/auth.py:25:19 - error: Argument of type "Literal['aws.auth#sigv4']" cannot be assigned to parameter "scheme_id" of type "ShapeID" in function "__init__"
    "Literal['aws.auth#sigv4']" is not assignable to "ShapeID" (reportArgumentType)
1 error, 0 warnings, 0 informations 
WARNING: there is a new pyright version available (v1.1.400 -> v1.1.403).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
