### PR TITLE
Remove missed reference to docformatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ test-protocols: ## Generates and runs the restJson1 protocol tests.
 
 
 lint-py: ## Runs linters and formatters on the python packages.
-	uv run docformatter packages --in-place || true
 	uv run ruff check packages --fix --config pyproject.toml
 	uv run ruff format packages --config pyproject.toml
 


### PR DESCRIPTION
## Summary

This PR cleans up a missed reference to `docformatter` which was removed in https://github.com/smithy-lang/smithy-python/pull/570 due to lack of Python 3.14 support. Work to reintroduce `docformatter` or replace it with ruff is being tracked in https://github.com/smithy-lang/smithy-python/issues/571. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
