### PR TITLE
fix: HTTPAPIKeyAuthTrait initialization

### DIFF
--- a/packages/smithy-core/src/smithy_core/traits.py
+++ b/packages/smithy-core/src/smithy_core/traits.py
@@ -335,10 +335,13 @@ class HTTPAPIKeyAuthTrait(Trait, id=ShapeID("smithy.api#httpApiKeyAuth")):
 
     def __init__(self, value: "DocumentValue | DynamicTrait" = None):
         super().__init__(value)
-        object.__setattr__(self, "location", APIKeyLocation(value))
         assert isinstance(self.document_value, Mapping)
+        assert isinstance(self.document_value["in"], str)
         assert isinstance(self.document_value["name"], str)
         assert isinstance(self.document_value.get("scheme"), str | None)
+
+        location = self.document_value["in"]
+        object.__setattr__(self, "location", APIKeyLocation(location))
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The initializer of the `HTTPAPIKeyAuthTrait` as currently implemented is incorrect. As it is currently written, initialization will always fail. The `httpApiKeyAuth` trait in the generated schema code ends up looking like this:

```py
Trait.new(
    id=ShapeID("smithy.api#httpApiKeyAuth"),
    value=MappingProxyType({"name": "Authorization", "in": "header"}),
),
```

When building:
```sh
  File "/app/smithy/build/conversations/python-client-codegen/src/conversations/_private/schemas.py", line 1036, in <module>
    Trait.new(
    ~~~~~~~~~^
        id=ShapeID("smithy.api#httpApiKeyAuth"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        value=MappingProxyType({"name": "Authorization", "in": "header"}),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/app/.venv/lib/python3.13/site-packages/smithy_core/traits.py", line 91, in new
    return cls(value)
  File "/app/.venv/lib/python3.13/site-packages/smithy_core/traits.py", line 338, in __init__
    object.__setattr__(self, "location", APIKeyLocation(value))
                                         ~~~~~~~~~~~~~~^^^^^^^
  File "/usr/local/lib/python3.13/enum.py", line 726, in __call__
    return cls.__new__(cls, value)
           ~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/enum.py", line 1203, in __new__
    raise ve_exc
ValueError: mappingproxy({'name': 'Authorization', 'in': 'header'}) is not a valid APIKeyLocation
```

The current implementation tries to construct an `APIKeyLocation` from this entire object, instead of from the required `in` property (https://smithy.io/2.0/spec/authentication-traits.html#httpapikeyauth-trait), as it should.

This change constructs the APIKeyLocation correctly from the `in` property

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
