### PR TITLE
Use UUID instead of timestamp for changelog entry filenames

### DIFF
--- a/scripts/changelog/new-entry.py
+++ b/scripts/changelog/new-entry.py
@@ -7,7 +7,7 @@ Create new changelog entries for a specific package.
 
 import argparse
 import json
-from datetime import datetime
+import uuid
 from pathlib import Path
 
 PROJECT_ROOT_DIR = Path(__file__).resolve().parent.parent.parent
@@ -33,8 +33,8 @@ def create_change_entry(
     next_release_dir.mkdir(exist_ok=True)
 
     # Generate unique filename
-    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-    filename = f"{package_name}-{change_type}-{timestamp}.json"
+    unique_id = uuid.uuid4().hex
+    filename = f"{package_name}-{change_type}-{unique_id}.json"
 
     entry_data = {
         "type": change_type,


### PR DESCRIPTION
## Summary

Replace timestamp-based changelog entry filenames with UUID to prevent overwrites when generating multiple entries for the same package/type in automated workflows.

### Before

```
smithy-core-feature-20251224113018.json
```

### After

```
smithy-core-feature-c72e95f3e3df456c87d973f4b7bcd23e.json
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
