### PR TITLE
Smithy Release - December 30, 2025

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsPythonDependency.java
@@ -22,7 +22,7 @@ public class AwsPythonDependency {
      */
     public static final PythonDependency SMITHY_AWS_CORE = new PythonDependency(
             "smithy_aws_core",
-            "~=0.2.0",
+            "~=0.3.0",
             PythonDependency.Type.DEPENDENCY,
             false);
 }

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -15,5 +15,5 @@
 
 allprojects {
     group = "software.amazon.smithy.python"
-    version = "0.1.0"
+    version = "0.2.0"
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SmithyPythonDependency.java
@@ -22,7 +22,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_CORE = new PythonDependency(
             "smithy_core",
-            "~=0.2.0",
+            "~=0.3.0",
             Type.DEPENDENCY,
             false);
 
@@ -78,7 +78,7 @@ public final class SmithyPythonDependency {
      */
     public static final PythonDependency SMITHY_AWS_CORE = new PythonDependency(
             "smithy_aws_core",
-            "~=0.2.0",
+            "~=0.3.0",
             Type.DEPENDENCY,
             false);
 

--- a/packages/smithy-aws-core/.changes/0.3.0.json
+++ b/packages/smithy-aws-core/.changes/0.3.0.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "dependency",
+      "description": "Bump `smithy-core` from `~=0.2.0` to `~=0.3.0`."
+    }
+  ]
+}

--- a/packages/smithy-aws-core/CHANGELOG.md
+++ b/packages/smithy-aws-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.0
+
+### Dependencies
+* Bump `smithy-core` from `~=0.2.0` to `~=0.3.0`.
+
 ## v0.2.0
 
 ### Dependencies

--- a/packages/smithy-aws-core/pyproject.toml
+++ b/packages/smithy-aws-core/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-    "smithy-core~=0.2.0",
+    "smithy-core~=0.3.0",
     "smithy-http~=0.3.0",
     "aws-sdk-signers~=0.1.0"
 ]

--- a/packages/smithy-aws-core/src/smithy_aws_core/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/packages/smithy-aws-event-stream/.changes/0.2.1.json
+++ b/packages/smithy-aws-event-stream/.changes/0.2.1.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "dependency",
+      "description": "Removed strict pinning on `smithy-core` in favor of client managed versions."
+    }
+  ]
+}

--- a/packages/smithy-aws-event-stream/CHANGELOG.md
+++ b/packages/smithy-aws-event-stream/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.1
+
+### Dependencies
+* Removed strict pinning on `smithy-core` in favor of client managed versions.
+
 ## v0.2.0
 
 ### Dependencies

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/__init__.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/packages/smithy-core/.changes/0.3.0.json
+++ b/packages/smithy-core/.changes/0.3.0.json
@@ -1,0 +1,12 @@
+{
+  "changes": [
+    {
+      "type": "enhancement",
+      "description": "Improved default error message for instances of ClientTimeoutError."
+    },
+    {
+      "type": "breaking",
+      "description": "Refactored `resolve_retry_strategy` to avoid code duplication per operation."
+    }
+  ]
+}

--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-20251124183509.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-20251124183509.json
@@ -1,4 +1,0 @@
-{
-  "type": "enhancement",
-  "description": "Improved default error message for instances of ClientTimeoutError."
-}

--- a/packages/smithy-core/CHANGELOG.md
+++ b/packages/smithy-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.3.0
+
+### Breaking Changes
+* Refactored `resolve_retry_strategy` to avoid code duplication per operation.
+
+### Enhancements
+* Improved default error message for instances of ClientTimeoutError.
+
 ## v0.2.0
 
 ### Features

--- a/packages/smithy-core/src/smithy_core/__init__.py
+++ b/packages/smithy-core/src/smithy_core/__init__.py
@@ -8,7 +8,7 @@ from urllib.parse import urlunparse
 from . import interfaces, rfc3986
 from .exceptions import SmithyError
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 
 class HostType(Enum):

--- a/packages/smithy-http/.changes/0.3.1.json
+++ b/packages/smithy-http/.changes/0.3.1.json
@@ -1,0 +1,12 @@
+{
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed empty error messaging for CRT-based timeout errors."
+    },
+    {
+      "type": "dependency",
+      "description": "Removed strict pinning on `smithy-core` in favor of client managed versions."
+    }
+  ]
+}

--- a/packages/smithy-http/.changes/next-release/smithy-http-enhancement-20251122132342.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-enhancement-20251122132342.json
@@ -1,4 +1,0 @@
-{
-  "type": "enhancement",
-  "description": "Improved error messaging for CRT-based timeout errors."
-}

--- a/packages/smithy-http/CHANGELOG.md
+++ b/packages/smithy-http/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.3.1
+
+### Bug fixes
+* Fixed empty error messaging for CRT-based timeout errors.
+
+### Dependencies
+* Removed strict pinning on `smithy-core` in favor of client managed versions.
+
 ## v0.3.0
 
 ### Features

--- a/packages/smithy-http/src/smithy_http/__init__.py
+++ b/packages/smithy-http/src/smithy_http/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Iterator
 from . import interfaces
 from .interfaces import FieldPosition
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 
 class Field(interfaces.Field):

--- a/packages/smithy-json/.changes/0.2.1.json
+++ b/packages/smithy-json/.changes/0.2.1.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    {
+      "type": "dependency",
+      "description": "Removed strict pinning on `smithy-core` in favor of client managed versions."
+    }
+  ]
+}

--- a/packages/smithy-json/CHANGELOG.md
+++ b/packages/smithy-json/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.1
+
+### Dependencies
+* Removed strict pinning on `smithy-core` in favor of client managed versions.
+
 ## v0.2.0
 
 ### Dependencies

--- a/packages/smithy-json/src/smithy_json/__init__.py
+++ b/packages/smithy-json/src/smithy_json/__init__.py
@@ -13,7 +13,7 @@ from ._private.documents import JSONDocument
 from ._private.serializers import JSONShapeSerializer as _JSONShapeSerializer
 from .settings import JSONSettings
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = ("JSONCodec", "JSONDocument", "JSONSettings")
 
 


### PR DESCRIPTION
This is a set of changes to release the 0.3.0 versions of `smithy-core` and `smithy-aws-core`, along with their dependencies. This will also bring the code generator up to date so that the next set of clients we release will pull in the minor version updates.

Changes for `smithy-aws-event-stream`, `smithy-http`, and `smithy-json` are being done as patch versions which can be picked up immediately as they're bugfixes or minor stylistic enhancements.

# Changelogs

## smithy-core 0.3.0

### Breaking Changes
* Refactored `resolve_retry_strategy` to avoid code duplication per operation.

### Enhancements
* Improved default error message for instances of ClientTimeoutError.

## smithy-aws-core 0.3.0

### Dependencies
* Bump `smithy-core` from `~=0.2.0` to `~=0.3.0`.

## smithy-aws-event-stream 0.2.1

### Dependencies
* Removed strict pinning on `smithy-core` in favor of client managed versions.

## smithy-http 0.3.1

### Bug fixes
* Fixed empty error messaging for CRT-based timeout errors.

### Dependencies
* Removed strict pinning on `smithy-core` in favor of client managed versions.

## smithy-json 0.2.1

### Dependencies
* Removed strict pinning on `smithy-core` in favor of client managed versions.