### PR TITLE
Add dependency changelog type

### DIFF
--- a/scripts/changelog/new-entry.py
+++ b/scripts/changelog/new-entry.py
@@ -55,7 +55,7 @@ def main():
         "-t",
         "--type",
         # TODO: Remove the 'breaking' option once this project is stable.
-        choices=("feature", "enhancement", "bugfix", "breaking"),
+        choices=("feature", "enhancement", "bugfix", "breaking", "dependency"),
         required=True,
         help="Type of change",
     )

--- a/scripts/changelog/new-release.py
+++ b/scripts/changelog/new-release.py
@@ -15,7 +15,7 @@ from typing import Any
 
 PROJECT_ROOT_DIR = Path(__file__).resolve().parent.parent.parent
 VERSION_PATTERN = r"^\d+\.\d+\.\d+$"
-CHANGE_TYPES_ORDER = {"breaking": 0, "feature": 1, "enhancement": 2, "bugfix": 3}
+CHANGE_TYPES_ORDER = {"breaking": 0, "feature": 1, "enhancement": 2, "bugfix": 3, "dependency": 4}
 CHANGE_TYPES = tuple(CHANGE_TYPES_ORDER.keys())
 
 

--- a/scripts/changelog/new-release.py
+++ b/scripts/changelog/new-release.py
@@ -15,7 +15,13 @@ from typing import Any
 
 PROJECT_ROOT_DIR = Path(__file__).resolve().parent.parent.parent
 VERSION_PATTERN = r"^\d+\.\d+\.\d+$"
-CHANGE_TYPES_ORDER = {"breaking": 0, "feature": 1, "enhancement": 2, "bugfix": 3, "dependency": 4}
+CHANGE_TYPES_ORDER = {
+    "breaking": 0,
+    "feature": 1,
+    "enhancement": 2,
+    "bugfix": 3,
+    "dependency": 4,
+}
 CHANGE_TYPES = tuple(CHANGE_TYPES_ORDER.keys())
 
 

--- a/scripts/changelog/templates/PACKAGE
+++ b/scripts/changelog/templates/PACKAGE
@@ -1,7 +1,7 @@
 # Changelog
 {% for release, changes in releases %}
 ## v{{ release }}
-{%- for type_name in ['breaking', 'feature', 'enhancement', 'bugfix'] %}
+{%- for type_name in ['breaking', 'feature', 'enhancement', 'bugfix', 'dependency'] %}
 {%- for change in changes.changes if change.type == type_name %}
 {%- if loop.first %}
 {%- if type_name == 'breaking' %}
@@ -16,6 +16,9 @@
 {%- elif type_name == 'bugfix' %}
 
 ### Bug fixes
+{%- elif type_name == 'dependency' %}
+
+### Dependencies
 {%- endif %}
 {%- endif %}
 * {{ change.description }}


### PR DESCRIPTION
## Summary

This PR adds a new "dependency" changelog type to the project's changelog management system. This allows changelog
entries to be categorized specifically for dependency updates, which are distinct from features, enhancements,
bugfixes, and breaking changes.

The changes include:
- Added "dependency" as a valid changelog type option in the new-entry.py script.
- Modified the PACKAGE changelog template to include a "Dependencies" section that appears after bug fixes.

This enhancement provides better organization for changelogs by separating dependency updates from other types of
changes, making it easier for users to track what dependencies have been updated in each release.

## Testing

- Verify that the new-entry.py script accepts the new "dependency" type:
  `./scripts/changelog/new-entry.py -p smithy-core -t dependency -d "Test dependency entry"`
- Run new-release.py to ensure dependency entries are sorted correctly and appear in the expected order (after
  bugfixes)
  `./scripts/changelog/new-release.py -p smithy-core -v 1.2.3`
- Check that the PACKAGE template renders dependency sections correctly with existing changelog entries
  `./scripts/changelog/render.py -p smithy-core`

Output:
```
# Changelog

## v1.2.3

### Dependencies
* Test dependency entry

... 

<Older Version Entries>
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
