### PR TITLE
Update docs README.md install command

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
@@ -471,7 +471,7 @@ public final class SetupGenerator {
                     following:
 
                     ```
-                    $$ uv pip install ".[docs]"
+                    $$ uv pip install --group docs .
                     $$ cd docs
                     $$ make html
                     ```


### PR DESCRIPTION
## Problem

When code generating a client, the `docs/README.md` file is currently generated with the following content:


> ## Generating Documentation
> 
> Sphinx is used for documentation. You can generate HTML locally with the
> following:
> 
> ```
> $ uv pip install ".[docs]"
> $ cd docs
> $ make html
> ```

However, when running `uv pip install ".[docs]"`, the docs dependencies are not actually installed and the following warning is thrown:
```
warning: The package `aws-sdk-bedrock-runtime @ file:///Users/gytndd/dev/GitHub/aws-sdk-python/clients/aws-sdk-bedrock-runtime` does not have an extra named `docs`
```

This is a result of [smithy-python#522](https://github.com/smithy-lang/smithy-python/pull/522) which moved the `docs` group from under `[project.optional-dependencies]` to `[dependency-groups]`.

## Solution 

Update the install command to `uv pip install --group docs .`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
