### PR TITLE
Fix eventHeader casing

### DIFF
--- a/packages/smithy-core/src/smithy_core/traits.py
+++ b/packages/smithy-core/src/smithy_core/traits.py
@@ -179,7 +179,7 @@ class MediaTypeTrait(Trait, id=ShapeID("smithy.api#mediaType")):
 
 
 @dataclass(init=False, frozen=True)
-class EventHeaderTrait(Trait, id=ShapeID("smithy.api#eventheader")):
+class EventHeaderTrait(Trait, id=ShapeID("smithy.api#eventHeader")):
     def __post_init__(self):
         assert self.document_value is None
 


### PR DESCRIPTION
Currently no services use event headers in smithy python.  A typo in the casing of the event streaming header will cause issues when [serializing](https://github.com/smithy-lang/smithy-python/blob/3c3bacffdcfeda6dfede98a780e107a60bb8ac4f/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/serializers.py#L176) and [deserializing](https://github.com/smithy-lang/smithy-python/blob/3c3bacffdcfeda6dfede98a780e107a60bb8ac4f/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/deserializers.py#L126) events with headers. The fact that we cannot correctly identify the member location as a header means the values will always end up in the event's body.  

See [smithy's docs](https://smithy.io/2.0/spec/streaming.html#eventheader-trait) for more information on the trait.  See [smithy's source code](https://github.com/smithy-lang/smithy/blob/786e8bdc1500821b24ba87a2244e3a3fcf1932ad/smithy-model/src/main/java/software/amazon/smithy/model/traits/EventHeaderTrait.java#L18) for confirmation of the correct casing.  