### PR TITLE
Fix missing deepcopy import for event stream operations

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -131,7 +131,6 @@ final class ClientGenerator implements Runnable {
         var outputSymbol = symbolProvider.toSymbol(output);
 
         writer.pushState(new OperationSection(service, operation));
-        writer.addStdlibImport("copy", "deepcopy");
         writer.putContext("input", inputSymbol);
         writer.putContext("output", outputSymbol);
         writer.putContext("plugin", pluginSymbol);
@@ -189,6 +188,7 @@ final class ClientGenerator implements Runnable {
         writer.addImport("smithy_core.types", "TypedProperties");
         writer.addImport("smithy_core.aio.client", "RequestPipeline");
         writer.addImport("smithy_core.exceptions", "ExpectationNotMetError");
+        writer.addStdlibImport("copy", "deepcopy");
 
         writer.write("""
                 operation_plugins: list[Plugin] = [
@@ -221,7 +221,6 @@ final class ClientGenerator implements Runnable {
 
     private void generateEventStreamOperation(PythonWriter writer, OperationShape operation) {
         writer.pushState(new OperationSection(service, operation));
-        writer.addStdlibImport("copy", "deepcopy");
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
         writer.addDependency(SmithyPythonDependency.SMITHY_AWS_CORE.withOptionalDependencies("eventstream"));
         var operationSymbol = symbolProvider.toSymbol(operation);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -221,6 +221,7 @@ final class ClientGenerator implements Runnable {
 
     private void generateEventStreamOperation(PythonWriter writer, OperationShape operation) {
         writer.pushState(new OperationSection(service, operation));
+        writer.addStdlibImport("copy", "deepcopy");
         writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
         writer.addDependency(SmithyPythonDependency.SMITHY_AWS_CORE.withOptionalDependencies("eventstream"));
         var operationSymbol = symbolProvider.toSymbol(operation);


### PR DESCRIPTION
The ClientGenerator was missing the deepcopy import in generateEventStreamOperation(). Services with only event stream operations fail when smithy-build runs `ruff check` on the generated code because the generated code calls deepcopy(self._config) without importing it. Non-event-stream operations [already had the import](https://github.com/SamRemis/smithy-python/blob/8000e36a2bbf82fffea075a6567221a674a257e3/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java#L134).

This adds the missing `writer.addStdlibImport("copy", "deepcopy")` line.