### PR TITLE
Fix characters interpreted as Smithy format specifiers in doc gen

### DIFF
--- a/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/MarkdownToRstDocConverterTest.java
+++ b/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/MarkdownToRstDocConverterTest.java
@@ -106,4 +106,13 @@ public class MarkdownToRstDocConverterTest {
         String result = markdownToRstDocConverter.convertCommonmarkToRst(html);
         assertEquals(expected, result.trim());
     }
+
+    @Test
+    public void testConvertCommonmarkToRstWithFormatSpecifierCharacters() {
+        // Test that Smithy format specifier characters ($) are properly escaped and treated as literal text
+        String html = "<html><body><p>Testing $placeholder_one and $placeholder_two</p></body></html>";
+        String expected = "Testing $placeholder_one and $placeholder_two";
+        String result = markdownToRstDocConverter.convertCommonmarkToRst(html);
+        assertEquals(expected, result.trim());
+    }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownToRstDocConverter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownToRstDocConverter.java
@@ -78,7 +78,7 @@ public class MarkdownToRstDocConverter {
                 if (!text.trim().isEmpty()) {
                     if (text.startsWith(":param ")) {
                         int secondColonIndex = text.indexOf(':', 1);
-                        writer.write(text.substring(0, secondColonIndex + 1));
+                        writer.write("$L", text.substring(0, secondColonIndex + 1));
                         //TODO right now the code generator gives us a mixture of
                         // RST and HTML (for instance :param xyz: <p> docs
                         // </p>).  Since we standardize to html above, that <p> tag
@@ -91,16 +91,16 @@ public class MarkdownToRstDocConverter {
                         } else {
                             writer.ensureNewline();
                             writer.indent();
-                            writer.write(text.substring(secondColonIndex + 1));
+                            writer.write("$L", text.substring(secondColonIndex + 1));
                             writer.dedent();
                         }
                     } else {
-                        writer.writeInline(text);
+                        writer.writeInline("$L", text);
                     }
                     // Account for services making a paragraph tag that's empty except
                     // for a newline
                 } else if (node.parent() != null && ((Element) node.parent()).tagName().equals("p")) {
-                    writer.writeInline(text.replaceAll("[ \\t]+", ""));
+                    writer.writeInline("$L", text.replaceAll("[ \\t]+", ""));
                 }
             } else if (node instanceof Element) {
                 Element element = (Element) node;
@@ -158,7 +158,7 @@ public class MarkdownToRstDocConverter {
                     case "a":
                         String href = element.attr("href");
                         if (!href.isEmpty()) {
-                            writer.writeInline(" <").writeInline(href).writeInline(">`_");
+                            writer.writeInline(" <").writeInline("$L", href).writeInline(">`_");
                         } else {
                             writer.writeInline("`");
                         }
@@ -196,7 +196,7 @@ public class MarkdownToRstDocConverter {
                         break;
                     case "h1":
                         String title = element.text();
-                        writer.ensureNewline().writeInline("=".repeat(title.length())).ensureNewline();
+                        writer.ensureNewline().writeInline("$L", "=".repeat(title.length())).ensureNewline();
                         break;
                     default:
                         break;


### PR DESCRIPTION
#### Description

Fixed an issue in doc string generation where special characters (specifically $) in the Smithy model's documentation traits were being incorrectly interpreted as Smithy format specifiers ([docs](https://smithy.io/2.0/guides/building-codegen/generating-code.html#formatters)). 

The fix adds the `$L` formatter to `write()` and `writeInline()` calls in `MarkdownToRstDocConverter.java`, ensuring doc strings are treated as string literals rather than as format expressions. This prevents the unintended interpolation of doc strings that contain characters like $.

#### Testing

Successfully rebuilt `aws-sdk-bedrock-runtime` client and ensured no changes were reflected in docstrings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
