### PR TITLE
Prepare release for bugfixes

### DIFF
--- a/packages/smithy-core/.changes/0.1.1.json
+++ b/packages/smithy-core/.changes/0.1.1.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fix incorrect header casing for the shape id of eventHeaders"
+    }
+  ]
+}

--- a/packages/smithy-core/.changes/0.1.1.json
+++ b/packages/smithy-core/.changes/0.1.1.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "type": "bugfix",
-      "description": "Fix incorrect header casing for the shape id of eventHeaders"
+      "description": "Fix incorrect header casing for the shape id of eventHeaders."
     }
   ]
 }

--- a/packages/smithy-core/.changes/next-release/smithy-core-bugfix-20251103155132.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-bugfix-20251103155132.json
@@ -1,4 +1,0 @@
-{
-  "type": "bugfix",
-  "description": "Fix incorrect header casing for the shape id of eventHeaders"
-}

--- a/packages/smithy-core/.changes/next-release/smithy-core-bugfix-20251103155132.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-bugfix-20251103155132.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Fix incorrect header casing for the shape id of eventHeaders"
+}

--- a/packages/smithy-core/CHANGELOG.md
+++ b/packages/smithy-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.1
+
+### Bug fixes
+* Fix incorrect header casing for the shape id of eventHeaders
+
 ## v0.1.0
 
 ### Breaking Changes

--- a/packages/smithy-core/CHANGELOG.md
+++ b/packages/smithy-core/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.1.1
 
 ### Bug fixes
-* Fix incorrect header casing for the shape id of eventHeaders
+* Fix incorrect header casing for the shape id of eventHeaders.
 
 ## v0.1.0
 

--- a/packages/smithy-core/src/smithy_core/__init__.py
+++ b/packages/smithy-core/src/smithy_core/__init__.py
@@ -8,7 +8,7 @@ from urllib.parse import urlunparse
 from . import interfaces, rfc3986
 from .exceptions import SmithyError
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 class HostType(Enum):

--- a/packages/smithy-http/.changes/0.2.1.json
+++ b/packages/smithy-http/.changes/0.2.1.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "add port to CRT HTTP client's host header"
+    }
+  ]
+}

--- a/packages/smithy-http/.changes/0.2.1.json
+++ b/packages/smithy-http/.changes/0.2.1.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "type": "bugfix",
-      "description": "add port to CRT HTTP client's host header"
+      "description": "Add port to CRT HTTP client's host header."
     }
   ]
 }

--- a/packages/smithy-http/.changes/next-release/smithy-http-bugfix-20251017171341.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-bugfix-20251017171341.json
@@ -1,4 +1,4 @@
 {
   "type": "bugfix",
-  "description": "add port to CRT HTTP client's host header"
+  "description": "Add port to CRT HTTP client's host header"
 }

--- a/packages/smithy-http/.changes/next-release/smithy-http-bugfix-20251017171341.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-bugfix-20251017171341.json
@@ -1,4 +1,0 @@
-{
-  "type": "bugfix",
-  "description": "Add port to CRT HTTP client's host header"
-}

--- a/packages/smithy-http/CHANGELOG.md
+++ b/packages/smithy-http/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.1
+
+### Bug fixes
+* add port to CRT HTTP client's host header
+
 ## v0.2.0
 
 ### Breaking Changes

--- a/packages/smithy-http/CHANGELOG.md
+++ b/packages/smithy-http/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.2.1
 
 ### Bug fixes
-* add port to CRT HTTP client's host header
+* Add port to CRT HTTP client's host header
 
 ## v0.2.0
 

--- a/packages/smithy-http/CHANGELOG.md
+++ b/packages/smithy-http/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.2.1
 
 ### Bug fixes
-* Add port to CRT HTTP client's host header
+* Add port to CRT HTTP client's host header.
 
 ## v0.2.0
 

--- a/packages/smithy-http/src/smithy_http/__init__.py
+++ b/packages/smithy-http/src/smithy_http/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Iterator
 from . import interfaces
 from .interfaces import FieldPosition
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 class Field(interfaces.Field):


### PR DESCRIPTION
This PR adds changelog entries and minor version bumps in preparation to release two bugfixes: adding the port to the host header to the CRT HTTP client and fixing a typo for the shapeId of eventHeaders in smithy-core


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
