### PR TITLE
Add Python 3.14 classifier to code-generated clients

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
@@ -136,7 +136,8 @@ public final class SetupGenerator {
                         "Programming Language :: Python :: 3",
                         "Programming Language :: Python :: 3 :: Only",
                         "Programming Language :: Python :: 3.12",
-                        "Programming Language :: Python :: 3.13"
+                        "Programming Language :: Python :: 3.13",
+                        "Programming Language :: Python :: 3.14"
                     ]
                     """, settings.moduleName(), settings.moduleVersion(), settings.moduleDescription());
 


### PR DESCRIPTION
## Summary

This PR adds the `Programming Language :: Python :: 3.14` classifier to clients generated with smithy python.

---

## Testing

### Code Generation
Used the code generator to build a new version of the `aws-sdk-bedrock-runtime` client and verified the classifier is present in the generated `pyproject.toml` file:

```
classifiers = [
    "Development Status :: 2 - Pre-Alpha",
    "Intended Audience :: Developers",
    "Intended Audience :: System Administrators",
    "Natural Language :: English",
    "License :: OSI Approved :: Apache Software License",
    "Programming Language :: Python",
    "Programming Language :: Python :: 3",
    "Programming Language :: Python :: 3 :: Only",
    "Programming Language :: Python :: 3.12",
    "Programming Language :: Python :: 3.13",
    "Programming Language :: Python :: 3.14"
]
```

### AWS SDK Bedrock Runtime
Installed `aws-sdk-bedrock-runtime` in a Python 3.14 virtual environment and confirmed that it successfully runs on Python 3.14. I did see a new error that will be removed with https://github.com/awslabs/aws-sdk-python/pull/22

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
