### PR TITLE
Implement Retry Strategy Resolver Pattern with Per-Client Caching

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -83,6 +83,8 @@ final class ClientGenerator implements Runnable {
                 }
             }
 
+            writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
+            writer.addImport("smithy_core.retries", "RetryStrategyResolver");
             writer.write("""
                     def __init__(self, config: $1T | None = None, plugins: list[$2T] | None = None):
                         self._config = config or $1T()
@@ -95,6 +97,8 @@ final class ClientGenerator implements Runnable {
 
                         for plugin in client_plugins:
                             plugin(self._config)
+
+                        self._retry_strategy_resolver = RetryStrategyResolver()
                     """, configSymbol, pluginSymbol, writer.consumer(w -> writeDefaultPlugins(w, defaultPlugins)));
 
             var topDownIndex = TopDownIndex.of(model);
@@ -187,6 +191,8 @@ final class ClientGenerator implements Runnable {
         writer.addImport("smithy_core.types", "TypedProperties");
         writer.addImport("smithy_core.aio.client", "RequestPipeline");
         writer.addImport("smithy_core.exceptions", "ExpectationNotMetError");
+        writer.addImport("smithy_core.retries", "RetryStrategyOptions");
+        writer.addImport("smithy_core.interfaces.retries", "RetryStrategy");
         writer.addStdlibImport("copy", "deepcopy");
 
         writer.write("""
@@ -200,6 +206,24 @@ final class ClientGenerator implements Runnable {
                     plugin(config)
                 if config.protocol is None or config.transport is None:
                     raise ExpectationNotMetError("protocol and transport MUST be set on the config to make calls.")
+
+                # Resolve retry strategy from config
+                if isinstance(config.retry_strategy, RetryStrategy):
+                    retry_strategy = config.retry_strategy
+                elif isinstance(config.retry_strategy, RetryStrategyOptions):
+                    retry_strategy = await self._retry_strategy_resolver.resolve_retry_strategy(
+                        options=config.retry_strategy
+                    )
+                elif config.retry_strategy is None:
+                    retry_strategy = await self._retry_strategy_resolver.resolve_retry_strategy(
+                        options=RetryStrategyOptions()
+                    )
+                else:
+                    raise TypeError(
+                        f"retry_strategy must be RetryStrategy, RetryStrategyOptions, or None, "
+                        f"got {type(config.retry_strategy).__name__}"
+                    )
+
                 pipeline = RequestPipeline(
                     protocol=config.protocol,
                     transport=config.transport
@@ -212,7 +236,7 @@ final class ClientGenerator implements Runnable {
                     auth_scheme_resolver=config.auth_scheme_resolver,
                     supported_auth_schemes=config.auth_schemes,
                     endpoint_resolver=config.endpoint_resolver,
-                    retry_strategy=config.retry_strategy,
+                    retry_strategy=retry_strategy,
                 )
                 """, writer.consumer(w -> writeDefaultPlugins(w, defaultPlugins)));
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -55,17 +55,20 @@ public final class ConfigGenerator implements Runnable {
             ConfigProperty.builder()
                     .name("retry_strategy")
                     .type(Symbol.builder()
-                            .name("RetryStrategy")
-                            .namespace("smithy_core.interfaces.retries", ".")
-                            .addDependency(SmithyPythonDependency.SMITHY_CORE)
+                            .name("RetryStrategy | RetryStrategyOptions")
+                            .addReference(Symbol.builder()
+                                    .name("RetryStrategy")
+                                    .namespace("smithy_core.interfaces.retries", ".")
+                                    .addDependency(SmithyPythonDependency.SMITHY_CORE)
+                                    .build())
+                            .addReference(Symbol.builder()
+                                    .name("RetryStrategyOptions")
+                                    .namespace("smithy_core.retries", ".")
+                                    .addDependency(SmithyPythonDependency.SMITHY_CORE)
+                                    .build())
                             .build())
-                    .documentation("The retry strategy for issuing retry tokens and computing retry delays.")
-                    .nullable(false)
-                    .initialize(writer -> {
-                        writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
-                        writer.addImport("smithy_core.retries", "SimpleRetryStrategy");
-                        writer.write("self.retry_strategy = retry_strategy or SimpleRetryStrategy()");
-                    })
+                    .documentation(
+                            "The retry strategy or options for configuring retry behavior. Can be either a configured RetryStrategy or RetryStrategyOptions to create one.")
                     .build(),
             ConfigProperty.builder()
                     .name("endpoint_uri")
@@ -379,7 +382,7 @@ public final class ConfigGenerator implements Runnable {
     }
 
     private void documentProperties(PythonWriter writer, Collection<ConfigProperty> properties) {
-        writer.writeDocs(() ->{
+        writer.writeDocs(() -> {
             var iter = properties.iterator();
             writer.write("\nConstructor.\n");
             while (iter.hasNext()) {

--- a/packages/smithy-core/src/smithy_core/interfaces/retries.py
+++ b/packages/smithy-core/src/smithy_core/interfaces/retries.py
@@ -55,6 +55,7 @@ class RetryToken(Protocol):
     """Delay in seconds to wait before the retry attempt."""
 
 
+@runtime_checkable
 class RetryStrategy(Protocol):
     """Issuer of :py:class:`RetryToken`s."""
 

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -46,14 +46,15 @@ class RetryStrategyResolver:
     def _create_retry_strategy(
         self, retry_mode: RetryStrategyType, max_attempts: int | None
     ) -> RetryStrategy:
-        kwargs: dict[str, Any] = (
-            {} if max_attempts is None else {"max_attempts": max_attempts}
-        )
+        kwargs = {"max_attempts": max_attempts}
+        filtered_kwargs: dict[str, Any] = {
+            k: v for k, v in kwargs.items() if v is not None
+        }
         match retry_mode:
             case "simple":
-                return SimpleRetryStrategy(**kwargs)
+                return SimpleRetryStrategy(**filtered_kwargs)
             case "standard":
-                return StandardRetryStrategy(**kwargs)
+                return StandardRetryStrategy(**filtered_kwargs)
             case _:
                 raise ValueError(f"Unknown retry mode: {retry_mode}")
 

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -46,17 +46,14 @@ class RetryStrategyResolver:
     def _create_retry_strategy(
         self, retry_mode: RetryStrategyType, max_attempts: int | None
     ) -> RetryStrategy:
+        kwargs: dict[str, Any] = (
+            {} if max_attempts is None else {"max_attempts": max_attempts}
+        )
         match retry_mode:
             case "simple":
-                if max_attempts is None:
-                    return SimpleRetryStrategy()
-                else:
-                    return SimpleRetryStrategy(max_attempts=max_attempts)
+                return SimpleRetryStrategy(**kwargs)
             case "standard":
-                if max_attempts is None:
-                    return StandardRetryStrategy()
-                else:
-                    return StandardRetryStrategy(max_attempts=max_attempts)
+                return StandardRetryStrategy(**kwargs)
             case _:
                 raise ValueError(f"Unknown retry mode: {retry_mode}")
 


### PR DESCRIPTION
### Summary
Introduces a resolver pattern for retry strategies that enables per-client caching and state management. This allows multiple operations from the same client to share a single retry strategy instance, which is important for strategies that maintain state across retries such as token buckets and rate limiters.

### Motivation
Previously, each operation created its own retry strategy instance, preventing state sharing across operations from the same client. This change implements a resolver-based approach.

### Key Changes
- Added a new `RetryStrategyResolver` protocol similar to `AuthSchemeResolver`.  This will be used for objects which will supply clients with retry strategies.
- Added a `CachingRetryStrategyResolver` which implements the protocol and returns a unique instance of a requested retry strategy object per unique combination of max attempts setting and retry mode setting.  This will get called by the client when no RetryStrategy is specified.  
- Added `RetryStrategyOptions` for users to configure their retry strategy mode and max attempts per client call.
