### PR TITLE
Restrict init file gen to package directories and fix docstring blank lines

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -168,8 +168,7 @@ final class ClientGenerator implements Runnable {
             writer.write("""
                     :param plugins: A list of callables that modify the configuration dynamically.
                         Changes made by these plugins only apply for the duration of the operation
-                        execution and will not affect any other operation invocations.
-                        """);
+                        execution and will not affect any other operation invocations.""");
 
         });
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -345,10 +345,7 @@ public final class ConfigGenerator implements Runnable {
                         *,
                         ${C|}
                     ):
-                        \"""Constructor.
-
                         ${C|}
-                        \"""
                         ${C|}
                 """,
                 configSymbol.getName(),
@@ -376,17 +373,20 @@ public final class ConfigGenerator implements Runnable {
     }
 
     private void documentProperties(PythonWriter writer, Collection<ConfigProperty> properties) {
-        var iter = properties.iterator();
-        while (iter.hasNext()) {
-            var property = iter.next();
-            var docs = writer.formatDocs(String.format(":param %s: %s", property.name(), property.documentation()));
+        writer.writeDocs(() ->{
+            var iter = properties.iterator();
+            writer.write("\nConstructor.\n");
+            while (iter.hasNext()) {
+                var property = iter.next();
+                var docs = writer.formatDocs(String.format(":param %s: %s", property.name(), property.documentation()));
 
-            if (iter.hasNext()) {
-                docs += "\n";
+                if (iter.hasNext()) {
+                    docs += "\n";
+                }
+
+                writer.write(docs);
             }
-
-            writer.write(docs);
-        }
+        });
     }
 
     private void initializeProperties(PythonWriter writer, Collection<ConfigProperty> properties) {

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/InitGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/InitGenerator.java
@@ -6,6 +6,7 @@ package software.amazon.smithy.python.codegen.generators;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Set;
 import java.util.stream.Collectors;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -15,6 +16,8 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class InitGenerator implements Runnable {
+    // Set of directories that need __init__.py files
+    private static final Set<String> PACKAGE_DIRECTORIES = Set.of("src", "tests");
 
     private final GenerationContext context;
 
@@ -31,6 +34,7 @@ public final class InitGenerator implements Runnable {
                 .stream()
                 .map(Paths::get)
                 .filter(path -> !path.getParent().equals(context.fileManifest().getBaseDir()))
+                .filter(path -> PACKAGE_DIRECTORIES.contains(path.getName(0).toString()))
                 .collect(Collectors.groupingBy(Path::getParent, Collectors.toSet()));
         for (var entry : directories.entrySet()) {
             var initPath = entry.getKey().resolve("__init__.py");

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -242,7 +242,8 @@ public final class StructureGenerator implements Runnable {
                     ${?useField}\
                     field(${?sensitive}repr=False, ${/sensitive}${defaultKey:L}=${defaultValue:L})\
                     ${/useField}
-                    ${?docs}""\"${docs:L}""\"${/docs}""", memberName, symbolProvider.toSymbol(member));
+                    ${?docs}""\"${docs:L}""\"${/docs}
+                    """, memberName, symbolProvider.toSymbol(member));
             writer.popState();
         }
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/PythonWriter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/PythonWriter.java
@@ -127,6 +127,8 @@ public final class PythonWriter extends SymbolWriter<PythonWriter, ImportDeclara
         pushState();
         writeInline("\"\"\"");
         runnable.run();
+        trimTrailingWhitespaces();
+        ensureNewline();
         write("\"\"\"");
         popState();
         return this;
@@ -140,6 +142,35 @@ public final class PythonWriter extends SymbolWriter<PythonWriter, ImportDeclara
      */
     public PythonWriter writeDocs(String docs) {
         writeDocs(() -> write(formatDocs(docs)));
+        return this;
+    }
+
+    /**
+     * Trims all trailing whitespace from the writer buffer.
+     *
+     * @return Returns the writer.
+     */
+    public PythonWriter trimTrailingWhitespaces() {
+        // Disable the writer formatting config to ensure toString()
+        // returns the unmodified state of the underlying StringBuilder
+        trimBlankLines(-1);
+        trimTrailingSpaces(false);
+
+        String current = super.toString();
+        int end = current.length() - 1;
+        while (end >= 0 && Character.isWhitespace(current.charAt(end))) {
+            end--;
+        }
+
+        String trailing = current.substring(end + 1);
+        if (!trailing.isEmpty()) {
+            unwrite(trailing);
+        }
+
+        // Re-enable the formatting config
+        trimBlankLines();
+        trimTrailingSpaces(true);
+
         return this;
     }
 


### PR DESCRIPTION
### Description

This PR removes `__init__.py` file generation in non-package directories such as `docs/*`.

### Examples

#### Bedrock Runtime

Before:
```
docs
├── client
│   ├── __init__.py
│   ├── apply_guardrail.rst
│   └── ...
├── models
│   ├── __init__.py
│   ├── AccessDeniedException.rst
│   └── ...
```

After:

```
docs
├── client
│   ├── apply_guardrail.rst
│   └── ...
├── models
│   ├── AccessDeniedException.rst
│   └── ...
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
