### PR TITLE
Resolve signing issues from mismatched list header formatting

### DIFF
--- a/packages/aws-sdk-signers/src/aws_sdk_signers/interfaces/http.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/interfaces/http.py
@@ -57,7 +57,7 @@ class Field(Protocol):
         """Remove all matching entries from list."""
         ...
 
-    def as_string(self, delimiter: str = ", ") -> str:
+    def as_string(self, delimiter: str = ",") -> str:
         """Serialize the ``Field``'s values into a single line string."""
         ...
 

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
@@ -705,7 +705,7 @@ class AsyncSigV4Signer:
 
     async def _normalize_signing_fields(self, *, request: AWSRequest) -> dict[str, str]:
         normalized_fields = {
-            field.name.lower(): field.as_string()
+            field.name.lower(): field.as_string(delimiter=",")
             for field in request.fields
             if self._is_signable_header(field.name.lower())
         }

--- a/packages/smithy-http/.changes/next-release/smithy-http-bugfix-20251023131033.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-bugfix-20251023131033.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Fix `InvalidSignatureException` caused by mismatched list header formatting during signing (e.g., `MyHeader: value1, value2` vs `MyHeader: value1,value2`)."
+}

--- a/packages/smithy-http/src/smithy_http/__init__.py
+++ b/packages/smithy-http/src/smithy_http/__init__.py
@@ -63,7 +63,7 @@ class Field(interfaces.Field):
             return ""
         if value_count == 1:
             return self.values[0]
-        return ", ".join(quote_and_escape_field_value(val) for val in self.values)
+        return delimiter.join(quote_and_escape_field_value(val) for val in self.values)
 
     def as_tuples(self) -> list[tuple[str, str]]:
         """Get list of ``name``, ``value`` tuples where each tuple represents one

--- a/packages/smithy-http/tests/unit/test_fields.py
+++ b/packages/smithy-http/tests/unit/test_fields.py
@@ -23,7 +23,7 @@ def test_field_multi_valued_basics() -> None:
     assert field.name == "fname"
     assert field.kind == FieldPosition.HEADER
     assert field.values == ["fval1", "fval2"]
-    assert field.as_string() == "fval1, fval2"
+    assert field.as_string() == "fval1,fval2"
     assert field.as_tuples() == [("fname", "fval1"), ("fname", "fval2")]
 
 
@@ -36,24 +36,24 @@ def test_field_multi_valued_basics() -> None:
         (['"'], '"'),
         (['val"1'], 'val"1'),
         (["val\\1"], "val\\1"),
-        # Multi-valued fields are joined with one comma and one space as separator.
-        (["val1", "val2"], "val1, val2"),
-        (["val1", "val2", "val3", "val4"], "val1, val2, val3, val4"),
-        (["©väl", "val2"], "©väl, val2"),
+        # Multi-valued fields are joined with one comma as separator.
+        (["val1", "val2"], "val1,val2"),
+        (["val1", "val2", "val3", "val4"], "val1,val2,val3,val4"),
+        (["©väl", "val2"], "©väl,val2"),
         # Values containing commas must be double-quoted.
-        (["val1", "val2,val3", "val4"], 'val1, "val2,val3", val4'),
-        (["v,a,l,1", "val2"], '"v,a,l,1", val2'),
+        (["val1", "val2,val3", "val4"], 'val1,"val2,val3",val4'),
+        (["v,a,l,1", "val2"], '"v,a,l,1",val2'),
         # In strings that get quoted, pre-existing double quotes are escaped with a
         # single backslash. The second backslash below is for escaping the actual
         # backslash in the string for Python.
-        (["slc", '4,196"'], 'slc, "4,196\\""'),
-        (['"val1"', "val2"], '"\\"val1\\"", val2'),
-        (["val1", '"'], 'val1, "\\""'),
-        (['val1:2",val3:4"', "val5"], '"val1:2\\",val3:4\\"", val5'),
+        (["slc", '4,196"'], 'slc,"4,196\\""'),
+        (['"val1"', "val2"], '"\\"val1\\"",val2'),
+        (["val1", '"'], 'val1,"\\""'),
+        (['val1:2",val3:4"', "val5"], '"val1:2\\",val3:4\\"",val5'),
         # If quoting happens, backslashes are also escaped. The following case is a
         # single backslash getting serialized into two backslashes. Python escaping
         # accounts for each actual backslash being written as two.
-        (["foo,bar\\", "val2"], '"foo,bar\\\\", val2'),
+        (["foo,bar\\", "val2"], '"foo,bar\\\\",val2'),
     ],
 )
 def test_field_serialization(values: list[str], expected: str):


### PR DESCRIPTION
## Overview

This PR fixes `InvalidSignatureException` errors caused by inconsistent formatting of list-valued headers during request signing. Previously, headers like were sent as `value1,value2` but signed as `value1, value2`, leading to signature mismatches. The SDK now ensures both the request and signature use identical header formatting.

> [!NOTE]
> This is a bit weird since the CRT will handle multi-valued headers by adding them individually on the request. The server seems to be handling this by joining them by the `,` for signature verification.

## Testing

Tested this change using the script below with both the `AWSCRTHTTPClient` and `AIOHTTPClient` clients:

```py
import asyncio
import json

from smithy_aws_core.identity import EnvironmentCredentialsResolver
from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient
from aws_sdk_bedrock_runtime.models import InvokeModelWithResponseStreamInput
from aws_sdk_bedrock_runtime.config import Config

from smithy_http.aio.aiohttp import AIOHTTPClient

MODEL_ID = "us.amazon.nova-lite-v1:0"


async def test_async():
    c = BedrockRuntimeClient(
        config=Config(
            endpoint_uri="https://bedrock-runtime.us-east-1.amazonaws.com",
            region="us-east-1",
            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
            transport=AIOHTTPClient() # Comment to use the default CRT client
        )
    )
    # Define your system prompt(s).
    system_list = [
        {
            "text": "Act as a creative writing assistant. When the user provides you with a topic, write a short story about that topic."
        }
    ]

    # Define one or more messages using the "user" and "assistant" roles.
    message_list = [{"role": "user", "content": [{"text": "A camping trip"}]}]

    # Configure the inference parameters.
    inf_params = {"maxTokens": 500, "topP": 0.9, "topK": 20, "temperature": 0.7}

    request_body = {
        "schemaVersion": "messages-v1",
        "messages": message_list,
        "system": system_list,
        "inferenceConfig": inf_params,
    }
    response = c.invoke_model_with_response_stream(
        InvokeModelWithResponseStreamInput(
            model_id=MODEL_ID,
            body=json.dumps(request_body).encode("utf-8"),
            content_type="application/json"
        )
    )

    async with await response as stream:
        output = ""
        async for r in stream.output_stream:
            try:
                text = json.loads(r.value.bytes_.decode())["contentBlockDelta"][
                    "delta"
                ]["text"]
                output += text
            except Exception:
                continue
        print(f"Response:\n------------\n{output}")


if __name__ == "__main__":
    asyncio.run(test_async())
```

Without this PR I was receiving the following error:
```
smithy_core.exceptions.CallError: Unknown error for operation com.amazonaws.bedrockruntime#InvokeModelWithResponseStream - status: 403 - id: com.amazonaws.bedrockruntime#InvalidSignatureException
``` 

With this change I received successful responses.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
