### PR TITLE
fix sytax errors with multiple auth types

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/OperationGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/OperationGenerator.java
@@ -93,7 +93,7 @@ public final class OperationGenerator implements Runnable {
         }
 
         for (var authSchemeId : authSchemes.keySet()) {
-            writer.write("ShapeID($S)", authSchemeId);
+            writer.write("ShapeID($S),", authSchemeId);
         }
 
     }


### PR DESCRIPTION
## Summary

This PR addresses a codegen bug that results in the following error when trying to generate a client that supports multiple auth schemes:

```
Projection client failed: software.amazon.smithy.codegen.core.CodegenException: Command `python3 -m ruff check --fix` failed with output:

src/aws_sdk_bedrock_runtime/models.py:648:1: SyntaxError: Expected ',', found name
    |
646 |         effective_auth_schemes = [
647 |             ShapeID("aws.auth#sigv4")
648 | ShapeID("smithy.api#httpBearerAuth")
    | ^
649 |         ]
650 | )
    |
```

**Problem:** Multiple `ShapeId` objects are getting added to the `effective_auth_schemes` list without a `,` delimiter, resulting in a `SyntaxError`. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
