### PR TITLE
Add perms and pins to github actions

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -2,19 +2,20 @@ name: License Header Check
 
 on:
   pull_request:
-    branches:
-      - develop
   push:
     branches:
       - develop
+
+permissions:
+  contents: read
 
 jobs:
   check-license-header: 
     name: Check License Header
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: apache/skywalking-eyes/header@main
+      - uses: apache/skywalking-eyes/header@b7f8b351c2db8005972712d7efc0a15484a15bcb
         with:
           mode: check 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,14 @@
 name: CI
 
 on:
+    pull_request:
     push:
         branches:
           - develop
           - main
 
-    pull_request:
-        branches:
-          - develop
+permissions:
+  contents: read
 
 jobs:
   ci:
@@ -20,19 +20,19 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
         with:
           java-version: 17
           distribution: 'corretto'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -7,14 +7,21 @@ on:
     # Run at midnight (UTC) every wednesday
     - cron: "0 0 * * 3"
 
+permissions:
+  contents: read
+
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest
 
+    permissions:
+        # allow job to open a pull request with changes
+        pull-requests: write
+
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v2
+        uses: gradle-update/update-gradle-wrapper-action@512b1875f3b6270828abfe77b247d5895a2da1e5
         with:
           paths: codegen/**


### PR DESCRIPTION
*Description of changes:*
This PR moves our GHAs to explicitly declare permissions and use pins bringing us more inline with standards and protecting the workflows from unintentional scope changes with future updates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
