### PR TITLE
Consolidate retry strategy resolver logic

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -101,27 +101,6 @@ final class ClientGenerator implements Runnable {
                         self._retry_strategy_resolver = RetryStrategyResolver()
                     """, configSymbol, pluginSymbol, writer.consumer(w -> writeDefaultPlugins(w, defaultPlugins)));
 
-            writer.addImport("smithy_core.retries", "RetryStrategyOptions");
-            writer.addImport("smithy_core.interfaces.retries", "RetryStrategy");
-            writer.write("""
-                    async def _resolve_retry_strategy(self, retry_strategy: RetryStrategy | RetryStrategyOptions | None) -> RetryStrategy:
-                        if isinstance(retry_strategy, RetryStrategy):
-                            return retry_strategy
-                        elif isinstance(retry_strategy, RetryStrategyOptions):
-                            return await self._retry_strategy_resolver.resolve_retry_strategy(
-                                options=retry_strategy
-                            )
-                        elif retry_strategy is None:
-                            return await self._retry_strategy_resolver.resolve_retry_strategy(
-                                options=RetryStrategyOptions()
-                            )
-                        else:
-                            raise TypeError(
-                                f"retry_strategy must be RetryStrategy, RetryStrategyOptions, or None, "
-                                f"got {type(retry_strategy).__name__}"
-                            )
-                    """);
-
             var topDownIndex = TopDownIndex.of(model);
             var eventStreamIndex = EventStreamIndex.of(model);
             for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
@@ -228,7 +207,9 @@ final class ClientGenerator implements Runnable {
                 if config.protocol is None or config.transport is None:
                     raise ExpectationNotMetError("protocol and transport MUST be set on the config to make calls.")
 
-                retry_strategy = await self._resolve_retry_strategy(config.retry_strategy)
+                retry_strategy = await self._retry_strategy_resolver.resolve_retry_strategy(
+                    retry_strategy=config.retry_strategy
+                )
 
                 pipeline = RequestPipeline(
                     protocol=config.protocol,

--- a/packages/smithy-core/src/smithy_core/retries.py
+++ b/packages/smithy-core/src/smithy_core/retries.py
@@ -34,13 +34,24 @@ class RetryStrategyResolver:
     """
 
     async def resolve_retry_strategy(
-        self, *, options: RetryStrategyOptions
+        self, *, retry_strategy: RetryStrategy | RetryStrategyOptions | None
     ) -> RetryStrategy:
         """Resolve a retry strategy from the provided options, using cache when possible.
 
-        :param options: The retry strategy options to use for creating the strategy.
+        :param retry_strategy: An explicitly configured retry strategy or options for creating one.
         """
-        return self._create_retry_strategy(options.retry_mode, options.max_attempts)
+        if isinstance(retry_strategy, RetryStrategy):
+            return retry_strategy
+        elif retry_strategy is None:
+            retry_strategy = RetryStrategyOptions()
+        elif not isinstance(retry_strategy, RetryStrategyOptions):  # type: ignore[reportUnnecessaryIsInstance]
+            raise TypeError(
+                f"retry_strategy must be RetryStrategy, RetryStrategyOptions, or None, "
+                f"got {type(retry_strategy).__name__}"
+            )
+        return self._create_retry_strategy(
+            retry_strategy.retry_mode, retry_strategy.max_attempts
+        )
 
     @lru_cache
     def _create_retry_strategy(


### PR DESCRIPTION
*Description of changes:*
Consolidate retry strategy resolver logic from being generated once per operation to being shared in a centralized function for each operation.


A few files are attached to show the diff and testing on the generated clients: 
- [The generated Bedrock Runtime client](https://github.com/user-attachments/files/24059096/generated-bedrock-client.py)
- [A diff of the generated bedrock runtime client compared to the client in the aws-sdk-python](https://github.com/user-attachments/files/24059192/generated-client-diff.patch)
- [Testing script to confirm functionality](https://github.com/user-attachments/files/23726493/retry_strategy_test_script.py)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



