### PR TITLE
Update error messages for timeout errors

### DIFF
--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-20251124183509.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-20251124183509.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Improved default error message for instances of ClientTimeoutError cought in client.py"
+}

--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-20251124183509.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-20251124183509.json
@@ -1,4 +1,4 @@
 {
   "type": "enhancement",
-  "description": "Improved default error message for instances of ClientTimeoutError cought in client.py"
+  "description": "Improved default error message for instances of ClientTimeoutError."
 }

--- a/packages/smithy-core/src/smithy_core/aio/client.py
+++ b/packages/smithy-core/src/smithy_core/aio/client.py
@@ -469,8 +469,7 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
                     )
             except Exception as e:
                 if isinstance(e, self.transport.TIMEOUT_EXCEPTIONS):
-                    error_msg = str(e) or "A timeout error occurred."
-                    raise ClientTimeoutError(message=error_msg) from e
+                    raise ClientTimeoutError(message="A timeout error occurred.") from e
                 raise
 
             _LOGGER.debug("Received response: %s", transport_response)

--- a/packages/smithy-core/src/smithy_core/aio/client.py
+++ b/packages/smithy-core/src/smithy_core/aio/client.py
@@ -469,10 +469,8 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
                     )
             except Exception as e:
                 if isinstance(e, self.transport.TIMEOUT_EXCEPTIONS):
-                    error_msg = str(e) or type(e).__name__
-                    raise ClientTimeoutError(
-                        message=f"Client timeout occurred: {error_msg}"
-                    ) from e
+                    error_msg = str(e) or "A timeout error occurred."
+                    raise ClientTimeoutError(message=error_msg) from e
                 raise
 
             _LOGGER.debug("Received response: %s", transport_response)

--- a/packages/smithy-core/src/smithy_core/aio/client.py
+++ b/packages/smithy-core/src/smithy_core/aio/client.py
@@ -469,8 +469,9 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
                     )
             except Exception as e:
                 if isinstance(e, self.transport.TIMEOUT_EXCEPTIONS):
+                    error_msg = str(e) or type(e).__name__
                     raise ClientTimeoutError(
-                        message=f"Client timeout occurred: {e}"
+                        message=f"Client timeout occurred: {error_msg}"
                     ) from e
                 raise
 

--- a/packages/smithy-http/.changes/next-release/smithy-http-enhancement-20251122132342.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-enhancement-20251122132342.json
@@ -1,4 +1,4 @@
 {
   "type": "enhancement",
-  "description": "Improved error messaging for CRT-based timeout errors"
+  "description": "Improved error messaging for CRT-based timeout errors."
 }

--- a/packages/smithy-http/.changes/next-release/smithy-http-enhancement-20251122132342.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-enhancement-20251122132342.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Improved error messaging for CRT-based timeout errors"
+}

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -187,7 +187,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             return await self._await_response(crt_stream)
         except AwsCrtError as e:
             if e.name in self._TIMEOUT_ERROR_NAMES:
-                raise _CRTTimeoutError(f"CRT {e.name}: {e.message}")
+                raise _CRTTimeoutError(f"CRT {e.name}: {e.message}") from e
             raise
 
     async def _await_response(

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -187,7 +187,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             return await self._await_response(crt_stream)
         except AwsCrtError as e:
             if e.name in self._TIMEOUT_ERROR_NAMES:
-                raise _CRTTimeoutError() from e
+                raise _CRTTimeoutError(f"CRT {e.name}: {e.message}")
             raise
 
     async def _await_response(


### PR DESCRIPTION
## Description 
This PR improves timeout error messages to provide more actionable information for debugging. Currently, timeout errors sometimes display messages like "Client timeout occurred: " with no additional context.  This occurs when the error's string representation is an empty string.

For the CRT client, we updated _CRTTimeoutError to include the underlying AWS error name and message, changing errors from `Client timeout occurred:`  to `CRT AWS_IO_SOCKET_TIMEOUT: socket operation timed out.`

For all clients, we now default to using the exception's class name when the string representation is empty.  This can occur in aiohttp when the [`total` attribute](https://github.com/aio-libs/aiohttp/blob/72fadb8f1a56e8bff0fef23ccf02e2067cd87e41/aiohttp/client.py#L192) is set on the `ClientTimeout` class, which will [raise a TimeoutError](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/helpers.py#L727) with no additional info.  This updates the same blank error message to `A timeout error occurred.`.


Test file:
[timeout_exceptions_test.py](https://github.com/user-attachments/files/23918715/timeout_exceptions_test.py)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.