### PR TITLE
Add Missing Dependencies In Codegen

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -222,7 +222,7 @@ final class ClientGenerator implements Runnable {
     private void generateEventStreamOperation(PythonWriter writer, OperationShape operation) {
         writer.pushState(new OperationSection(service, operation));
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-        writer.addDependency(SmithyPythonDependency.SMITHY_AWS_EVENT_STREAM);
+        writer.addDependency(SmithyPythonDependency.SMITHY_AWS_CORE.withOptionalDependencies("eventstream"));
         var operationSymbol = symbolProvider.toSymbol(operation);
         writer.putContext("operation", operationSymbol);
         var operationMethodSymbol = operationSymbol.expectProperty(OPERATION_METHOD);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -222,6 +222,7 @@ final class ClientGenerator implements Runnable {
     private void generateEventStreamOperation(PythonWriter writer, OperationShape operation) {
         writer.pushState(new OperationSection(service, operation));
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
+        writer.addDependency(SmithyPythonDependency.SMITHY_AWS_EVENT_STREAM);
         var operationSymbol = symbolProvider.toSymbol(operation);
         writer.putContext("operation", operationSymbol);
         var operationMethodSymbol = operationSymbol.expectProperty(OPERATION_METHOD);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
@@ -84,6 +84,7 @@ public class RestJsonProtocolGenerator implements ProtocolGenerator {
     @Override
     public void initializeProtocol(GenerationContext context, PythonWriter writer) {
         writer.addDependency(SmithyPythonDependency.SMITHY_AWS_CORE);
+        writer.addDependency(SmithyPythonDependency.SMITHY_JSON);
         writer.addImport("smithy_aws_core.aio.protocols", "RestJsonClientProtocol");
         var serviceSymbol = context.symbolProvider().toSymbol(context.settings().service(context.model()));
         var serviceSchema = serviceSymbol.expectProperty(SymbolProperties.SCHEMA);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
@@ -83,8 +83,7 @@ public class RestJsonProtocolGenerator implements ProtocolGenerator {
 
     @Override
     public void initializeProtocol(GenerationContext context, PythonWriter writer) {
-        writer.addDependency(SmithyPythonDependency.SMITHY_AWS_CORE);
-        writer.addDependency(SmithyPythonDependency.SMITHY_JSON);
+        writer.addDependency(SmithyPythonDependency.SMITHY_AWS_CORE.withOptionalDependencies("json"));
         writer.addImport("smithy_aws_core.aio.protocols", "RestJsonClientProtocol");
         var serviceSymbol = context.symbolProvider().toSymbol(context.settings().service(context.model()));
         var serviceSchema = serviceSymbol.expectProperty(SymbolProperties.SCHEMA);

--- a/packages/smithy-aws-core/pyproject.toml
+++ b/packages/smithy-aws-core/pyproject.toml
@@ -47,6 +47,9 @@ path = "src/smithy_aws_core/__init__.py"
 eventstream = [
     "smithy-aws-event-stream"
 ]
+json = [
+    "smithy-json"
+]
 
 [tool.hatch.build]
 exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -692,6 +692,9 @@ dependencies = [
 eventstream = [
     { name = "smithy-aws-event-stream" },
 ]
+json = [
+    { name = "smithy-json" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -699,8 +702,9 @@ requires-dist = [
     { name = "smithy-aws-event-stream", marker = "extra == 'eventstream'", editable = "packages/smithy-aws-event-stream" },
     { name = "smithy-core", editable = "packages/smithy-core" },
     { name = "smithy-http", editable = "packages/smithy-http" },
+    { name = "smithy-json", marker = "extra == 'json'", editable = "packages/smithy-json" },
 ]
-provides-extras = ["eventstream"]
+provides-extras = ["eventstream", "json"]
 
 [[package]]
 name = "smithy-aws-event-stream"


### PR DESCRIPTION
### Overview
When generating a client for a service that uses REST-JSON or AWS Event Streaming, the client is unusable after install (see "Error Examples" section below) due to nothing taking a dependency on `smithy-json` or `smith-aws-event-stream`. 

This PR adds the following:
- Adds a `json` optional dependency group that includes `smithy-json`.
- Updates the code generator to include a `smithy-aws-core[eventstream]` dependency in `pyproject.toml` when operations with event streaming are added.
- Updates the code generator to include a `smithy-aws-core[json]` dependency in `pyproject.toml` when generating services that support REST-JSON.

## Dependencies Before and After

### Dependencies Before Fix
```
# in pyproject.toml

dependencies = [
    "smithy_aws_core<0.1.0",
    "smithy_core<0.1.0",
    "smithy_http[awscrt]<0.1.0"
]
```

### Dependencies After Fix
```
# in pyproject.toml

dependencies = [
    "smithy_aws_core[eventstream, json]<0.1.0",
    "smithy_core<0.1.0",
    "smithy_http[awscrt]<0.1.0"
]
```

## Error Examples

**Error without smithy-json**
```
ModuleNotFoundError: No module named 'smithy_json'
```

**Error without smithy-aws-event-stream**
```
smithy_core.exceptions.MissingDependencyError: Attempted to use event streams, but smithy-aws-event-stream is not installed.
``` 


## Alternative Option
Add a direct dependency on `smithy-json` and `smith-aws-event-stream`:

```
# in pyproject.toml

dependencies = [
    "smithy_aws_core<0.1.0",
    "smithy_aws_event_stream<0.1.0",
    "smithy_core<0.1.0",
    "smithy_http[awscrt]<0.1.0",
    "smithy_json<0.1.0"
]
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
