### PR TITLE
Remove version constraint for smithy-core in intermediate packages

### DIFF
--- a/packages/smithy-aws-event-stream/pyproject.toml
+++ b/packages/smithy-aws-event-stream/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-    "smithy-core~=0.2.0",
+    "smithy-core",
 ]
 
 [project.urls]

--- a/packages/smithy-http/pyproject.toml
+++ b/packages/smithy-http/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-    "smithy-core~=0.2.0",
+    "smithy-core",
 ]
 
 [project.urls]

--- a/packages/smithy-json/pyproject.toml
+++ b/packages/smithy-json/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "ijson>=3.3.0",
-    "smithy-core~=0.2.0",
+    "smithy-core",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

https://github.com/smithy-lang/smithy-python/pull/562 added minor version constraints on `smithy-core` using `~=` in intermediate packages such as `smithy-http` and `smithy-json`. This provided more strict compatibility, however, it also means that we have many unnecessary package bumps in the case where smithy-core receives a minor version bump.

This PR reverts the smithy-core constraint and we will rely on the constraints defined in smithy-aws-core and all AWS client packages. This prevents us from have to do unnecessary minor version bumps for intermediate packages in the future.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
