### PR TITLE
Rename from ContainerCredentialResolver to ContainerCredentialsResolver

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/__init__.py
@@ -8,7 +8,7 @@ from .components import (
     AWSIdentityConfig,
     AWSIdentityProperties,
 )
-from .container import ContainerCredentialResolver
+from .container import ContainerCredentialsResolver
 from .environment import EnvironmentCredentialsResolver
 from .imds import IMDSCredentialsResolver
 from .static import StaticCredentialsResolver
@@ -17,7 +17,7 @@ __all__ = (
     "AWSCredentialsIdentity",
     "AWSCredentialsResolver",
     "AWSIdentityProperties",
-    "ContainerCredentialResolver",
+    "ContainerCredentialsResolver",
     "EnvironmentCredentialsResolver",
     "IMDSCredentialsResolver",
     "StaticCredentialsResolver",

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/container.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/container.py
@@ -33,7 +33,7 @@ _SLEEP_SECONDS = 1
 
 
 @dataclass
-class ContainerCredentialConfig:
+class ContainerCredentialsConfig:
     """Configuration for container credential retrieval operations."""
 
     timeout: int = _DEFAULT_TIMEOUT
@@ -43,7 +43,7 @@ class ContainerCredentialConfig:
 class ContainerMetadataClient:
     """Client for remote credential retrieval in Container environments like ECS/EKS."""
 
-    def __init__(self, http_client: HTTPClient, config: ContainerCredentialConfig):
+    def __init__(self, http_client: HTTPClient, config: ContainerCredentialsConfig):
         self._http_client = http_client
         self._config = config
 
@@ -103,7 +103,7 @@ class ContainerMetadataClient:
         return hostname in _CONTAINER_METADATA_ALLOWED_HOSTS
 
 
-class ContainerCredentialResolver(
+class ContainerCredentialsResolver(
     IdentityResolver[AWSCredentialsIdentity, AWSIdentityProperties]
 ):
     """Resolves AWS Credentials from container credential sources."""
@@ -116,10 +116,10 @@ class ContainerCredentialResolver(
     def __init__(
         self,
         http_client: HTTPClient,
-        config: ContainerCredentialConfig | None = None,
+        config: ContainerCredentialsConfig | None = None,
     ):
         self._http_client = http_client
-        self._config = config or ContainerCredentialConfig()
+        self._config = config or ContainerCredentialsConfig()
         self._client = ContainerMetadataClient(http_client, self._config)
         self._credentials = None
 

--- a/packages/smithy-aws-core/tests/unit/identity/test_container.py
+++ b/packages/smithy-aws-core/tests/unit/identity/test_container.py
@@ -11,8 +11,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from smithy_aws_core.identity import AWSCredentialsIdentity
 from smithy_aws_core.identity.container import (
-    ContainerCredentialConfig,
-    ContainerCredentialResolver,
+    ContainerCredentialsConfig,
+    ContainerCredentialsResolver,
     ContainerMetadataClient,
 )
 from smithy_core import URI
@@ -32,7 +32,7 @@ ISO8601 = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def test_config_custom_values():
-    config = ContainerCredentialConfig(timeout=10, retries=5)
+    config = ContainerCredentialsConfig(timeout=10, retries=5)
     assert config.timeout == 10
     assert config.retries == 5
 
@@ -62,7 +62,7 @@ def _assert_expected_credentials(
 async def test_metadata_client_valid_host(host: str):
     resp_body = json.dumps(DEFAULT_RESPONSE_DATA)
     http_client = mock_http_client_response(200, resp_body.encode("utf-8"))
-    config = ContainerCredentialConfig()
+    config = ContainerCredentialsConfig()
     client = ContainerMetadataClient(http_client, config)
 
     # Valid Host
@@ -76,7 +76,7 @@ async def test_metadata_client_valid_host(host: str):
 async def test_metadata_client_https_host():
     resp_body = json.dumps(DEFAULT_RESPONSE_DATA)
     http_client = mock_http_client_response(200, resp_body.encode("utf-8"))
-    config = ContainerCredentialConfig()
+    config = ContainerCredentialsConfig()
     client = ContainerMetadataClient(http_client, config)
 
     # Valid HTTPS Host
@@ -90,7 +90,7 @@ async def test_metadata_client_https_host():
 async def test_metadata_client_invalid_host():
     resp_body = json.dumps(DEFAULT_RESPONSE_DATA)
     http_client = mock_http_client_response(200, resp_body.encode("utf-8"))
-    config = ContainerCredentialConfig(retries=0)
+    config = ContainerCredentialsConfig(retries=0)
     client = ContainerMetadataClient(http_client, config)
 
     # Invalid Host
@@ -103,7 +103,7 @@ async def test_metadata_client_invalid_host():
 @pytest.mark.asyncio
 async def test_metadata_client_non_200_response():
     http_client = mock_http_client_response(404, b"not found")
-    config = ContainerCredentialConfig(retries=1)
+    config = ContainerCredentialsConfig(retries=1)
     client = ContainerMetadataClient(http_client, config)
 
     uri = URI(scheme="http", host="169.254.170.2")
@@ -120,7 +120,7 @@ async def test_metadata_client_invalid_json():
     http_client = mock_http_client_response(
         200, b"<!DOCTYPE html><head><title>proxy</title>"
     )
-    config = ContainerCredentialConfig(retries=1)
+    config = ContainerCredentialsConfig(retries=1)
     client = ContainerMetadataClient(http_client, config)
 
     uri = URI(scheme="http", host="169.254.170.2")
@@ -137,7 +137,7 @@ def _assert_expected_identity(identity: AWSCredentialsIdentity) -> None:
 @pytest.mark.asyncio
 async def test_metadata_client_retries():
     http_client = AsyncMock()
-    config = ContainerCredentialConfig(retries=2)
+    config = ContainerCredentialsConfig(retries=2)
     client = ContainerMetadataClient(http_client, config)
     uri = URI(scheme="http", host="169.254.170.2", path="/task")
     http_client.send.side_effect = Exception()
@@ -153,9 +153,9 @@ async def test_resolver_env_relative():
     http_client = mock_http_client_response(200, resp_body.encode("utf-8"))
 
     with patch.dict(
-        os.environ, {ContainerCredentialResolver.ENV_VAR: "/test"}, clear=True
+        os.environ, {ContainerCredentialsResolver.ENV_VAR: "/test"}, clear=True
     ):
-        resolver = ContainerCredentialResolver(http_client)
+        resolver = ContainerCredentialsResolver(http_client)
         identity = await resolver.get_identity(properties={})
 
     # Ensure we derive the correct destination
@@ -177,10 +177,10 @@ async def test_resolver_env_full():
 
     with patch.dict(
         os.environ,
-        {ContainerCredentialResolver.ENV_VAR_FULL: "http://169.254.170.23/full"},
+        {ContainerCredentialsResolver.ENV_VAR_FULL: "http://169.254.170.23/full"},
         clear=True,
     ):
-        resolver = ContainerCredentialResolver(http_client)
+        resolver = ContainerCredentialsResolver(http_client)
         identity = await resolver.get_identity(properties={})
 
     # Ensure we derive the correct destination
@@ -203,12 +203,12 @@ async def test_resolver_env_token():
     with patch.dict(
         os.environ,
         {
-            ContainerCredentialResolver.ENV_VAR_FULL: "http://169.254.170.23/full",
-            ContainerCredentialResolver.ENV_VAR_AUTH_TOKEN: "Bearer foobar",
+            ContainerCredentialsResolver.ENV_VAR_FULL: "http://169.254.170.23/full",
+            ContainerCredentialsResolver.ENV_VAR_AUTH_TOKEN: "Bearer foobar",
         },
         clear=True,
     ):
-        resolver = ContainerCredentialResolver(http_client)
+        resolver = ContainerCredentialsResolver(http_client)
         identity = await resolver.get_identity(properties={})
 
     # Ensure we derive the correct destination and fields
@@ -238,12 +238,12 @@ async def test_resolver_env_token_file(tmp_path: pathlib.Path):
     with patch.dict(
         os.environ,
         {
-            ContainerCredentialResolver.ENV_VAR_FULL: "http://169.254.170.23/full",
-            ContainerCredentialResolver.ENV_VAR_AUTH_TOKEN_FILE: str(token_file),
+            ContainerCredentialsResolver.ENV_VAR_FULL: "http://169.254.170.23/full",
+            ContainerCredentialsResolver.ENV_VAR_AUTH_TOKEN_FILE: str(token_file),
         },
         clear=True,
     ):
-        resolver = ContainerCredentialResolver(http_client)
+        resolver = ContainerCredentialsResolver(http_client)
         identity = await resolver.get_identity(properties={})
 
     # Ensure we derive the correct destination and fields
@@ -273,12 +273,12 @@ async def test_resolver_env_token_file_invalid_bytes(tmp_path: pathlib.Path):
     with patch.dict(
         os.environ,
         {
-            ContainerCredentialResolver.ENV_VAR_FULL: "http://169.254.170.23/full",
-            ContainerCredentialResolver.ENV_VAR_AUTH_TOKEN_FILE: str(token_file),
+            ContainerCredentialsResolver.ENV_VAR_FULL: "http://169.254.170.23/full",
+            ContainerCredentialsResolver.ENV_VAR_AUTH_TOKEN_FILE: str(token_file),
         },
         clear=True,
     ):
-        resolver = ContainerCredentialResolver(http_client)
+        resolver = ContainerCredentialsResolver(http_client)
         with pytest.raises(SmithyIdentityError) as e:
             await resolver.get_identity(properties={})
         assert "Unable to read valid utf-8 bytes from " in str(e.value)
@@ -296,13 +296,13 @@ async def test_resolver_env_token_file_precedence(tmp_path: pathlib.Path):
     with patch.dict(
         os.environ,
         {
-            ContainerCredentialResolver.ENV_VAR_FULL: "http://169.254.170.23/full",
-            ContainerCredentialResolver.ENV_VAR_AUTH_TOKEN_FILE: str(token_file),
-            ContainerCredentialResolver.ENV_VAR_AUTH_TOKEN: "Bearer foobar",
+            ContainerCredentialsResolver.ENV_VAR_FULL: "http://169.254.170.23/full",
+            ContainerCredentialsResolver.ENV_VAR_AUTH_TOKEN_FILE: str(token_file),
+            ContainerCredentialsResolver.ENV_VAR_AUTH_TOKEN: "Bearer foobar",
         },
         clear=True,
     ):
-        resolver = ContainerCredentialResolver(http_client)
+        resolver = ContainerCredentialsResolver(http_client)
         identity = await resolver.get_identity(properties={})
 
     # Ensure we derive the correct destination and fields
@@ -331,9 +331,9 @@ async def test_resolver_valid_credentials_reused():
     http_client = mock_http_client_response(200, resp_body.encode("utf-8"))
 
     with patch.dict(
-        os.environ, {ContainerCredentialResolver.ENV_VAR: "/test"}, clear=True
+        os.environ, {ContainerCredentialsResolver.ENV_VAR: "/test"}, clear=True
     ):
-        resolver = ContainerCredentialResolver(http_client)
+        resolver = ContainerCredentialsResolver(http_client)
         identity_one = await resolver.get_identity(properties={})
         identity_two = await resolver.get_identity(properties={})
 
@@ -352,9 +352,9 @@ async def test_resolver_expired_credentials_refreshed():
     http_client = mock_http_client_response(200, resp_body.encode("utf-8"))
 
     with patch.dict(
-        os.environ, {ContainerCredentialResolver.ENV_VAR: "/test"}, clear=True
+        os.environ, {ContainerCredentialsResolver.ENV_VAR: "/test"}, clear=True
     ):
-        resolver = ContainerCredentialResolver(http_client)
+        resolver = ContainerCredentialsResolver(http_client)
         identity_one = await resolver.get_identity(properties={})
         identity_two = await resolver.get_identity(properties={})
 
@@ -372,7 +372,11 @@ async def test_resolver_missing_env():
     resp_body = json.dumps(DEFAULT_RESPONSE_DATA)
     http_client = mock_http_client_response(200, resp_body.encode("utf-8"))
 
-    with patch.dict(os.environ, {}, clear=True):
-        resolver = ContainerCredentialResolver(http_client)
+    with patch.dict(
+        os.environ,
+        {},
+        clear=True,
+    ):
+        resolver = ContainerCredentialsResolver(http_client)
         with pytest.raises(SmithyIdentityError):
             await resolver.get_identity(properties={})


### PR DESCRIPTION
### Summary

When releasing `smithy-aws-core` v0.0.3, the `ContainerCredentialResolver` was renamed to `ContainerCredentialsResolver` in [this commit](https://github.com/smithy-lang/smithy-python/commit/db2082f233c2d18c9ac4cca7ff74aa9a99992698). When porting over these changes onto develop in https://github.com/smithy-lang/smithy-python/pull/515, this rename was missed. This PR ports the changes from the missing commit back to develop.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
