### PR TITLE
Release: Smithy Python Packages v0.1.0

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
@@ -22,7 +22,7 @@ public class AwsPythonDependency {
      */
     public static final PythonDependency SMITHY_AWS_CORE = new PythonDependency(
             "smithy_aws_core",
-            "<0.1.0",
+            "~=0.1.0",
             PythonDependency.Type.DEPENDENCY,
             false);
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -22,7 +22,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_CORE = new PythonDependency(
             "smithy_core",
-            "<0.1.0",
+            "~=0.1.0",
             Type.DEPENDENCY,
             false);
 
@@ -33,7 +33,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_HTTP = new PythonDependency(
             "smithy_http",
-            "<0.1.0",
+            "~=0.1.0",
             Type.DEPENDENCY,
             false);
 
@@ -60,7 +60,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_JSON = new PythonDependency(
             "smithy_json",
-            "<0.1.0",
+            "~=0.1.0",
             Type.DEPENDENCY,
             false);
 
@@ -69,7 +69,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_AWS_EVENT_STREAM = new PythonDependency(
             "smithy_aws_event_stream",
-            "<0.1.0",
+            "~=0.1.0",
             Type.DEPENDENCY,
             false);
 
@@ -78,7 +78,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_AWS_CORE = new PythonDependency(
             "smithy_aws_core",
-            "<0.1.0",
+            "~=0.1.0",
             Type.DEPENDENCY,
             false);
 

--- a/packages/aws-sdk-signers/.changes/0.1.0.json
+++ b/packages/aws-sdk-signers/.changes/0.1.0.json
@@ -6,7 +6,7 @@
     },
     {
       "type": "enhancement",
-      "description": "Update the async signer to use the special payload hash\nfor event stream operations."
+      "description": "Update the async signer to use the special payload hash for event stream operations."
     },
     {
       "type": "enhancement",

--- a/packages/aws-sdk-signers/.changes/0.1.0.json
+++ b/packages/aws-sdk-signers/.changes/0.1.0.json
@@ -1,0 +1,16 @@
+{
+  "changes": [
+    {
+      "type": "breaking",
+      "description": "Changed the `signing_properties` and `http_request` args to `properties` and `request` for the `sign` methods in `SigV4Signer` and `AsyncSigV4Signer`."
+    },
+    {
+      "type": "enhancement",
+      "description": "Update the async signer to use the special payload hash\nfor event stream operations."
+    },
+    {
+      "type": "enhancement",
+      "description": "Check seekable in aws signers"
+    }
+  ]
+}

--- a/packages/aws-sdk-signers/CHANGELOG.md
+++ b/packages/aws-sdk-signers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.1.0
+
+### Breaking Changes
+* Changed the `signing_properties` and `http_request` args to `properties` and `request` for the `sign` methods in `SigV4Signer` and `AsyncSigV4Signer`.
+
+### Enhancements
+* Update the async signer to use the special payload hash
+for event stream operations.
+* Check seekable in aws signers
+
 ## v0.0.3
 
 ### Features

--- a/packages/aws-sdk-signers/CHANGELOG.md
+++ b/packages/aws-sdk-signers/CHANGELOG.md
@@ -6,8 +6,7 @@
 * Changed the `signing_properties` and `http_request` args to `properties` and `request` for the `sign` methods in `SigV4Signer` and `AsyncSigV4Signer`.
 
 ### Enhancements
-* Update the async signer to use the special payload hash
-for event stream operations.
+* Update the async signer to use the special payload hash for event stream operations.
 * Check seekable in aws signers
 
 ## v0.0.3

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/__init__.py
@@ -16,7 +16,7 @@ from .signers import (
 )
 
 __license__ = "Apache-2.0"
-__version__ = "0.0.3"
+__version__ = "0.1.0"
 
 __all__ = (
     "URI",

--- a/packages/smithy-aws-core/.changes/0.1.0.json
+++ b/packages/smithy-aws-core/.changes/0.1.0.json
@@ -1,0 +1,12 @@
+{
+  "changes": [
+    {
+      "type": "breaking",
+      "description": "Updated sigv4 auth resolution and identity providers to the new transport-agnostic interfaces."
+    },
+    {
+      "type": "feature",
+      "description": "Added a hand-written implementation for the `restJson1` protocol."
+    }
+  ]
+}

--- a/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-breaking-20250904125854.json
+++ b/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-breaking-20250904125854.json
@@ -1,4 +1,0 @@
-{
-  "type": "breaking",
-  "description": "Updated sigv4 auth resolution and identity providers to the new transport-agnostic interfaces."
-}

--- a/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-feature-20250904125834.json
+++ b/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-feature-20250904125834.json
@@ -1,4 +1,0 @@
-{
-  "type": "feature",
-  "description": "Added a hand-written implementation for the `restJson1` protocol."
-}

--- a/packages/smithy-aws-core/CHANGELOG.md
+++ b/packages/smithy-aws-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.0
+
+### Breaking Changes
+* Updated sigv4 auth resolution and identity providers to the new transport-agnostic interfaces.
+
+### Features
+* Added a hand-written implementation for the `restJson1` protocol.
+
 ## v0.0.3
 
 ### Bug fixes

--- a/packages/smithy-aws-core/pyproject.toml
+++ b/packages/smithy-aws-core/pyproject.toml
@@ -26,9 +26,9 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-    "smithy-core",
-    "smithy-http",
-    "aws-sdk-signers"
+    "smithy-core~=0.1.0",
+    "smithy-http~=0.1.0",
+    "aws-sdk-signers~=0.1.0"
 ]
 
 [project.urls]
@@ -45,10 +45,10 @@ path = "src/smithy_aws_core/__init__.py"
 
 [project.optional-dependencies]
 eventstream = [
-    "smithy-aws-event-stream"
+    "smithy-aws-event-stream~=0.1.0"
 ]
 json = [
-    "smithy-json"
+    "smithy-json~=0.1.0"
 ]
 
 [tool.hatch.build]

--- a/packages/smithy-aws-core/src/smithy_aws_core/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.0.3"
+__version__ = "0.1.0"

--- a/packages/smithy-aws-event-stream/.changes/0.1.0.json
+++ b/packages/smithy-aws-event-stream/.changes/0.1.0.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "breaking",
+      "description": "Update `AWSEventPublisher` to use `SigningConfig` instead of `EventSigner` so identity can be fetched at signing time."
+    }
+  ]
+}

--- a/packages/smithy-aws-event-stream/CHANGELOG.md
+++ b/packages/smithy-aws-event-stream/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.0
+
+### Breaking Changes
+* Update `AWSEventPublisher` to use `SigningConfig` instead of `EventSigner` so identity can be fetched at signing time.
+
 ## v0.0.1
 
 ### Features

--- a/packages/smithy-aws-event-stream/pyproject.toml
+++ b/packages/smithy-aws-event-stream/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-    "smithy-core",
+    "smithy-core~=0.1.0",
 ]
 
 [project.urls]

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/__init__.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"

--- a/packages/smithy-core/.changes/0.1.0.json
+++ b/packages/smithy-core/.changes/0.1.0.json
@@ -1,0 +1,40 @@
+{
+  "changes": [
+    {
+      "type": "breaking",
+      "description": "Introduced transport-agnostic interfaces for identity and auth, replacing the existing interfaces that were coupled to HTTP requests and responses."
+    },
+    {
+      "type": "breaking",
+      "description": "Updated retry interfaces to pull information from exceptions instead of requiring a separate classification step."
+    },
+    {
+      "type": "breaking",
+      "description": "Replaced `Exception` suffix with `Error` to follow PEP8 conventions."
+    },
+    {
+      "type": "feature",
+      "description": "Updated schema members to preserve their ordering from the model using dict ordering, which significantly cuts back the amount of code that must be generated."
+    },
+    {
+      "type": "feature",
+      "description": "Introduced the `ClientProtocol` interface to allow for hand-written protocol implementations and protocol swapping at runtime."
+    },
+    {
+      "type": "feature",
+      "description": "Introduced a hand-written request pipeline to replace the one that was code-generated in Java."
+    },
+    {
+      "type": "feature",
+      "description": "Updated exceptions to embed retryablity information."
+    },
+    {
+      "type": "enhancement",
+      "description": "Added usages of `TypeForm` from PEP747 via `typing_extensions` to better support typing for event streams and typed properties."
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix broken initializer for `HTTPAPIKeyAuthTrait`. ([#533](https://github.com/smithy-lang/smithy-python/pull/553))"
+    }
+  ]
+}

--- a/packages/smithy-core/.changes/next-release/smithy-core-breaking-20250904131215.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-breaking-20250904131215.json
@@ -1,4 +1,0 @@
-{
-  "type": "breaking",
-  "description": "Updated retry interfaces to pull information from exceptions instead of requiring a separate classification step."
-}

--- a/packages/smithy-core/.changes/next-release/smithy-core-breaking-20250904131233.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-breaking-20250904131233.json
@@ -1,4 +1,0 @@
-{
-  "type": "breaking",
-  "description": "Introduced transport-agnostic interfaces for identity and auth, replacing the existing interfaces that were coupled to HTTP requests and responses."
-}

--- a/packages/smithy-core/.changes/next-release/smithy-core-breaking-20250904131302.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-breaking-20250904131302.json
@@ -1,4 +1,0 @@
-{
-  "type": "breaking",
-  "description": "Replaced `Exception` suffix with `Error` to follow PEP8 conventions."
-}

--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-20250904131027.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-20250904131027.json
@@ -1,4 +1,0 @@
-{
-  "type": "enhancement",
-  "description": "Added usages of `TypeForm` from PEP747 via `typing_extensions` to better support typing for event streams and typed properties."
-}

--- a/packages/smithy-core/.changes/next-release/smithy-core-feature-20250904131114.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-feature-20250904131114.json
@@ -1,4 +1,0 @@
-{
-  "type": "feature",
-  "description": "Introduced the `ClientProtocol` interface to allow for hand-written protocol implementations and protocol swapping at runtime."
-}

--- a/packages/smithy-core/.changes/next-release/smithy-core-feature-20250904131129.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-feature-20250904131129.json
@@ -1,4 +1,0 @@
-{
-  "type": "feature",
-  "description": "Updated exceptions to embed retryablity information."
-}

--- a/packages/smithy-core/.changes/next-release/smithy-core-feature-20250904131140.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-feature-20250904131140.json
@@ -1,4 +1,0 @@
-{
-  "type": "feature",
-  "description": "Updated schema members to preserve their ordering from the model using dict ordering, which significantly cuts back the amount of code that must be generated."
-}

--- a/packages/smithy-core/.changes/next-release/smithy-core-feature-20250904131155.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-feature-20250904131155.json
@@ -1,4 +1,0 @@
-{
-  "type": "feature",
-  "description": "Introduced a hand-written request pipeline to replace the one that was code-generated in Java."
-}

--- a/packages/smithy-core/CHANGELOG.md
+++ b/packages/smithy-core/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.1.0
+
+### Breaking Changes
+* Introduced transport-agnostic interfaces for identity and auth, replacing the existing interfaces that were coupled to HTTP requests and responses.
+* Updated retry interfaces to pull information from exceptions instead of requiring a separate classification step.
+* Replaced `Exception` suffix with `Error` to follow PEP8 conventions.
+
+### Features
+* Updated schema members to preserve their ordering from the model using dict ordering, which significantly cuts back the amount of code that must be generated.
+* Introduced the `ClientProtocol` interface to allow for hand-written protocol implementations and protocol swapping at runtime.
+* Introduced a hand-written request pipeline to replace the one that was code-generated in Java.
+* Updated exceptions to embed retryablity information.
+
+### Enhancements
+* Added usages of `TypeForm` from PEP747 via `typing_extensions` to better support typing for event streams and typed properties.
+
+### Bug fixes
+* Fix broken initializer for `HTTPAPIKeyAuthTrait`. ([#533](https://github.com/smithy-lang/smithy-python/pull/553))
+
 ## v0.0.2
 
 ### Bug fixes

--- a/packages/smithy-core/src/smithy_core/__init__.py
+++ b/packages/smithy-core/src/smithy_core/__init__.py
@@ -8,7 +8,7 @@ from urllib.parse import urlunparse
 from . import interfaces, rfc3986
 from .exceptions import SmithyError
 
-__version__ = "0.0.2"
+__version__ = "0.1.0"
 
 
 class HostType(Enum):

--- a/packages/smithy-http/.changes/0.1.0.json
+++ b/packages/smithy-http/.changes/0.1.0.json
@@ -1,0 +1,12 @@
+{
+  "changes": [
+    {
+      "type": "breaking",
+      "description": "Removed identity and auth interfaces in favor of the transport-agnostic interfaces introduced in `smithy-core`."
+    },
+    {
+      "type": "feature",
+      "description": "Introduced schema-based serializers and deserializers for HTTP binding protocols."
+    }
+  ]
+}

--- a/packages/smithy-http/.changes/next-release/smithy-http-breaking-20250904132003.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-breaking-20250904132003.json
@@ -1,4 +1,0 @@
-{
-  "type": "breaking",
-  "description": "Removed identity and auth interfaces in favor of the transport-agnostic interfaces introduced in `smithy-core`."
-}

--- a/packages/smithy-http/.changes/next-release/smithy-http-feature-20250904131946.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-feature-20250904131946.json
@@ -1,4 +1,0 @@
-{
-  "type": "feature",
-  "description": "Introduced schema-based serializers and deserializers for HTTP binding protocols."
-}

--- a/packages/smithy-http/CHANGELOG.md
+++ b/packages/smithy-http/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.0
+
+### Breaking Changes
+* Removed identity and auth interfaces in favor of the transport-agnostic interfaces introduced in `smithy-core`.
+
+### Features
+* Introduced schema-based serializers and deserializers for HTTP binding protocols.
+
 ## v0.0.1
 
 ### Features

--- a/packages/smithy-http/pyproject.toml
+++ b/packages/smithy-http/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-    "smithy-core",
+    "smithy-core~=0.1.0",
 ]
 
 [project.urls]

--- a/packages/smithy-http/src/smithy_http/__init__.py
+++ b/packages/smithy-http/src/smithy_http/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Iterator
 from . import interfaces
 from .interfaces import FieldPosition
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 
 
 class Field(interfaces.Field):

--- a/packages/smithy-json/.changes/0.1.0.json
+++ b/packages/smithy-json/.changes/0.1.0.json
@@ -1,0 +1,16 @@
+{
+  "changes": [
+    {
+      "type": "enhancement",
+      "description": "Use shared settings for JSON codec"
+    },
+    {
+      "type": "enhancement",
+      "description": "Pass JSON document class through settings"
+    },
+    {
+      "type": "enhancement",
+      "description": "Use natural dict ordering for member index"
+    }
+  ]
+}

--- a/packages/smithy-json/CHANGELOG.md
+++ b/packages/smithy-json/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.1.0
+
+### Enhancements
+* Use shared settings for JSON codec
+* Pass JSON document class through settings
+* Use natural dict ordering for member index
+
 ## v0.0.1
 
 ### Features

--- a/packages/smithy-json/pyproject.toml
+++ b/packages/smithy-json/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "ijson>=3.3.0",
-    "smithy-core",
+    "smithy-core~=0.1.0",
 ]
 
 [project.urls]

--- a/packages/smithy-json/src/smithy_json/__init__.py
+++ b/packages/smithy-json/src/smithy_json/__init__.py
@@ -13,7 +13,7 @@ from ._private.documents import JSONDocument
 from ._private.serializers import JSONShapeSerializer as _JSONShapeSerializer
 from .settings import JSONSettings
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 __all__ = ("JSONCodec", "JSONDocument", "JSONSettings")
 
 


### PR DESCRIPTION
> [!NOTE]
> The release process for this repo will be automated in the near future.

## Summary

This PR includes new releases for all the following smithy python packages:

Package | Current Version | New Version
-- | -- | --
smithy-core | v0.0.2 | v0.1.0
smithy-http | v0.0.1 | v0.1.0
smithy-json | v0.0.1 | v0.1.0
smithy-aws-core | v0.0.3 | v0.1.0
smithy-aws-event-stream | v0.0.1 | v0.1.0
aws-sdk-signers | v0.0.3 | v0.1.0

Each of the packages above received the following changes:
- Minor version bump (v0.1.0)
- Updated CHANGELOG.md entries for v0.1.0
- Updated smithy python dependencies 

## Post-Merge Tasks
After merging this PR:

- [ ] Tag all packages with their respective v0.1.0 versions
- [ ] Merge `main` back to `develop` to sync release changes
- [ ] Clean up the `release/2025-09-22 branch`
- [ ] Publish to PyPI

## Testing

<TODO: Will add testing once the `aws-sdk-python` PR is up>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
