### PR TITLE
fix: api key identity resolver config codegen

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/HttpApiKeyAuth.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/HttpApiKeyAuth.java
@@ -63,8 +63,9 @@ public final class HttpApiKeyAuth implements PythonIntegration {
                                 .initialize(writer -> {
                                     writer.addImport("smithy_http.aio.identity.apikey", "APIKeyIdentityResolver");
                                     writer.write("""
-                                            if api_key_identity_resolver is None:
-                                                api_key_identity_resolver = APIKeyIdentityResolver()
+                                            self.api_key_identity_resolver = (
+                                                api_key_identity_resolver or APIKeyIdentityResolver()
+                                            )
                                             """);
                                 })
                                 .build())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`self.api_key_identity_resolver` was never being set on the generated `Config`, only a local `api_key_identity_resolver` was being set (and then never being used).

This was leading to an error when trying to make requests to a service with api key auth.

`'Config' object has no attribute 'api_key_identity_resolver'`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
