### PR TITLE
Improve docstring for code-generated Config object

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -10,6 +10,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
+import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.knowledge.EventStreamIndex;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
@@ -331,6 +332,11 @@ public final class ConfigGenerator implements Runnable {
         }
 
         var finalProperties = List.copyOf(properties);
+        final String serviceId = context.settings()
+                .service(context.model())
+                .getTrait(ServiceTrait.class)
+                .map(ServiceTrait::getSdkId)
+                .orElse(context.settings().service().getName());
         writer.pushState(new ConfigSection(finalProperties));
         writer.addStdlibImport("dataclasses", "dataclass");
         writer.write("""
@@ -352,7 +358,7 @@ public final class ConfigGenerator implements Runnable {
                         ${C|}
                 """,
                 configSymbol.getName(),
-                context.settings().service().getName(),
+                serviceId,
                 writer.consumer(w -> writePropertyDeclarations(w, finalProperties)),
                 writer.consumer(w -> writeInitParams(w, finalProperties)),
                 writer.consumer(w -> documentProperties(w, finalProperties)),


### PR DESCRIPTION
## Summary

This PR improves the docstring for code-generated `Config` objects for AWS service clients.

We currently use the name of the smithy service type and will instead try to use the sdkId.

## Examples

### Bedrock Runtime

Before:
```py
class Config:
    """Configuration for AmazonBedrockFrontendService."""
```

After:

```py
class Config:
    """Configuration for Bedrock Runtime."""
```

## Transcribe Streaming

Before:
```py
class Config:
    """Configuration for Transcribe."""
```

After:

```py
class Config:
    """Configuration for Transcribe Streaming."""
```


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
