### PR TITLE
Remove SyntaxWarning on Python 3.14

### DIFF
--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/serializers.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/serializers.py
@@ -59,10 +59,8 @@ class EventSerializer(SpecificShapeSerializer):
         # Note that if we're serializing an operation input or output, it won't be a
         # union at all, so this won't get triggered. Thankfully, that's what we want.
         if schema.shape_type is ShapeType.UNION:
-            try:
-                yield self
-            finally:
-                return
+            yield self
+            return
 
         headers: dict[str, HEADER_VALUE] = {}
 


### PR DESCRIPTION
## Summary

This PR addresses the following `SyntaxWarning` thrown when using the `smithy-aws-event-stream` package on Python 3.14:

```
/Users/gytndd/dev/.venv/lib/python3.14/site-packages/smithy_aws_event_stream/_private/serializers.py:65: SyntaxWarning: 'return' in a 'finally' block
  return
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
