### PR TITLE
Release: smithy_http-0.2.0, smithy_aws_core-0.1.1

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -33,7 +33,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_HTTP = new PythonDependency(
             "smithy_http",
-            "~=0.1.0",
+            "~=0.2.0",
             Type.DEPENDENCY,
             false);
 
@@ -42,7 +42,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency AWS_CRT = new PythonDependency(
             "awscrt",
-            ">=0.23.10",
+            "~=0.28.2",
             Type.DEPENDENCY,
             false);
 

--- a/packages/smithy-aws-core/.changes/0.1.1.json
+++ b/packages/smithy-aws-core/.changes/0.1.1.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "type": "dependency",
-      "description": "**Updated**: `smithy-http` from `~=0.1.0` to `~=0.2.0`."
+      "description": "Bump `smithy-http` from `~=0.1.0` to `~=0.2.0`."
     }
   ]
 }

--- a/packages/smithy-aws-core/.changes/0.1.1.json
+++ b/packages/smithy-aws-core/.changes/0.1.1.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "dependency",
+      "description": "**Updated**: `smithy-http` from `~=0.1.0` to `~=0.2.0`."
+    }
+  ]
+}

--- a/packages/smithy-aws-core/CHANGELOG.md
+++ b/packages/smithy-aws-core/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.1.1
 
 ### Dependencies
-* **Updated**: `smithy-http` from `~=0.1.0` to `~=0.2.0`.
+* Bump `smithy-http` from `~=0.1.0` to `~=0.2.0`.
 
 ## v0.1.0
 

--- a/packages/smithy-aws-core/CHANGELOG.md
+++ b/packages/smithy-aws-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.1
+
+### Dependencies
+* **Updated**: `smithy-http` from `~=0.1.0` to `~=0.2.0`.
+
 ## v0.1.0
 
 ### Breaking Changes

--- a/packages/smithy-aws-core/pyproject.toml
+++ b/packages/smithy-aws-core/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "smithy-core~=0.1.0",
-    "smithy-http~=0.1.0",
+    "smithy-http~=0.2.0",
     "aws-sdk-signers~=0.1.0"
 ]
 

--- a/packages/smithy-aws-core/src/smithy_aws_core/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/packages/smithy-http/.changes/0.2.0.json
+++ b/packages/smithy-http/.changes/0.2.0.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "type": "breaking",
-      "description": "Update `AWSCRTHTTPClient` to integrate with the new AWS CRT async interfaces. ([#573](https://github.com/smithy-lang/smithy-python/pull/573))"
+      "description": "Update `AWSCRTHTTPClient` to integrate with the new AWS CRT async interfaces. ([#573](https://github.com/smithy-lang/smithy-python/pull/573)). The `AWSCRTHTTPResponse` constructor now accepts a `stream` argument of type `awscrt.aio.http.AIOHttpClientStreamUnified`. Additionally, the following classes were removed: `CRTResponseBody`, `CRTResponseFactory`, and `BufferableByteStream`."
     }
   ]
 }

--- a/packages/smithy-http/.changes/0.2.0.json
+++ b/packages/smithy-http/.changes/0.2.0.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "breaking",
+      "description": "Update `AWSCRTHTTPClient` to integrate with the new AWS CRT async interfaces. ([#573](https://github.com/smithy-lang/smithy-python/pull/573))"
+    }
+  ]
+}

--- a/packages/smithy-http/.changes/next-release/smithy-http-breaking-20251017150112.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-breaking-20251017150112.json
@@ -1,4 +1,0 @@
-{
-  "type": "breaking",
-  "description": "Update `AWSCRTHTTPClient` to integrate with the new AWS CRT async interfaces. ([#573](https://github.com/smithy-lang/smithy-python/pull/573))"
-}

--- a/packages/smithy-http/CHANGELOG.md
+++ b/packages/smithy-http/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.0
+
+### Breaking Changes
+* Update `AWSCRTHTTPClient` to integrate with the new AWS CRT async interfaces. ([#573](https://github.com/smithy-lang/smithy-python/pull/573))
+
 ## v0.1.0
 
 ### Breaking Changes

--- a/packages/smithy-http/CHANGELOG.md
+++ b/packages/smithy-http/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.2.0
 
 ### Breaking Changes
-* Update `AWSCRTHTTPClient` to integrate with the new AWS CRT async interfaces. ([#573](https://github.com/smithy-lang/smithy-python/pull/573))
+* Update `AWSCRTHTTPClient` to integrate with the new AWS CRT async interfaces. ([#573](https://github.com/smithy-lang/smithy-python/pull/573)). The `AWSCRTHTTPResponse` constructor now accepts a `stream` argument of type `awscrt.aio.http.AIOHttpClientStreamUnified`. Additionally, the following classes were removed: `CRTResponseBody`, `CRTResponseFactory`, and `BufferableByteStream`.
 
 ## v0.1.0
 

--- a/packages/smithy-http/src/smithy_http/__init__.py
+++ b/packages/smithy-http/src/smithy_http/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Iterator
 from . import interfaces
 from .interfaces import FieldPosition
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
 class Field(interfaces.Field):


### PR DESCRIPTION
This PR adds changelog entries, bumps versions, and updates dependencies for the following packages:

- `smithy-http` - `0.1.0` --> `0.2.0`
- `smithy-aws-core` - `0.1.0` --> `0.1.1`
  - Dependency on `smithy-http` is bumped to `~=0.2.0`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
