### PR TITLE
Add standard retry mode

### DIFF
--- a/packages/smithy-core/.changes/next-release/smithy-core-breaking-20251106184528.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-breaking-20251106184528.json
@@ -1,0 +1,4 @@
+{
+  "type": "breaking",
+  "description": "Added standard retry mode as the default retry strategy for AWS clients."
+}

--- a/packages/smithy-core/.changes/next-release/smithy-core-breaking-20251106184528.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-breaking-20251106184528.json
@@ -1,4 +1,4 @@
 {
-  "type": "breaking",
-  "description": "Added standard retry mode as the default retry strategy for AWS clients."
+  "type": "feature",
+  "description": "Added support for `standard` retry mode."
 }

--- a/packages/smithy-core/src/smithy_core/aio/client.py
+++ b/packages/smithy-core/src/smithy_core/aio/client.py
@@ -330,7 +330,7 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
             return await self._handle_attempt(call, request_context, request_future)
 
         retry_strategy = call.retry_strategy
-        retry_token = retry_strategy.acquire_initial_retry_token(
+        retry_token = await retry_strategy.acquire_initial_retry_token(
             token_scope=call.retry_scope
         )
 
@@ -349,7 +349,7 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
 
             if isinstance(output_context.response, Exception):
                 try:
-                    retry_strategy.refresh_retry_token_for_retry(
+                    retry_token = await retry_strategy.refresh_retry_token_for_retry(
                         token_to_renew=retry_token,
                         error=output_context.response,
                     )
@@ -364,7 +364,7 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
 
                 await seek(request_context.transport_request.body, 0)
             else:
-                retry_strategy.record_success(token=retry_token)
+                await retry_strategy.record_success(token=retry_token)
                 return output_context
 
     async def _handle_attempt[I: SerializeableShape, O: DeserializeableShape](

--- a/packages/smithy-core/src/smithy_core/aio/client.py
+++ b/packages/smithy-core/src/smithy_core/aio/client.py
@@ -330,7 +330,7 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
             return await self._handle_attempt(call, request_context, request_future)
 
         retry_strategy = call.retry_strategy
-        retry_token = await retry_strategy.acquire_initial_retry_token(
+        retry_token = retry_strategy.acquire_initial_retry_token(
             token_scope=call.retry_scope
         )
 
@@ -349,7 +349,7 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
 
             if isinstance(output_context.response, Exception):
                 try:
-                    retry_token = await retry_strategy.refresh_retry_token_for_retry(
+                    retry_token = retry_strategy.refresh_retry_token_for_retry(
                         token_to_renew=retry_token,
                         error=output_context.response,
                     )
@@ -364,7 +364,7 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
 
                 await seek(request_context.transport_request.body, 0)
             else:
-                await retry_strategy.record_success(token=retry_token)
+                retry_strategy.record_success(token=retry_token)
                 return output_context
 
     async def _handle_attempt[I: SerializeableShape, O: DeserializeableShape](

--- a/packages/smithy-core/src/smithy_core/interfaces/retries.py
+++ b/packages/smithy-core/src/smithy_core/interfaces/retries.py
@@ -61,7 +61,7 @@ class RetryStrategy(Protocol):
     max_attempts: int
     """Upper limit on total attempt count (initial attempt plus retries)."""
 
-    async def acquire_initial_retry_token(
+    def acquire_initial_retry_token(
         self, *, token_scope: str | None = None
     ) -> RetryToken:
         """Create a base retry token for the start of a request.
@@ -74,7 +74,7 @@ class RetryStrategy(Protocol):
         """
         ...
 
-    async def refresh_retry_token_for_retry(
+    def refresh_retry_token_for_retry(
         self, *, token_to_renew: RetryToken, error: Exception
     ) -> RetryToken:
         """Replace an existing retry token from a failed attempt with a new token.
@@ -91,7 +91,7 @@ class RetryStrategy(Protocol):
         """
         ...
 
-    async def record_success(self, *, token: RetryToken) -> None:
+    def record_success(self, *, token: RetryToken) -> None:
         """Return token after successful completion of an operation.
 
         Upon successful completion of the operation, a user calls this function to

--- a/packages/smithy-core/src/smithy_core/interfaces/retries.py
+++ b/packages/smithy-core/src/smithy_core/interfaces/retries.py
@@ -64,7 +64,7 @@ class RetryStrategy(Protocol):
     async def acquire_initial_retry_token(
         self, *, token_scope: str | None = None
     ) -> RetryToken:
-        """Called before any retries (for the first attempt at the operation).
+        """Create a base retry token for the start of a request.
 
         :param token_scope: An arbitrary string accepted by the retry strategy to
             separate tokens into scopes.

--- a/packages/smithy-core/src/smithy_core/interfaces/retries.py
+++ b/packages/smithy-core/src/smithy_core/interfaces/retries.py
@@ -61,7 +61,7 @@ class RetryStrategy(Protocol):
     max_attempts: int
     """Upper limit on total attempt count (initial attempt plus retries)."""
 
-    def acquire_initial_retry_token(
+    async def acquire_initial_retry_token(
         self, *, token_scope: str | None = None
     ) -> RetryToken:
         """Called before any retries (for the first attempt at the operation).
@@ -74,7 +74,7 @@ class RetryStrategy(Protocol):
         """
         ...
 
-    def refresh_retry_token_for_retry(
+    async def refresh_retry_token_for_retry(
         self, *, token_to_renew: RetryToken, error: Exception
     ) -> RetryToken:
         """Replace an existing retry token from a failed attempt with a new token.
@@ -91,7 +91,7 @@ class RetryStrategy(Protocol):
         """
         ...
 
-    def record_success(self, *, token: RetryToken) -> None:
+    async def record_success(self, *, token: RetryToken) -> None:
         """Return token after successful completion of an operation.
 
         Upon successful completion of the operation, a user calls this function to

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -408,16 +408,3 @@ class StandardRetryQuota:
     def available_capacity(self) -> int:
         """Return the amount of capacity available."""
         return self._available_capacity
-
-
-class RetryStrategyMode(Enum):
-    """Enumeration of available retry strategies."""
-
-    SIMPLE = "simple"
-    STANDARD = "standard"
-
-
-RETRY_MODE_MAP = {
-    RetryStrategyMode.SIMPLE: SimpleRetryStrategy,
-    RetryStrategyMode.STANDARD: StandardRetryStrategy,
-}

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -208,7 +208,7 @@ class SimpleRetryStrategy(retries_interface.RetryStrategy):
     async def acquire_initial_retry_token(
         self, *, token_scope: str | None = None
     ) -> SimpleRetryToken:
-        """Called before any retries (for the first attempt at the operation).
+        """Create a base retry token for the start of a request.
 
         :param token_scope: This argument is ignored by this retry strategy.
         """
@@ -284,7 +284,7 @@ class StandardRetryStrategy(retries_interface.RetryStrategy):
     async def acquire_initial_retry_token(
         self, *, token_scope: str | None = None
     ) -> StandardRetryToken:
-        """Called before any retries (for the first attempt at the operation).
+        """Create a base retry token for the start of a request.
 
         :param token_scope: This argument is ignored by this retry strategy.
         """
@@ -340,10 +340,7 @@ class StandardRetryStrategy(retries_interface.RetryStrategy):
             raise RetryError(f"Error is not retryable: {error}") from error
 
     async def record_success(self, *, token: retries_interface.RetryToken) -> None:
-        """Return token after successful completion of an operation.
-
-        Releases retry tokens back to the retry quota based on the previous amount
-        consumed.
+        """Release retry quota back based on the amount consumed by the last retry.
 
         :param token: The token used for the previous successful attempt.
         """

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -370,7 +370,7 @@ class StandardRetryQuota:
     async def acquire(self, *, error: Exception) -> int:
         """Attempt to acquire a certain amount of capacity.
 
-        If there's no sufficient amount of capacity available, raise an exception.
+        If there's insufficient capacity available, raise an exception.
         Otherwise, we return the amount of capacity successfully allocated.
         """
         # TODO: update `is_timeout` when `is_timeout_error` is implemented

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -261,19 +261,27 @@ class StandardRetryToken:
 
 
 class StandardRetryStrategy(retries_interface.RetryStrategy):
-    def __init__(self, *, max_attempts: int = 3):
+    def __init__(
+        self,
+        *,
+        backoff_strategy: retries_interface.RetryBackoffStrategy | None = None,
+        max_attempts: int = 3,
+    ):
         """Standard retry strategy using truncated binary exponential backoff with full
         jitter.
+
+        :param backoff_strategy: The backoff strategy used by returned tokens to compute
+        the retry delay. Defaults to :py:class:`ExponentialRetryBackoffStrategy`.
 
         :param max_attempts: Upper limit on total number of attempts made, including
             initial attempt and retries.
         """
-        if max_attempts < 1:
+        if max_attempts < 0:
             raise ValueError(
-                f"max_attempts must be a positive integer, got {max_attempts}"
+                f"max_attempts must be a non-negative integer, got {max_attempts}"
             )
 
-        self.backoff_strategy = ExponentialRetryBackoffStrategy(
+        self.backoff_strategy = backoff_strategy or ExponentialRetryBackoffStrategy(
             backoff_scale_value=1,
             max_backoff=20,
             jitter_type=ExponentialBackoffJitterType.FULL,

--- a/packages/smithy-core/tests/unit/test_retries.py
+++ b/packages/smithy-core/tests/unit/test_retries.py
@@ -4,7 +4,12 @@
 import pytest
 from smithy_core.exceptions import CallError, RetryError
 from smithy_core.retries import ExponentialBackoffJitterType as EBJT
-from smithy_core.retries import ExponentialRetryBackoffStrategy, SimpleRetryStrategy
+from smithy_core.retries import (
+    ExponentialRetryBackoffStrategy,
+    SimpleRetryStrategy,
+    StandardRetryQuota,
+    StandardRetryStrategy,
+)
 
 
 @pytest.mark.parametrize(
@@ -54,49 +59,229 @@ def test_exponential_backoff_strategy(
         assert delay_actual == pytest.approx(delay_expected)  # type: ignore
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("max_attempts", [2, 3, 10])
-def test_simple_retry_strategy(max_attempts: int) -> None:
+async def test_simple_retry_strategy(max_attempts: int) -> None:
     strategy = SimpleRetryStrategy(
         backoff_strategy=ExponentialRetryBackoffStrategy(backoff_scale_value=5),
         max_attempts=max_attempts,
     )
     error = CallError(is_retry_safe=True)
-    token = strategy.acquire_initial_retry_token()
+    token = await strategy.acquire_initial_retry_token()
     for _ in range(max_attempts - 1):
-        token = strategy.refresh_retry_token_for_retry(
+        token = await strategy.refresh_retry_token_for_retry(
             token_to_renew=token, error=error
         )
     with pytest.raises(RetryError):
-        strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
+        await strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
 
 
-def test_simple_retry_does_not_retry_unclassified() -> None:
+@pytest.mark.asyncio
+async def test_simple_retry_does_not_retry_unclassified() -> None:
     strategy = SimpleRetryStrategy(
         backoff_strategy=ExponentialRetryBackoffStrategy(backoff_scale_value=5),
         max_attempts=2,
     )
-    token = strategy.acquire_initial_retry_token()
+    token = await strategy.acquire_initial_retry_token()
     with pytest.raises(RetryError):
-        strategy.refresh_retry_token_for_retry(token_to_renew=token, error=Exception())
+        await strategy.refresh_retry_token_for_retry(
+            token_to_renew=token, error=Exception()
+        )
 
 
-def test_simple_retry_does_not_retry_when_safety_unknown() -> None:
+@pytest.mark.asyncio
+async def test_simple_retry_does_not_retry_when_safety_unknown() -> None:
     strategy = SimpleRetryStrategy(
         backoff_strategy=ExponentialRetryBackoffStrategy(backoff_scale_value=5),
         max_attempts=2,
     )
     error = CallError(is_retry_safe=None)
-    token = strategy.acquire_initial_retry_token()
+    token = await strategy.acquire_initial_retry_token()
     with pytest.raises(RetryError):
-        strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
+        await strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
 
 
-def test_simple_retry_does_not_retry_unsafe() -> None:
+@pytest.mark.asyncio
+async def test_simple_retry_does_not_retry_unsafe() -> None:
     strategy = SimpleRetryStrategy(
         backoff_strategy=ExponentialRetryBackoffStrategy(backoff_scale_value=5),
         max_attempts=2,
     )
     error = CallError(fault="client", is_retry_safe=False)
-    token = strategy.acquire_initial_retry_token()
+    token = await strategy.acquire_initial_retry_token()
     with pytest.raises(RetryError):
-        strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
+        await strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("max_attempts", [2, 3, 10])
+async def test_standard_retry_strategy(max_attempts: int) -> None:
+    strategy = StandardRetryStrategy(max_attempts=max_attempts)
+    error = CallError(is_retry_safe=True)
+    token = await strategy.acquire_initial_retry_token()
+    for _ in range(max_attempts - 1):
+        token = await strategy.refresh_retry_token_for_retry(
+            token_to_renew=token, error=error
+        )
+    with pytest.raises(RetryError):
+        await strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
+
+
+@pytest.mark.asyncio
+async def test_standard_retry_does_not_retry_unclassified() -> None:
+    strategy = StandardRetryStrategy()
+    token = await strategy.acquire_initial_retry_token()
+    with pytest.raises(RetryError):
+        await strategy.refresh_retry_token_for_retry(
+            token_to_renew=token, error=Exception()
+        )
+
+
+@pytest.mark.asyncio
+async def test_standard_retry_does_not_retry_when_safety_unknown() -> None:
+    strategy = StandardRetryStrategy()
+    error = CallError(is_retry_safe=None)
+    token = await strategy.acquire_initial_retry_token()
+    with pytest.raises(RetryError):
+        await strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
+
+
+@pytest.mark.asyncio
+async def test_standard_retry_does_not_retry_unsafe() -> None:
+    strategy = StandardRetryStrategy()
+    error = CallError(fault="client", is_retry_safe=False)
+    token = await strategy.acquire_initial_retry_token()
+    with pytest.raises(RetryError):
+        await strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
+
+
+@pytest.mark.asyncio
+async def test_standard_retry_strategy_respects_max_attempts() -> None:
+    strategy = StandardRetryStrategy()
+    error = CallError(is_retry_safe=True)
+    token = await strategy.acquire_initial_retry_token()
+    token = await strategy.refresh_retry_token_for_retry(
+        token_to_renew=token, error=error
+    )
+    token = await strategy.refresh_retry_token_for_retry(
+        token_to_renew=token, error=error
+    )
+    with pytest.raises(RetryError):
+        await strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
+
+
+@pytest.mark.asyncio
+async def test_retry_after_overrides_backoff() -> None:
+    strategy = StandardRetryStrategy()
+    error = CallError(is_retry_safe=True, retry_after=5)
+    token = await strategy.acquire_initial_retry_token()
+    token = await strategy.refresh_retry_token_for_retry(
+        token_to_renew=token, error=error
+    )
+    assert token.retry_delay == 5
+
+
+@pytest.mark.asyncio
+async def test_retry_quota_acquire_when_exhausted(monkeypatch) -> None:
+    monkeypatch.setattr(StandardRetryQuota, "INITIAL_RETRY_TOKENS", 5, raising=False)
+    monkeypatch.setattr(StandardRetryQuota, "RETRY_COST", 2, raising=False)
+
+    quota = StandardRetryQuota()
+    assert quota._available_capacity == 5
+
+    # First acquire: 5 -> 3
+    assert await quota.acquire(error=Exception()) == 2
+    assert quota._available_capacity == 3
+
+    # Second acquire: 3 -> 1
+    assert await quota.acquire(error=Exception()) == 2
+    assert quota._available_capacity == 1
+
+    # Third acquire needs 2 but only 1 remains -> should raise
+    with pytest.raises(RetryError):
+        await quota.acquire(error=Exception())
+    assert quota._available_capacity == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_quota_release_zero_adds_increment(monkeypatch) -> None:
+    monkeypatch.setattr(StandardRetryQuota, "INITIAL_RETRY_TOKENS", 5, raising=False)
+    monkeypatch.setattr(StandardRetryQuota, "RETRY_COST", 2, raising=False)
+    monkeypatch.setattr(StandardRetryQuota, "NO_RETRY_INCREMENT", 1, raising=False)
+
+    quota = StandardRetryQuota()
+    assert quota._available_capacity == 5
+
+    # First acquire: 5 -> 3
+    assert await quota.acquire(error=Exception()) == 2
+    assert quota._available_capacity == 3
+
+    # release 0 should add NO_RETRY_INCREMENT: 3 -> 4
+    await quota.release(release_amount=0)
+    assert quota._available_capacity == 4
+
+    # Next acquire should still work: 4 -> 2
+    assert await quota.acquire(error=Exception()) == 2
+    assert quota._available_capacity == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_quota_release_caps_at_max(monkeypatch) -> None:
+    monkeypatch.setattr(StandardRetryQuota, "INITIAL_RETRY_TOKENS", 10, raising=False)
+    monkeypatch.setattr(StandardRetryQuota, "RETRY_COST", 3, raising=False)
+
+    quota = StandardRetryQuota()
+    assert quota._available_capacity == 10
+
+    # Drain some capacity: 10 -> 7 -> 4
+    assert await quota.acquire(error=Exception()) == 3
+    assert quota._available_capacity == 7
+    assert await quota.acquire(error=Exception()) == 3
+    assert quota._available_capacity == 4
+
+    # Release more than needed: 4 + 8 = 12. Should cap at max = 10
+    await quota.release(release_amount=8)
+    assert quota._available_capacity == 10
+
+    # Another acquire should succeed from max: 10 -> 7
+    assert await quota.acquire(error=Exception()) == 3
+    assert quota._available_capacity == 7
+
+
+@pytest.mark.asyncio
+async def test_retry_quota_releases_last_acquired_amount(monkeypatch) -> None:
+    monkeypatch.setattr(StandardRetryQuota, "INITIAL_RETRY_TOKENS", 10, raising=False)
+    monkeypatch.setattr(StandardRetryQuota, "RETRY_COST", 5, raising=False)
+
+    strategy = StandardRetryStrategy()
+    err = CallError(is_retry_safe=True)
+    token = await strategy.acquire_initial_retry_token()
+
+    # Two retries: 10 -> 5 -> 0
+    token = await strategy.refresh_retry_token_for_retry(
+        token_to_renew=token, error=err
+    )
+    assert strategy._retry_quota._available_capacity == 5
+    token = await strategy.refresh_retry_token_for_retry(
+        token_to_renew=token, error=err
+    )
+    assert strategy._retry_quota._available_capacity == 0
+
+    # Success returns ONLY the last acquired amount -> 5
+    await strategy.record_success(token=token)
+    assert strategy._retry_quota._available_capacity == 5
+
+
+@pytest.mark.asyncio
+async def test_retry_quota_release_when_no_retry(monkeypatch) -> None:
+    monkeypatch.setattr(StandardRetryQuota, "INITIAL_RETRY_TOKENS", 10, raising=False)
+    quota = StandardRetryQuota()
+
+    await quota.acquire(error=Exception())
+    assert quota._available_capacity == 5
+    before = quota._available_capacity
+
+    await quota.release(release_amount=0)
+    # Should increment by NO_RETRY_INCREMENT = 1
+    assert quota._available_capacity == min(before + 1, quota._max_capacity)
+    assert quota._available_capacity == 6

--- a/packages/smithy-core/tests/unit/test_retries.py
+++ b/packages/smithy-core/tests/unit/test_retries.py
@@ -148,19 +148,6 @@ def test_standard_retry_after_overrides_backoff() -> None:
     assert token.retry_delay == 5.5
 
 
-def test_standard_retry_quota_consumed_accumulates() -> None:
-    strategy = StandardRetryStrategy()
-    error = CallError(is_retry_safe=True)
-    token = strategy.acquire_initial_retry_token()
-
-    token = strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
-    first_consumed = token.quota_consumed
-    assert first_consumed == StandardRetryQuota.RETRY_COST
-
-    token = strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
-    assert token.quota_consumed == first_consumed + StandardRetryQuota.RETRY_COST
-
-
 def test_standard_retry_invalid_max_attempts() -> None:
     with pytest.raises(ValueError):
         StandardRetryStrategy(max_attempts=-1)

--- a/packages/smithy-core/tests/unit/test_retries.py
+++ b/packages/smithy-core/tests/unit/test_retries.py
@@ -120,24 +120,21 @@ def test_standard_retry_strategy(max_attempts: int) -> None:
         strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
 
 
-def test_standard_retry_does_not_retry_unclassified() -> None:
+@pytest.mark.parametrize(
+    "error",
+    [
+        Exception(),
+        CallError(is_retry_safe=None),
+        CallError(fault="client", is_retry_safe=False),
+    ],
+    ids=[
+        "unclassified_error",
+        "safety_unknown_error",
+        "unsafe_error",
+    ],
+)
+def test_standard_retry_does_not_retry(error: Exception | CallError) -> None:
     strategy = StandardRetryStrategy()
-    token = strategy.acquire_initial_retry_token()
-    with pytest.raises(RetryError):
-        strategy.refresh_retry_token_for_retry(token_to_renew=token, error=Exception())
-
-
-def test_standard_retry_does_not_retry_when_safety_unknown() -> None:
-    strategy = StandardRetryStrategy()
-    error = CallError(is_retry_safe=None)
-    token = strategy.acquire_initial_retry_token()
-    with pytest.raises(RetryError):
-        strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)
-
-
-def test_standard_retry_does_not_retry_unsafe() -> None:
-    strategy = StandardRetryStrategy()
-    error = CallError(fault="client", is_retry_safe=False)
     token = strategy.acquire_initial_retry_token()
     with pytest.raises(RetryError):
         strategy.refresh_retry_token_for_retry(token_to_renew=token, error=error)


### PR DESCRIPTION
*Description of changes:*
Adds support for a new retry mode: `standard`.  This behavior is now consistent with other AWS SDKs implementing standard mode. This mode also adds support for retry quotas which control how many unsuccessful retries a client can make.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
