### PR TITLE
Add a config property descriptor along with a custom resolver and validators

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/config/custom_resolvers.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/custom_resolvers.py
@@ -5,7 +5,7 @@ from typing import cast
 from smithy_core.config.resolver import ConfigResolver
 from smithy_core.retries import RetryStrategyOptions, RetryStrategyType
 
-from smithy_aws_core.config.validators import validate_retry_mode
+from smithy_aws_core.config.validators import validate_max_attempts, validate_retry_mode
 
 
 def resolve_retry_strategy(
@@ -20,10 +20,10 @@ def resolve_retry_strategy(
 
     :param resolver: The config resolver to use for resolution
 
-    :returns: Tuple of (RetryStrategyOptions or None, source_name or None).
-        Returns (None, None) if neither retry_mode nor max_attempts is set.
+    :returns: Tuple of (RetryStrategyOptions, source_name) if both retry_mode and max_attempts
+        are resolved. Returns (None, None) if either value is missing.
 
-        For mixed sources, the source string includes both component sources:
+        For mixed sources, the source name includes both component sources:
         "retry_mode=environment, max_attempts=config_file"
     """
     # Get retry_mode
@@ -32,21 +32,20 @@ def resolve_retry_strategy(
     # Get max_attempts
     max_attempts, attempts_source = resolver.get("max_attempts")
 
-    # If neither is set, return None
-    if retry_mode is None and max_attempts is None:
-        return (None, None)
+    if retry_mode is None or max_attempts is None:
+        return None, None
 
-    if retry_mode is not None:
-        retry_mode = validate_retry_mode(retry_mode, mode_source)
-        retry_mode = cast(RetryStrategyType, retry_mode)
+    retry_mode = validate_retry_mode(retry_mode, mode_source)
+    retry_mode = cast(RetryStrategyType, retry_mode)
 
-    # Construct options with defaults
+    max_attempts = validate_max_attempts(max_attempts, attempts_source)
+
     options = RetryStrategyOptions(
-        retry_mode=retry_mode or "standard",
-        max_attempts=int(max_attempts) if max_attempts else None,
+        retry_mode=retry_mode,
+        max_attempts=max_attempts,
     )
 
     # Construct mixed source string showing where each component came from
-    source = f"retry_mode={mode_source or 'unresolved'}, max_attempts={attempts_source or 'unresolved'}"
+    source = f"retry_mode={mode_source}, max_attempts={attempts_source}"
 
     return (options, source)

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/custom_resolvers.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/custom_resolvers.py
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import cast
+
+from smithy_core.config.resolver import ConfigResolver
+from smithy_core.retries import RetryStrategyOptions, RetryStrategyType
+
+from smithy_aws_core.config.validators import validate_retry_mode
+
+
+def resolve_retry_strategy(
+    resolver: ConfigResolver,
+) -> tuple[RetryStrategyOptions | None, str | None]:
+    """Resolve retry strategy from multiple config keys.
+
+    Resolves both retry_mode and max_attempts from sources and constructs
+    a RetryStrategyOptions object. This allows the retry strategy to be
+    configured from multiple sources. Example: retry_mode from config file and
+    max_attempts from environment variables.
+
+    :param resolver: The config resolver to use for resolution
+
+    :returns: Tuple of (RetryStrategyOptions or None, source_name or None).
+        Returns (None, None) if neither retry_mode nor max_attempts is set.
+
+        For mixed sources, the source string includes both component sources:
+        "retry_mode=environment, max_attempts=config_file"
+    """
+    # Get retry_mode
+    retry_mode, mode_source = resolver.get("retry_mode")
+
+    # Get max_attempts
+    max_attempts, attempts_source = resolver.get("max_attempts")
+
+    # If neither is set, return None
+    if retry_mode is None and max_attempts is None:
+        return (None, None)
+
+    if retry_mode is not None:
+        retry_mode = validate_retry_mode(retry_mode, mode_source)
+        retry_mode = cast(RetryStrategyType, retry_mode)
+
+    # Construct options with defaults
+    options = RetryStrategyOptions(
+        retry_mode=retry_mode or "standard",
+        max_attempts=int(max_attempts) if max_attempts else None,
+    )
+
+    # Construct mixed source string showing where each component came from
+    source = f"retry_mode={mode_source or 'unresolved'}, max_attempts={attempts_source or 'unresolved'}"
+
+    return (options, source)

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/custom_resolvers.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/custom_resolvers.py
@@ -1,9 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import cast
 
 from smithy_core.config.resolver import ConfigResolver
-from smithy_core.retries import RetryStrategyOptions, RetryStrategyType
+from smithy_core.retries import RetryStrategyOptions
 
 from smithy_aws_core.config.validators import validate_max_attempts, validate_retry_mode
 
@@ -21,31 +20,31 @@ def resolve_retry_strategy(
     :param resolver: The config resolver to use for resolution
 
     :returns: Tuple of (RetryStrategyOptions, source_name) if both retry_mode and max_attempts
-        are resolved. Returns (None, None) if either value is missing.
+        are resolved. Returns (None, None) if both values are missing.
 
         For mixed sources, the source name includes both component sources:
         "retry_mode=environment, max_attempts=config_file"
     """
-    # Get retry_mode
+
     retry_mode, mode_source = resolver.get("retry_mode")
 
-    # Get max_attempts
     max_attempts, attempts_source = resolver.get("max_attempts")
 
-    if retry_mode is None or max_attempts is None:
+    if retry_mode is None and max_attempts is None:
         return None, None
 
-    retry_mode = validate_retry_mode(retry_mode, mode_source)
-    retry_mode = cast(RetryStrategyType, retry_mode)
+    if retry_mode is not None:
+        retry_mode = validate_retry_mode(retry_mode, mode_source)
 
-    max_attempts = validate_max_attempts(max_attempts, attempts_source)
+    if max_attempts is not None:
+        max_attempts = validate_max_attempts(max_attempts, attempts_source)
 
     options = RetryStrategyOptions(
-        retry_mode=retry_mode,
-        max_attempts=max_attempts,
+        retry_mode=retry_mode or "standard",  # type: ignore
+        max_attempts=max_attempts,  # Can be None because strategy will use its default
     )
 
     # Construct mixed source string showing where each component came from
-    source = f"retry_mode={mode_source}, max_attempts={attempts_source}"
+    source = f"retry_mode={mode_source or 'default'}, max_attempts={attempts_source or 'default'}"
 
     return (options, source)

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/custom_resolvers.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/custom_resolvers.py
@@ -40,7 +40,7 @@ def resolve_retry_strategy(
         max_attempts = validate_max_attempts(max_attempts, attempts_source)
 
     options = RetryStrategyOptions(
-        retry_mode=retry_mode or "standard",  # type: ignore
+        retry_mode=retry_mode,  # type: ignore
         max_attempts=max_attempts,  # Can be None because strategy will use its default
     )
 

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
@@ -23,41 +23,37 @@ class ConfigValidationError(ValueError):
         super().__init__(msg)
 
 
-def validate_region(region_name: Any, source: str | None = None) -> str | None:
-    """Validate AWS region format.
+def validate_host(host_name: Any, source: str | None = None) -> str:
+    """Validate host name format.
 
-    Valid formats:
-    - us-east-1, us-west-2, eu-west-1, etc.
-    - Pattern: {partition}-{region}-{number}
-
-    :param region_name: The region value to validate
+    :param host_name: The value to validate
     :param source: The config source that provided this value
 
-    :returns: The validated region string, or None if value is None
+    :returns: The validated value
 
-    :raises ConfigValidationError: If the region format is invalid
+    :raises ConfigValidationError: If the value format is invalid
     """
-    if not isinstance(region_name, str):
+    if not isinstance(host_name, str):
         raise ConfigValidationError(
-            "region",
-            region_name,
-            f"Region must be a string, got {type(region_name).__name__}",
+            "host",
+            host_name,
+            f"Host must be a string, got {type(host_name).__name__}",
             source,
         )
 
     pattern = r"^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)$"
 
-    if not re.match(pattern, region_name):
+    if not re.match(pattern, host_name):
         raise ConfigValidationError(
-            "region",
-            region_name,
-            "Region doesn't match the pattern (e.g., 'us-west-2', 'eu-central-1')",
+            "host",
+            host_name,
+            "Host doesn't match the pattern.",
             source,
         )
-    return region_name
+    return host_name
 
 
-def validate_retry_mode(retry_mode: Any, source: str | None = None) -> str | None:
+def validate_retry_mode(retry_mode: Any, source: str | None = None) -> str:
     """Validate retry mode.
 
     Valid values: 'standard', 'simple'
@@ -65,7 +61,7 @@ def validate_retry_mode(retry_mode: Any, source: str | None = None) -> str | Non
     :param retry_mode: The retry mode value to validate
     :param source: The source that provided this value
 
-    :returns: The validated retry mode string, or None if value is None
+    :returns: The validated retry mode string
 
     :raises: ConfigValidationError: If the retry mode is invalid
     """
@@ -77,40 +73,59 @@ def validate_retry_mode(retry_mode: Any, source: str | None = None) -> str | Non
             source,
         )
 
-    valid_modes = set(get_args(RetryStrategyType))
+    valid_modes = get_args(RetryStrategyType)
 
     if retry_mode not in valid_modes:
         raise ConfigValidationError(
             "retry_mode",
             retry_mode,
-            f"Retry mode must be one of {RetryStrategyType}, got {retry_mode}",
+            f"Retry mode must be one of {valid_modes}, got {retry_mode}",
             source,
         )
 
     return retry_mode
 
 
-def validate_retry_strategy(value: Any, source: str | None = None) -> Any:
+def validate_max_attempts(max_attempts: str | int, source: str | None = None) -> int:
+    """Validate and convert max_attempts to integer.
+
+    :param max_attempts: The max attempts value (string or int)
+    :param source: The source that provided this value
+
+    :returns: The validated max_attempts as an integer
+
+    :raises ConfigValidationError: If the value cannot be converted to an integer
+    """
+    try:
+        return int(max_attempts)
+    except (ValueError, TypeError):
+        raise ConfigValidationError(
+            "max_attempts",
+            max_attempts,
+            f"max_attempts must be a number, got {type(max_attempts).__name__}",
+            source,
+        )
+
+
+def validate_retry_strategy(
+    value: Any, source: str | None = None
+) -> RetryStrategy | RetryStrategyOptions:
     """Validate retry strategy configuration.
 
-    :param value: The retry strategy value to validate (None is allowed and returns None)
-    :param source: The source that provided this value (for error messages)
+    :param value: The retry strategy value to validate
+    :param source: The source that provided this value
 
     :returns: The validated retry strategy (RetryStrategy or RetryStrategyOptions)
 
     :raises: ConfigValidationError: If the value is not a valid retry strategy type
     """
-    # Allow RetryStrategy instances
-    if isinstance(value, RetryStrategy):
-        return value
 
-    # Allow RetryStrategyOptions instances
-    if isinstance(value, RetryStrategyOptions):
+    if isinstance(value, RetryStrategy | RetryStrategyOptions):
         return value
 
     raise ConfigValidationError(
         "retry_strategy",
         value,
-        f"Retry strategy must be a RetryStrategy or RetryStrategyOptions got {type(value).__name__}",
+        f"retry_strategy must be RetryStrategy or RetryStrategyOptions, got {type(value).__name__}",
         source,
     )

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
@@ -23,7 +23,7 @@ class ConfigValidationError(ValueError):
         super().__init__(msg)
 
 
-def validate_host(host_name: Any, source: str | None = None) -> str:
+def validate_host_label(host_label: Any, source: str | None = None) -> str:
     """Validate host name format.
 
     :param host_name: The value to validate
@@ -33,24 +33,24 @@ def validate_host(host_name: Any, source: str | None = None) -> str:
 
     :raises ConfigValidationError: If the value format is invalid
     """
-    if not isinstance(host_name, str):
+    if not isinstance(host_label, str):
         raise ConfigValidationError(
-            "host",
-            host_name,
-            f"Host must be a string, got {type(host_name).__name__}",
+            "host_label",
+            host_label,
+            f"host_label must be a string, got {type(host_label).__name__}",
             source,
         )
 
-    pattern = r"^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)$"
+    pattern = r"^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{1,63}(?<!-)$"
 
-    if not re.match(pattern, host_name):
+    if not re.match(pattern, host_label):
         raise ConfigValidationError(
             "host",
-            host_name,
-            "Host doesn't match the pattern.",
+            host_label,
+            "host_label doesn't match the pattern.",
             source,
         )
-    return host_name
+    return host_label
 
 
 def validate_retry_mode(retry_mode: Any, source: str | None = None) -> str:

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
@@ -94,10 +94,10 @@ def validate_max_attempts(max_attempts: str | int, source: str | None = None) ->
 
     :returns: The validated max_attempts as an integer
 
-    :raises ConfigValidationError: If the value cannot be converted to an integer
+    :raises ConfigValidationError: If the value is less than 1 or cannot be converted to an integer
     """
     try:
-        return int(max_attempts)
+        max_attempts = int(max_attempts)
     except (ValueError, TypeError):
         raise ConfigValidationError(
             "max_attempts",
@@ -105,6 +105,16 @@ def validate_max_attempts(max_attempts: str | int, source: str | None = None) ->
             f"max_attempts must be a number, got {type(max_attempts).__name__}",
             source,
         )
+
+    if max_attempts < 1:
+        raise ConfigValidationError(
+            "max_attempts",
+            max_attempts,
+            f"max_attempts must be a positive integer, got {max_attempts}",
+            source,
+        )
+
+    return max_attempts
 
 
 def validate_retry_strategy(

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
@@ -1,0 +1,144 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar
+
+from smithy_core.interfaces.retries import RetryStrategy
+from smithy_core.retries import RetryStrategyOptions
+
+T = TypeVar("T")
+
+
+def allow_none(validator: Callable[[Any, str | None], T]) -> Callable[..., T | None]:
+    """Decorator that allows None values to pass through validators.
+
+    If the value is None, returns None without calling the validator.
+    Otherwise, calls the validator with the value.
+
+    :param validator: The validation function to wrap
+
+    :returns: Wrapped validator that allows None values
+    """
+
+    @wraps(validator)
+    def wrapper(value: Any, source: str | None = None) -> T | None:
+        if value is None:
+            return None
+        return validator(value, source)
+
+    return wrapper
+
+
+class ConfigValidationError(ValueError):
+    """Raised when a configuration value fails validation."""
+
+    def __init__(self, key: str, value: Any, reason: str, source: str | None = None):
+        self.key = key
+        self.value = value
+        self.reason = reason
+        self.source = source
+
+        msg = f"Invalid value for '{key}': {value!r}. {reason}"
+        if source:
+            msg += f" (from source: {source})"
+        super().__init__(msg)
+
+
+@allow_none
+def validate_region(value: Any, source: str | None = None) -> str | None:
+    """Validate AWS region format.
+
+    Valid formats:
+    - us-east-1, us-west-2, eu-west-1, etc.
+    - Pattern: {partition}-{region}-{number}
+
+    :param value: The region value to validate
+    :param source: The config source that provided this value
+
+    :returns: The validated region string, or None if value is None
+
+    :raises ConfigValidationError: If the region format is invalid
+    """
+    if not isinstance(value, str):
+        raise ConfigValidationError(
+            "region",
+            value,
+            f"Region must be a string, got {type(value).__name__}",
+            source,
+        )
+
+    # AWS region pattern: partition-region-number
+    pattern = r"^[a-z]{2}-[a-z]+-\d+$"
+
+    if not re.match(pattern, value):
+        raise ConfigValidationError(
+            "region",
+            value,
+            "Region must match pattern '{partition}-{region}-{number}' (e.g., 'us-west-2', 'eu-central-1')",
+            source,
+        )
+    return value
+
+
+@allow_none
+def validate_retry_mode(value: Any, source: str | None = None) -> str | None:
+    """Validate retry mode.
+
+    Valid values: 'standard', 'simple'
+
+    :param value: The retry mode value to validate
+    :param source: The source that provided this value
+
+    :returns: The validated retry mode string, or None if value is None
+
+    :raises: ConfigValidationError: If the retry mode is invalid
+    """
+    if not isinstance(value, str):
+        raise ConfigValidationError(
+            "retry_mode",
+            value,
+            f"Retry mode must be a string, got {type(value).__name__}",
+            source,
+        )
+
+    valid_modes = {"standard", "simple"}
+
+    if value not in valid_modes:
+        raise ConfigValidationError(
+            "retry_mode",
+            value,
+            f"Retry mode must be one of {valid_modes}, got {value!r}",
+            source,
+        )
+
+    return value
+
+
+@allow_none
+def validate_retry_strategy(value: Any, source: str | None = None) -> Any:
+    """Validate retry strategy configuration.
+
+    :param value: The retry strategy value to validate (None is allowed and returns None)
+    :param source: The source that provided this value (for error messages)
+
+    :returns: The validated retry strategy (RetryStrategy or RetryStrategyOptions)
+
+    :raises: ConfigValidationError: If the value is not a valid retry strategy type
+    """
+    # Allow RetryStrategy instances
+    if isinstance(value, RetryStrategy):
+        return value
+
+    # Allow RetryStrategyOptions instances
+    if isinstance(value, RetryStrategyOptions):
+        return value
+
+    raise ConfigValidationError(
+        "retry_strategy",
+        value,
+        f"Retry strategy must be a RetryStrategy or RetryStrategyOptions got {type(value).__name__}",
+        source,
+    )

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
@@ -23,37 +23,29 @@ class ConfigValidationError(ValueError):
         super().__init__(msg)
 
 
-def validate_host_label(host_label: Any, source: str | None = None) -> str:
-    """Validate host name format.
+def validate_region(region: str, source: str | None = None) -> str:
+    """Validate region name format.
 
-    :param host_name: The value to validate
+    :param region: The value to validate
     :param source: The config source that provided this value
 
     :returns: The validated value
 
     :raises ConfigValidationError: If the value format is invalid
     """
-    if not isinstance(host_label, str):
-        raise ConfigValidationError(
-            "host_label",
-            host_label,
-            f"host_label must be a string, got {type(host_label).__name__}",
-            source,
-        )
-
     pattern = r"^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{1,63}(?<!-)$"
 
-    if not re.match(pattern, host_label):
+    if not re.match(pattern, region):
         raise ConfigValidationError(
-            "host",
-            host_label,
-            "host_label doesn't match the pattern.",
+            "region",
+            region,
+            "region doesn't match the pattern.",
             source,
         )
-    return host_label
+    return region
 
 
-def validate_retry_mode(retry_mode: Any, source: str | None = None) -> str:
+def validate_retry_mode(retry_mode: str, source: str | None = None) -> str:
     """Validate retry mode.
 
     Valid values: 'standard', 'simple'
@@ -65,13 +57,6 @@ def validate_retry_mode(retry_mode: Any, source: str | None = None) -> str:
 
     :raises: ConfigValidationError: If the retry mode is invalid
     """
-    if not isinstance(retry_mode, str):
-        raise ConfigValidationError(
-            "retry_mode",
-            retry_mode,
-            f"Retry mode must be a string, got {type(retry_mode).__name__}",
-            source,
-        )
 
     valid_modes = get_args(RetryStrategyType)
 
@@ -79,7 +64,7 @@ def validate_retry_mode(retry_mode: Any, source: str | None = None) -> str:
         raise ConfigValidationError(
             "retry_mode",
             retry_mode,
-            f"Retry mode must be one of {valid_modes}, got {retry_mode}",
+            f"retry_mode must be one of {valid_modes}, got {retry_mode}",
             source,
         )
 

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
@@ -2,34 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from collections.abc import Callable
-from functools import wraps
-from typing import Any, TypeVar
+from typing import Any, get_args
 
 from smithy_core.interfaces.retries import RetryStrategy
-from smithy_core.retries import RetryStrategyOptions
-
-T = TypeVar("T")
-
-
-def allow_none(validator: Callable[[Any, str | None], T]) -> Callable[..., T | None]:
-    """Decorator that allows None values to pass through validators.
-
-    If the value is None, returns None without calling the validator.
-    Otherwise, calls the validator with the value.
-
-    :param validator: The validation function to wrap
-
-    :returns: Wrapped validator that allows None values
-    """
-
-    @wraps(validator)
-    def wrapper(value: Any, source: str | None = None) -> T | None:
-        if value is None:
-            return None
-        return validator(value, source)
-
-    return wrapper
+from smithy_core.retries import RetryStrategyOptions, RetryStrategyType
 
 
 class ConfigValidationError(ValueError):
@@ -47,77 +23,73 @@ class ConfigValidationError(ValueError):
         super().__init__(msg)
 
 
-@allow_none
-def validate_region(value: Any, source: str | None = None) -> str | None:
+def validate_region(region_name: Any, source: str | None = None) -> str | None:
     """Validate AWS region format.
 
     Valid formats:
     - us-east-1, us-west-2, eu-west-1, etc.
     - Pattern: {partition}-{region}-{number}
 
-    :param value: The region value to validate
+    :param region_name: The region value to validate
     :param source: The config source that provided this value
 
     :returns: The validated region string, or None if value is None
 
     :raises ConfigValidationError: If the region format is invalid
     """
-    if not isinstance(value, str):
+    if not isinstance(region_name, str):
         raise ConfigValidationError(
             "region",
-            value,
-            f"Region must be a string, got {type(value).__name__}",
+            region_name,
+            f"Region must be a string, got {type(region_name).__name__}",
             source,
         )
 
-    # AWS region pattern: partition-region-number
-    pattern = r"^[a-z]{2}-[a-z]+-\d+$"
+    pattern = r"^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)$"
 
-    if not re.match(pattern, value):
+    if not re.match(pattern, region_name):
         raise ConfigValidationError(
             "region",
-            value,
-            "Region must match pattern '{partition}-{region}-{number}' (e.g., 'us-west-2', 'eu-central-1')",
+            region_name,
+            "Region doesn't match the pattern (e.g., 'us-west-2', 'eu-central-1')",
             source,
         )
-    return value
+    return region_name
 
 
-@allow_none
-def validate_retry_mode(value: Any, source: str | None = None) -> str | None:
+def validate_retry_mode(retry_mode: Any, source: str | None = None) -> str | None:
     """Validate retry mode.
 
     Valid values: 'standard', 'simple'
 
-    :param value: The retry mode value to validate
+    :param retry_mode: The retry mode value to validate
     :param source: The source that provided this value
 
     :returns: The validated retry mode string, or None if value is None
 
     :raises: ConfigValidationError: If the retry mode is invalid
     """
-    if not isinstance(value, str):
+    if not isinstance(retry_mode, str):
         raise ConfigValidationError(
             "retry_mode",
-            value,
-            f"Retry mode must be a string, got {type(value).__name__}",
+            retry_mode,
+            f"Retry mode must be a string, got {type(retry_mode).__name__}",
             source,
         )
 
-    valid_modes = {"standard", "simple"}
+    valid_modes = set(get_args(RetryStrategyType))
 
-    if value not in valid_modes:
+    if retry_mode not in valid_modes:
         raise ConfigValidationError(
             "retry_mode",
-            value,
-            f"Retry mode must be one of {valid_modes}, got {value!r}",
+            retry_mode,
+            f"Retry mode must be one of {RetryStrategyType}, got {retry_mode}",
             source,
         )
 
-    return value
+    return retry_mode
 
 
-@allow_none
 def validate_retry_strategy(value: Any, source: str | None = None) -> Any:
     """Validate retry strategy configuration.
 

--- a/packages/smithy-aws-core/tests/unit/config/test_custom_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_custom_resolver.py
@@ -1,0 +1,109 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for custom resolver functions."""
+
+from typing import Any
+
+from smithy_aws_core.config.custom_resolvers import resolve_retry_strategy
+from smithy_core.config.resolver import ConfigResolver
+from smithy_core.retries import RetryStrategyOptions
+
+
+class StubSource:
+    """A simple ConfigSource implementation for testing."""
+
+    def __init__(self, source_name: str, data: dict[str, Any] | None = None) -> None:
+        self._name = source_name
+        self._data = data or {}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get(self, key: str) -> Any | None:
+        return self._data.get(key)
+
+
+class TestResolveCustomResolverRetryStrategy:
+    """Test suite for complex configuration resolution"""
+
+    def test_resolves_when_only_retry_mode_set(self) -> None:
+        source = StubSource("environment", {"retry_mode": "standard"})
+        resolver = ConfigResolver(sources=[source])
+
+        result, source_name = resolve_retry_strategy(resolver)
+
+        assert isinstance(result, RetryStrategyOptions)
+        assert result.retry_mode == "standard"
+        assert result.max_attempts is None
+        assert source_name == "retry_mode=environment, max_attempts=unresolved"
+
+    def test_resolves_when_only_max_attempts_set(self) -> None:
+        source = StubSource("environment", {"max_attempts": "5"})
+        resolver = ConfigResolver(sources=[source])
+
+        result, source_name = resolve_retry_strategy(resolver)
+
+        assert isinstance(result, RetryStrategyOptions)
+        assert result.retry_mode == "standard"
+        assert result.max_attempts == 5
+        assert source_name == "retry_mode=unresolved, max_attempts=environment"
+
+    def test_resolves_from_both_values_when_set(self) -> None:
+        # When both retry mode and max attempts are set
+        # It should use source names for both values
+        source = StubSource(
+            "environment", {"retry_mode": "standard", "max_attempts": "3"}
+        )
+        resolver = ConfigResolver(sources=[source])
+
+        result, source_name = resolve_retry_strategy(resolver)
+
+        assert isinstance(result, RetryStrategyOptions)
+        assert result.retry_mode == "standard"
+        assert result.max_attempts == 3
+        assert source_name == "retry_mode=environment, max_attempts=environment"
+
+    def test_returns_none_when_neither_value_set(self) -> None:
+        source = StubSource("environment", {})
+        resolver = ConfigResolver(sources=[source])
+
+        result, source_name = resolve_retry_strategy(resolver)
+        # It should return (None, None) when values not set
+        assert result is None
+        assert source_name is None
+
+    def test_tracks_different_sources_for_each_component(self) -> None:
+        source1 = StubSource("environment", {"retry_mode": "standard"})
+        source2 = StubSource("config_file", {"max_attempts": "5"})
+        resolver = ConfigResolver(sources=[source1, source2])
+
+        result, source_name = resolve_retry_strategy(resolver)
+
+        assert isinstance(result, RetryStrategyOptions)
+        assert result.retry_mode == "standard"
+        assert result.max_attempts == 5
+        assert source_name == "retry_mode=environment, max_attempts=config_file"
+
+    def test_tracks_source_when_only_max_attempts_set(self) -> None:
+        source1 = StubSource("environment", {})
+        source2 = StubSource("config_file", {"max_attempts": "5"})
+        resolver = ConfigResolver(sources=[source1, source2])
+
+        result, source_name = resolve_retry_strategy(resolver)
+
+        assert isinstance(result, RetryStrategyOptions)
+        assert result.retry_mode == "standard"  # Default
+        assert result.max_attempts == 5
+        assert source_name == "retry_mode=unresolved, max_attempts=config_file"
+
+    def test_converts_max_attempts_string_to_int(self) -> None:
+        source = StubSource("environment", {"max_attempts": "10"})
+        resolver = ConfigResolver(sources=[source])
+
+        result, _ = resolve_retry_strategy(resolver)
+
+        assert isinstance(result, RetryStrategyOptions)
+        assert result.max_attempts == 10
+        assert isinstance(result.max_attempts, int)

--- a/packages/smithy-aws-core/tests/unit/config/test_custom_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_custom_resolver.py
@@ -65,23 +65,27 @@ class TestResolveCustomResolverRetryStrategy:
         assert result.max_attempts == 10
         assert isinstance(result.max_attempts, int)
 
-    def test_returns_none_when_only_retry_mode_set(self) -> None:
+    def test_returns_strategy_when_only_retry_mode_set(self) -> None:
         source = StubSource("environment", {"retry_mode": "standard"})
         resolver = ConfigResolver(sources=[source])
 
         result, source_name = resolve_retry_strategy(resolver)
 
-        assert result is None
-        assert source_name is None
+        assert isinstance(result, RetryStrategyOptions)
+        assert result.retry_mode == "standard"
+        assert result.max_attempts is None
+        assert source_name == "retry_mode=environment, max_attempts=default"
 
-    def test_returns_none_when_only_max_attempts_set(self) -> None:
+    def test_returns_strategy_when_only_max_attempts_set(self) -> None:
         source = StubSource("environment", {"max_attempts": "5"})
         resolver = ConfigResolver(sources=[source])
 
         result, source_name = resolve_retry_strategy(resolver)
 
-        assert result is None
-        assert source_name is None
+        assert isinstance(result, RetryStrategyOptions)
+        assert result.retry_mode == "standard"
+        assert result.max_attempts == 5
+        assert source_name == "retry_mode=default, max_attempts=environment"
 
     def test_returns_none_when_both_values_missing(self) -> None:
         source = StubSource("environment", {})

--- a/packages/smithy-aws-core/tests/unit/config/test_custom_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_custom_resolver.py
@@ -83,7 +83,6 @@ class TestResolveCustomResolverRetryStrategy:
         result, source_name = resolve_retry_strategy(resolver)
 
         assert isinstance(result, RetryStrategyOptions)
-        assert result.retry_mode == "standard"
         assert result.max_attempts == 5
         assert source_name == "retry_mode=default, max_attempts=environment"
 

--- a/packages/smithy-aws-core/tests/unit/config/test_custom_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_custom_resolver.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for custom resolver functions."""
-
 from typing import Any
 
 from smithy_aws_core.config.custom_resolvers import resolve_retry_strategy
@@ -28,29 +26,7 @@ class StubSource:
 class TestResolveCustomResolverRetryStrategy:
     """Test suite for complex configuration resolution"""
 
-    def test_resolves_when_only_retry_mode_set(self) -> None:
-        source = StubSource("environment", {"retry_mode": "standard"})
-        resolver = ConfigResolver(sources=[source])
-
-        result, source_name = resolve_retry_strategy(resolver)
-
-        assert isinstance(result, RetryStrategyOptions)
-        assert result.retry_mode == "standard"
-        assert result.max_attempts is None
-        assert source_name == "retry_mode=environment, max_attempts=unresolved"
-
-    def test_resolves_when_only_max_attempts_set(self) -> None:
-        source = StubSource("environment", {"max_attempts": "5"})
-        resolver = ConfigResolver(sources=[source])
-
-        result, source_name = resolve_retry_strategy(resolver)
-
-        assert isinstance(result, RetryStrategyOptions)
-        assert result.retry_mode == "standard"
-        assert result.max_attempts == 5
-        assert source_name == "retry_mode=unresolved, max_attempts=environment"
-
-    def test_resolves_from_both_values_when_set(self) -> None:
+    def test_resolves_from_both_values(self) -> None:
         # When both retry mode and max attempts are set
         # It should use source names for both values
         source = StubSource(
@@ -65,15 +41,6 @@ class TestResolveCustomResolverRetryStrategy:
         assert result.max_attempts == 3
         assert source_name == "retry_mode=environment, max_attempts=environment"
 
-    def test_returns_none_when_neither_value_set(self) -> None:
-        source = StubSource("environment", {})
-        resolver = ConfigResolver(sources=[source])
-
-        result, source_name = resolve_retry_strategy(resolver)
-        # It should return (None, None) when values not set
-        assert result is None
-        assert source_name is None
-
     def test_tracks_different_sources_for_each_component(self) -> None:
         source1 = StubSource("environment", {"retry_mode": "standard"})
         source2 = StubSource("config_file", {"max_attempts": "5"})
@@ -86,20 +53,10 @@ class TestResolveCustomResolverRetryStrategy:
         assert result.max_attempts == 5
         assert source_name == "retry_mode=environment, max_attempts=config_file"
 
-    def test_tracks_source_when_only_max_attempts_set(self) -> None:
-        source1 = StubSource("environment", {})
-        source2 = StubSource("config_file", {"max_attempts": "5"})
-        resolver = ConfigResolver(sources=[source1, source2])
-
-        result, source_name = resolve_retry_strategy(resolver)
-
-        assert isinstance(result, RetryStrategyOptions)
-        assert result.retry_mode == "standard"  # Default
-        assert result.max_attempts == 5
-        assert source_name == "retry_mode=unresolved, max_attempts=config_file"
-
     def test_converts_max_attempts_string_to_int(self) -> None:
-        source = StubSource("environment", {"max_attempts": "10"})
+        source = StubSource(
+            "environment", {"max_attempts": "10", "retry_mode": "standard"}
+        )
         resolver = ConfigResolver(sources=[source])
 
         result, _ = resolve_retry_strategy(resolver)
@@ -107,3 +64,30 @@ class TestResolveCustomResolverRetryStrategy:
         assert isinstance(result, RetryStrategyOptions)
         assert result.max_attempts == 10
         assert isinstance(result.max_attempts, int)
+
+    def test_returns_none_when_only_retry_mode_set(self) -> None:
+        source = StubSource("environment", {"retry_mode": "standard"})
+        resolver = ConfigResolver(sources=[source])
+
+        result, source_name = resolve_retry_strategy(resolver)
+
+        assert result is None
+        assert source_name is None
+
+    def test_returns_none_when_only_max_attempts_set(self) -> None:
+        source = StubSource("environment", {"max_attempts": "5"})
+        resolver = ConfigResolver(sources=[source])
+
+        result, source_name = resolve_retry_strategy(resolver)
+
+        assert result is None
+        assert source_name is None
+
+    def test_returns_none_when_both_values_missing(self) -> None:
+        source = StubSource("environment", {})
+        resolver = ConfigResolver(sources=[source])
+
+        result, source_name = resolve_retry_strategy(resolver)
+
+        assert result is None
+        assert source_name is None

--- a/packages/smithy-aws-core/tests/unit/config/test_validators.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_validators.py
@@ -1,11 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for AWS configuration validators."""
-
 import pytest
 from smithy_aws_core.config.validators import (
     ConfigValidationError,
-    validate_host,
+    validate_host_label,
     validate_max_attempts,
     validate_retry_mode,
 )
@@ -14,12 +12,12 @@ from smithy_aws_core.config.validators import (
 class TestValidators:
     @pytest.mark.parametrize("region", ["us-east-1", "eu-west-1", "ap-south-1"])
     def test_validate_region_accepts_valid_values(self, region: str) -> None:
-        assert validate_host(region) == region
+        assert validate_host_label(region) == region
 
-    @pytest.mark.parametrize("invalid", ["-invalid", "-east", "12345", 1234])
+    @pytest.mark.parametrize("invalid", ["-invalid", "-east", "12345", "", 1234])
     def test_validate_region_rejects_invalid_values(self, invalid: str) -> None:
         with pytest.raises(ConfigValidationError):
-            validate_host(invalid)
+            validate_host_label(invalid)
 
     @pytest.mark.parametrize("mode", ["standard", "simple"])
     def test_validate_retry_mode_accepts_valid_values(self, mode: str) -> None:

--- a/packages/smithy-aws-core/tests/unit/config/test_validators.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_validators.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+from typing import Any
+
 import pytest
 from smithy_aws_core.config.validators import (
     ConfigValidationError,
@@ -30,11 +32,15 @@ class TestValidators:
         with pytest.raises(ConfigValidationError):
             validate_retry_mode(invalid_mode)
 
-    def test_validate_invalid_max_attempts_raises_error(self) -> None:
+    @pytest.mark.parametrize("invalid_max_attempts", ["abcd", 0, -1])
+    def test_validate_invalid_max_attempts_raises_error(
+        self, invalid_max_attempts: Any
+    ) -> None:
         with pytest.raises(
-            ConfigValidationError, match="max_attempts must be a number"
+            ConfigValidationError,
+            match=r"(max_attempts must be a number|max_attempts must be a positive integer)",
         ):
-            validate_max_attempts("abcd")
+            validate_max_attempts(invalid_max_attempts)
 
     def test_invalid_retry_mode_error_message(self) -> None:
         with pytest.raises(ConfigValidationError) as exc_info:

--- a/packages/smithy-aws-core/tests/unit/config/test_validators.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_validators.py
@@ -5,8 +5,8 @@ from typing import Any
 import pytest
 from smithy_aws_core.config.validators import (
     ConfigValidationError,
-    validate_host_label,
     validate_max_attempts,
+    validate_region,
     validate_retry_mode,
 )
 
@@ -14,12 +14,12 @@ from smithy_aws_core.config.validators import (
 class TestValidators:
     @pytest.mark.parametrize("region", ["us-east-1", "eu-west-1", "ap-south-1"])
     def test_validate_region_accepts_valid_values(self, region: str) -> None:
-        assert validate_host_label(region) == region
+        assert validate_region(region) == region
 
-    @pytest.mark.parametrize("invalid", ["-invalid", "-east", "12345", "", 1234])
+    @pytest.mark.parametrize("invalid", ["-invalid", "-east", "12345", ""])
     def test_validate_region_rejects_invalid_values(self, invalid: str) -> None:
         with pytest.raises(ConfigValidationError):
-            validate_host_label(invalid)
+            validate_region(invalid)
 
     @pytest.mark.parametrize("mode", ["standard", "simple"])
     def test_validate_retry_mode_accepts_valid_values(self, mode: str) -> None:
@@ -46,6 +46,6 @@ class TestValidators:
         with pytest.raises(ConfigValidationError) as exc_info:
             validate_retry_mode("random_mode")
         assert (
-            "Invalid value for 'retry_mode': 'random_mode'. Retry mode must be one "
+            "Invalid value for 'retry_mode': 'random_mode'. retry_mode must be one "
             "of ('simple', 'standard'), got random_mode" in str(exc_info.value)
         )

--- a/packages/smithy-aws-core/tests/unit/config/test_validators.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_validators.py
@@ -5,7 +5,8 @@
 import pytest
 from smithy_aws_core.config.validators import (
     ConfigValidationError,
-    validate_region,
+    validate_host,
+    validate_max_attempts,
     validate_retry_mode,
 )
 
@@ -13,12 +14,12 @@ from smithy_aws_core.config.validators import (
 class TestValidators:
     @pytest.mark.parametrize("region", ["us-east-1", "eu-west-1", "ap-south-1"])
     def test_validate_region_accepts_valid_values(self, region: str) -> None:
-        assert validate_region(region) == region
+        assert validate_host(region) == region
 
     @pytest.mark.parametrize("invalid", ["-invalid", "-east", "12345", 1234])
     def test_validate_region_rejects_invalid_values(self, invalid: str) -> None:
         with pytest.raises(ConfigValidationError):
-            validate_region(invalid)
+            validate_host(invalid)
 
     @pytest.mark.parametrize("mode", ["standard", "simple"])
     def test_validate_retry_mode_accepts_valid_values(self, mode: str) -> None:
@@ -30,3 +31,17 @@ class TestValidators:
     ) -> None:
         with pytest.raises(ConfigValidationError):
             validate_retry_mode(invalid_mode)
+
+    def test_validate_invalid_max_attempts_raises_error(self) -> None:
+        with pytest.raises(
+            ConfigValidationError, match="max_attempts must be a number"
+        ):
+            validate_max_attempts("abcd")
+
+    def test_invalid_retry_mode_error_message(self) -> None:
+        with pytest.raises(ConfigValidationError) as exc_info:
+            validate_retry_mode("random_mode")
+        assert (
+            "Invalid value for 'retry_mode': 'random_mode'. Retry mode must be one "
+            "of ('simple', 'standard'), got random_mode" in str(exc_info.value)
+        )

--- a/packages/smithy-aws-core/tests/unit/config/test_validators.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_validators.py
@@ -2,52 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for AWS configuration validators."""
 
-from typing import Any
-
 import pytest
 from smithy_aws_core.config.validators import (
     ConfigValidationError,
-    allow_none,
     validate_region,
     validate_retry_mode,
 )
-
-
-class TestAllowNoneDecorator:
-    def test_allows_none_to_pass_through(self) -> None:
-        call_count = 0
-
-        @allow_none
-        def mock_validator(value: Any, source: str | None = None) -> Any:
-            nonlocal call_count
-            call_count += 1
-            return value
-
-        result: Any = mock_validator(None)
-
-        assert result is None
-        assert call_count == 0  # Validator should not be called
-
-    def test_calls_validator_for_non_none_values(self) -> None:
-        call_count = 0
-
-        @allow_none
-        def mock_validator(value: Any, source: str | None = None) -> Any:
-            nonlocal call_count
-            call_count += 1
-            return value
-
-        _ = mock_validator("test")
-
-        assert call_count == 1
-
-    def test_preserves_validator_exceptions(self) -> None:
-        @allow_none
-        def failing_validator(value: Any, source: str | None = None) -> str:
-            raise ValueError("Validation failed")
-
-        with pytest.raises(ValueError, match="Validation failed"):
-            failing_validator("test")
 
 
 class TestValidators:
@@ -55,7 +15,7 @@ class TestValidators:
     def test_validate_region_accepts_valid_values(self, region: str) -> None:
         assert validate_region(region) == region
 
-    @pytest.mark.parametrize("invalid", ["invalid-east-2", "us-east", "", "US-EAST-1"])
+    @pytest.mark.parametrize("invalid", ["-invalid", "-east", "12345", 1234])
     def test_validate_region_rejects_invalid_values(self, invalid: str) -> None:
         with pytest.raises(ConfigValidationError):
             validate_region(invalid)

--- a/packages/smithy-aws-core/tests/unit/config/test_validators.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_validators.py
@@ -1,0 +1,72 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for AWS configuration validators."""
+
+from typing import Any
+
+import pytest
+from smithy_aws_core.config.validators import (
+    ConfigValidationError,
+    allow_none,
+    validate_region,
+    validate_retry_mode,
+)
+
+
+class TestAllowNoneDecorator:
+    def test_allows_none_to_pass_through(self) -> None:
+        call_count = 0
+
+        @allow_none
+        def mock_validator(value: Any, source: str | None = None) -> Any:
+            nonlocal call_count
+            call_count += 1
+            return value
+
+        result: Any = mock_validator(None)
+
+        assert result is None
+        assert call_count == 0  # Validator should not be called
+
+    def test_calls_validator_for_non_none_values(self) -> None:
+        call_count = 0
+
+        @allow_none
+        def mock_validator(value: Any, source: str | None = None) -> Any:
+            nonlocal call_count
+            call_count += 1
+            return value
+
+        _ = mock_validator("test")
+
+        assert call_count == 1
+
+    def test_preserves_validator_exceptions(self) -> None:
+        @allow_none
+        def failing_validator(value: Any, source: str | None = None) -> str:
+            raise ValueError("Validation failed")
+
+        with pytest.raises(ValueError, match="Validation failed"):
+            failing_validator("test")
+
+
+class TestValidators:
+    @pytest.mark.parametrize("region", ["us-east-1", "eu-west-1", "ap-south-1"])
+    def test_validate_region_accepts_valid_values(self, region: str) -> None:
+        assert validate_region(region) == region
+
+    @pytest.mark.parametrize("invalid", ["invalid-east-2", "us-east", "", "US-EAST-1"])
+    def test_validate_region_rejects_invalid_values(self, invalid: str) -> None:
+        with pytest.raises(ConfigValidationError):
+            validate_region(invalid)
+
+    @pytest.mark.parametrize("mode", ["standard", "simple"])
+    def test_validate_retry_mode_accepts_valid_values(self, mode: str) -> None:
+        assert validate_retry_mode(mode) == mode
+
+    @pytest.mark.parametrize("invalid_mode", ["some_retry", "some_retry_one", ""])
+    def test_validate_retry_mode_rejects_invalid_values(
+        self, invalid_mode: str
+    ) -> None:
+        with pytest.raises(ConfigValidationError):
+            validate_retry_mode(invalid_mode)

--- a/packages/smithy-core/src/smithy_core/config/property.py
+++ b/packages/smithy-core/src/smithy_core/config/property.py
@@ -72,7 +72,7 @@ class ConfigProperty:
         else:
             value, source = obj._resolver.get(self.key)
 
-        if self.validator:
+        if self.validator and value is not None:
             value = self.validator(value, source)
 
         obj.__dict__[self.cache_attr] = (value, source)

--- a/packages/smithy-core/src/smithy_core/config/property.py
+++ b/packages/smithy-core/src/smithy_core/config/property.py
@@ -29,6 +29,7 @@ class ConfigProperty:
         key: str,
         validator: Callable[[Any, str | None], Any] | None = None,
         resolver_func: Callable[[ConfigResolver], tuple[Any, str | None]] | None = None,
+        default_value: Any = None,
     ):
         """Initialize config property descriptor.
 
@@ -43,23 +44,26 @@ class ConfigProperty:
         self.resolver_func = resolver_func
         # Cache attribute name in instance __dict__ (e.g., "_cache_region")
         self.cache_attr = f"_cache_{key}"
+        self.default_value = default_value
 
     def __get__(self, obj: Any, objtype: type | None = None) -> Any:
         """Get the config value with lazy resolution and caching.
 
         On first access, the property checks if the value is already cached. If not, it resolves
-        the value from sources using resolver via either a resolver function or obj._resolver.
-        When a validator is provided, the resolved value is validated before use. Finally, the
-        property caches the (value, source) tuple in obj.__dict__. On subsequent accesses, it
-        returns cached value from obj.__dict__.
+        the value from sources using resolver. When a validator is provided, the resolved value
+        is validated before use. Finally, the property caches the (value, source) tuple. On
+        subsequent accesses, it returns the cached value.
 
         :param obj: The Config instance
         :param objtype: The Config class
 
         :returns: The resolved and validated config value
         """
+        # If accessed on class instead of instance, return descriptor itself
+        if obj is None:
+            return self
 
-        cached = obj.__dict__.get(self.cache_attr)
+        cached = getattr(obj, self.cache_attr, None)
         if cached is not None:
             return cached[
                 0
@@ -72,10 +76,14 @@ class ConfigProperty:
         else:
             value, source = obj._resolver.get(self.key)
 
-        if self.validator and value is not None:
+        if value is None:
+            value = self.default_value
+            source = "default"
+
+        if self.validator:
             value = self.validator(value, source)
 
-        obj.__dict__[self.cache_attr] = (value, source)
+        setattr(obj, self.cache_attr, (value, source))
         return value
 
     def __set__(self, obj: Any, value: Any) -> None:
@@ -83,17 +91,16 @@ class ConfigProperty:
 
         When a config value is set, the property validates the new value if a validator is provided, then
         updates the cached (value, source) tuple. The source is marked as 'instance' if the value
-        is set during __init__, or 'plugin' if set later.
+        is set during __init__, or 'in-code' if set later.
 
         :param obj: The Config instance
         :param value: The new value to set
         """
         # Determine source based on when the value was set
         # If cache already exists, it means it was not set during initialization
-        # In that case source will be set to plugin
-        source = "plugin" if self.cache_attr in obj.__dict__ else "instance"
-
+        # In that case source will be set to in-code
+        source = "in-code" if hasattr(obj, self.cache_attr) else "instance"
         if self.validator:
             value = self.validator(value, source)
 
-        obj.__dict__[self.cache_attr] = (value, source)
+        setattr(obj, self.cache_attr, (value, source))

--- a/packages/smithy-core/src/smithy_core/config/property.py
+++ b/packages/smithy-core/src/smithy_core/config/property.py
@@ -1,0 +1,99 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from collections.abc import Callable
+from typing import Any
+
+from smithy_core.config.resolver import ConfigResolver
+
+
+class ConfigProperty:
+    """Descriptor for config properties with resolution, caching, and validation.
+
+    This descriptor handles:
+    - Lazy resolution from sources (only on first access)
+    - Custom resolution for variables requiring complex resolution
+    - Caching of resolved values
+    - Source tracking for provenance
+    - Validation of values
+
+    Example:
+        class Config:
+            region = ConfigProperty('region', validator=validate_region)
+
+            def __init__(self):
+                self._resolver = ConfigResolver(sources=[...])
+    """
+
+    def __init__(
+        self,
+        key: str,
+        validator: Callable[[Any, str | None], Any] | None = None,
+        resolver_func: Callable[[ConfigResolver], tuple[Any, str | None]] | None = None,
+    ):
+        """Initialize config property descriptor.
+
+        :param key: The configuration key (e.g., 'region')
+        :param validator: Optional validation function that takes (value, source)
+                      and returns validated value or raises an exception
+        :param resolver_func: Optional custom resolver function for complex resolution.
+                  Takes a ConfigResolver and returns (value, source) tuple.
+        """
+        self.key = key
+        self.validator = validator
+        self.resolver_func = resolver_func
+        # Cache attribute name in instance __dict__ (e.g., "_cache_region")
+        self.cache_attr = f"_cache_{key}"
+
+    def __get__(self, obj: Any, objtype: type | None = None) -> Any:
+        """Get the config value with lazy resolution and caching.
+
+        On first access, the property checks if the value is already cached. If not, it resolves
+        the value from sources using resolver via either a resolver function or obj._resolver.
+        When a validator is provided, the resolved value is validated before use. Finally, the
+        property caches the (value, source) tuple in obj.__dict__. On subsequent accesses, it
+        returns cached value from obj.__dict__.
+
+        :param obj: The Config instance
+        :param objtype: The Config class
+
+        :returns: The resolved and validated config value
+        """
+
+        cached = obj.__dict__.get(self.cache_attr)
+        if cached is not None:
+            return cached[
+                0
+            ]  # Return value from tuple (value, source) if already cached
+
+        # If not cached, use a resolver to go through the sources to get (value, source)
+        # For complex config resolutions, use a custom resolver function to resolve values
+        if self.resolver_func:
+            value, source = self.resolver_func(obj._resolver)
+        else:
+            value, source = obj._resolver.get(self.key)
+
+        if self.validator:
+            value = self.validator(value, source)
+
+        obj.__dict__[self.cache_attr] = (value, source)
+        return value
+
+    def __set__(self, obj: Any, value: Any) -> None:
+        """Set the config value (called during __init__ or after).
+
+        When a config value is set, the property validates the new value if a validator is provided, then
+        updates the cached (value, source) tuple. The source is marked as 'instance' if the value
+        is set during __init__, or 'plugin' if set later.
+
+        :param obj: The Config instance
+        :param value: The new value to set
+        """
+        # Determine source based on when the value was set
+        # If cache already exists, it means it was not set during initialization
+        # In that case source will be set to plugin
+        source = "plugin" if self.cache_attr in obj.__dict__ else "instance"
+
+        if self.validator:
+            value = self.validator(value, source)
+
+        obj.__dict__[self.cache_attr] = (value, source)

--- a/packages/smithy-core/tests/unit/config/test_property.py
+++ b/packages/smithy-core/tests/unit/config/test_property.py
@@ -55,33 +55,24 @@ class TestConfigPropertyDescriptor:
         result2 = config.region
 
         assert result1 == result2 == "us-west-2"
-        # Verify it's cached in __dict__ of config object
-        assert "_cache_region" in config.__dict__
+        # Verify it's cached
+        assert hasattr(config, "_cache_region")
 
-    def test_returns_none_when_value_unresolved(self) -> None:
+    def test_uses_default_value_when_unresolved(self) -> None:
+        class ConfigWithDefault:
+            region = ConfigProperty("region", default_value="us-east-1")
+
+            def __init__(self, resolver: ConfigResolver) -> None:
+                self._resolver = resolver
+
         source = StubSource("environment", {})
         resolver = ConfigResolver(sources=[source])
-        config = StubConfig(resolver)
+        config = ConfigWithDefault(resolver)
 
         result = config.region
 
-        assert result is None
-
-    def test_caches_none_for_unresolved_values(self) -> None:
-        source = StubSource("environment", {})
-        resolver = ConfigResolver(sources=[source])
-        config = StubConfig(resolver)
-
-        # First access
-        result1 = config.region
-        # Second access
-        result2 = config.region
-
-        assert result1 is None
-        assert result2 is None
-        # Verify it's cached
-        assert "_cache_region" in config.__dict__
-        assert config.__dict__["_cache_region"] == (None, None)
+        assert result == "us-east-1"
+        assert getattr(config, "_cache_region") == ("us-east-1", "default")
 
     def test_different_properties_resolve_independently(self) -> None:
         source = StubSource(
@@ -176,7 +167,7 @@ class TestConfigPropertySetter:
         config.region = "eu-west-1"
 
         # Check the cached tuple
-        assert config.__dict__["_cache_region"] == ("eu-west-1", "instance")
+        assert getattr(config, "_cache_region") == ("eu-west-1", "instance")
 
     def test_value_set_after_resolution_marks_source_as_plugin(self) -> None:
         source = StubSource("environment", {"region": "us-west-2"})
@@ -191,9 +182,9 @@ class TestConfigPropertySetter:
 
         # Verify the new value is returned
         assert config.region == "eu-west-1"
-        # Verify source is marked as 'plugin'
-        # Any config value modified after initialization will have 'plugin' for source
-        assert config.__dict__["_cache_region"] == ("eu-west-1", "plugin")
+        # Verify source is marked as 'in-code'
+        # Any config value modified after initialization will have 'in-code' for source
+        assert getattr(config, "_cache_region") == ("eu-west-1", "in-code")
 
     def test_validator_is_called_when_setting_values(self) -> None:
         call_log: list[tuple[Any, str | None]] = []
@@ -259,7 +250,7 @@ class TestConfigPropertyCaching:
 
         _ = config.region
 
-        cached: Any = config.__dict__["_cache_region"]
+        cached: Any = getattr(config, "_cache_region")
         assert cached == ("us-west-2", "environment")
 
     def test_cache_key_is_unique_per_property(self) -> None:
@@ -272,6 +263,29 @@ class TestConfigPropertyCaching:
         _ = config.region
         _ = config.retry_mode
 
-        assert "_cache_region" in config.__dict__
-        assert "_cache_retry_mode" in config.__dict__
-        assert config.__dict__["_cache_region"] != config.__dict__["_cache_retry_mode"]
+        assert hasattr(config, "_cache_retry_mode")
+        assert hasattr(config, "_cache_region")
+        assert getattr(config, "_cache_region") != getattr(config, "_cache_retry_mode")
+
+    def test_validator_called_on_default_value(self) -> None:
+        call_log: list[tuple[Any, str | None]] = []
+
+        def mock_validator(value: Any, source: str | None) -> Any:
+            call_log.append((value, source))
+            return value
+
+        class ConfigWithDefault:
+            region = ConfigProperty(
+                "region", default_value="us-default-1", validator=mock_validator
+            )
+
+            def __init__(self, resolver: ConfigResolver) -> None:
+                self._resolver = resolver
+
+        source = StubSource("environment", {})
+        resolver = ConfigResolver(sources=[source])
+        config = ConfigWithDefault(resolver)
+
+        _ = config.region
+
+        assert call_log == [("us-default-1", "default")]

--- a/packages/smithy-core/tests/unit/config/test_property.py
+++ b/packages/smithy-core/tests/unit/config/test_property.py
@@ -1,0 +1,277 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable
+from typing import Any, NoReturn
+
+import pytest
+from smithy_core.config.property import ConfigProperty
+from smithy_core.config.resolver import ConfigResolver
+
+
+class StubSource:
+    """A simple ConfigSource implementation for testing."""
+
+    def __init__(self, source_name: str, data: dict[str, Any] | None = None) -> None:
+        self._name = source_name
+        self._data = data or {}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get(self, key: str) -> Any | None:
+        return self._data.get(key)
+
+
+class StubConfig:
+    """A minimal Config class for testing ConfigProperty descriptor."""
+
+    region = ConfigProperty("region")
+    retry_mode = ConfigProperty("retry_mode")
+
+    def __init__(self, resolver: ConfigResolver) -> None:
+        self._resolver = resolver
+
+
+class TestConfigPropertyDescriptor:
+    def test_resolves_value_from_resolver_on_first_access(self) -> None:
+        source = StubSource("environment", {"region": "us-west-2"})
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        result = config.region
+
+        assert result == "us-west-2"
+
+    def test_caches_resolved_value(self) -> None:
+        source = StubSource("environment", {"region": "us-west-2"})
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        # First access
+        result1 = config.region
+        # Second access
+        result2 = config.region
+
+        assert result1 == result2 == "us-west-2"
+        # Verify it's cached in __dict__ of config object
+        assert "_cache_region" in config.__dict__
+
+    def test_returns_none_when_value_unresolved(self) -> None:
+        source = StubSource("environment", {})
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        result = config.region
+
+        assert result is None
+
+    def test_caches_none_for_unresolved_values(self) -> None:
+        source = StubSource("environment", {})
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        # First access
+        result1 = config.region
+        # Second access
+        result2 = config.region
+
+        assert result1 is None
+        assert result2 is None
+        # Verify it's cached
+        assert "_cache_region" in config.__dict__
+        assert config.__dict__["_cache_region"] == (None, None)
+
+    def test_different_properties_resolve_independently(self) -> None:
+        source = StubSource(
+            "environment", {"region": "us-west-2", "retry_mode": "adaptive"}
+        )
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        region = config.region
+        retry_mode = config.retry_mode
+
+        assert region == "us-west-2"
+        assert retry_mode == "adaptive"
+
+
+class TestConfigPropertyValidation:
+    """Test suite for ConfigProperty validation behavior."""
+
+    def _create_config_with_validator(
+        self, validator: Callable[[Any, str | None], Any]
+    ) -> type[Any]:
+        """Helper to create a config class with a specific validator."""
+
+        class ConfigWithValidator:
+            region = ConfigProperty("region", validator=validator)
+
+            def __init__(self, resolver: ConfigResolver) -> None:
+                self._resolver = resolver
+
+        return ConfigWithValidator
+
+    def test_calls_validator_on_resolution(self) -> None:
+        call_log: list[tuple[Any, str | None]] = []
+
+        def mock_validator(value: Any, source: str | None) -> Any:
+            call_log.append((value, source))
+            return value
+
+        ConfigWithValidator = self._create_config_with_validator(mock_validator)
+        source = StubSource("environment", {"region": "us-west-2"})
+        resolver = ConfigResolver(sources=[source])
+        config = ConfigWithValidator(resolver)
+
+        result = config.region
+
+        assert result == "us-west-2"
+        assert len(call_log) == 1
+        assert call_log[0] == ("us-west-2", "environment")
+
+    def test_validator_exception_propagates(self) -> None:
+        def failing_validator(value: Any, source: str | None) -> NoReturn:
+            raise ValueError("Invalid value")
+
+        ConfigWithValidator = self._create_config_with_validator(failing_validator)
+        source = StubSource("environment", {"region": "invalid-region-123"})
+        resolver = ConfigResolver(sources=[source])
+        config = ConfigWithValidator(resolver)
+
+        with pytest.raises(ValueError, match="Invalid value"):
+            _ = config.region
+
+    def test_validator_not_called_on_cached_access(self) -> None:
+        call_count = 0
+
+        def counting_validator(value: Any, source: str | None) -> Any:
+            nonlocal call_count
+            call_count += 1
+            return value
+
+        ConfigWithValidator = self._create_config_with_validator(counting_validator)
+        source = StubSource("environment", {"region": "us-west-2"})
+        resolver = ConfigResolver(sources=[source])
+        config = ConfigWithValidator(resolver)
+
+        # Multiple accesses
+        _ = config.region
+        _ = config.region
+        _ = config.region
+
+        # Only the first call accessed the validator
+        assert call_count == 1  # Validator called only once
+
+
+class TestConfigPropertySetter:
+    """Test suite for ConfigProperty setter behavior."""
+
+    def test_set_value_marks_source_as_instance(self) -> None:
+        source = StubSource("environment", {})
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        config.region = "eu-west-1"
+
+        # Check the cached tuple
+        assert config.__dict__["_cache_region"] == ("eu-west-1", "instance")
+
+    def test_value_set_after_resolution_marks_source_as_plugin(self) -> None:
+        source = StubSource("environment", {"region": "us-west-2"})
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        # First access triggers resolution from environment source
+        _ = config.region
+
+        # Modify after resolution
+        config.region = "eu-west-1"
+
+        # Verify the new value is returned
+        assert config.region == "eu-west-1"
+        # Verify source is marked as 'plugin'
+        # Any config value modified after initialization will have 'plugin' for source
+        assert config.__dict__["_cache_region"] == ("eu-west-1", "plugin")
+
+    def test_validator_is_called_when_setting_values(self) -> None:
+        call_log: list[tuple[Any, str | None]] = []
+
+        def mock_validator(value: Any, source: str | None) -> Any:
+            call_log.append((value, source))
+            return value
+
+        class ConfigWithValidator:
+            region = ConfigProperty("region", validator=mock_validator)
+
+            def __init__(self, resolver: ConfigResolver) -> None:
+                self._resolver = resolver
+
+        source = StubSource("environment", {})
+        resolver = ConfigResolver(sources=[source])
+        config = ConfigWithValidator(resolver)
+
+        config.region = "us-west-2"
+
+        assert config.region == "us-west-2"
+        assert len(call_log) == 1
+        assert call_log[0] == ("us-west-2", "instance")
+
+    def test_validator_throws_exception_when_setting_invalid_value(self) -> None:
+        def mock_failing_validation(value: Any, source: str | None) -> NoReturn:
+            raise ValueError("Invalid value")
+
+        class ConfigWithValidator:
+            region = ConfigProperty("region", validator=mock_failing_validation)
+
+            def __init__(self, resolver: ConfigResolver) -> None:
+                self._resolver = resolver
+
+        source = StubSource("environment", {})
+        resolver = ConfigResolver(sources=[source])
+        config = ConfigWithValidator(resolver)
+
+        with pytest.raises(ValueError, match="Invalid value"):
+            config.region = "some-invalid-2"
+
+    def test_set_overrides_resolved_value(self) -> None:
+        source = StubSource("environment", {"region": "us-west-2"})
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        # First access resolves from environment
+        assert config.region == "us-west-2"
+
+        # Setting overrides
+        config.region = "eu-west-1"
+
+        assert config.region == "eu-west-1"
+
+
+class TestConfigPropertyCaching:
+    """Test suite for ConfigProperty caching implementation details."""
+
+    def test_cache_stores_value_and_source_as_tuple(self) -> None:
+        source = StubSource("environment", {"region": "us-west-2"})
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        _ = config.region
+
+        cached: Any = config.__dict__["_cache_region"]
+        assert cached == ("us-west-2", "environment")
+
+    def test_cache_key_is_unique_per_property(self) -> None:
+        source = StubSource(
+            "environment", {"region": "us-west-2", "retry_mode": "adaptive"}
+        )
+        resolver = ConfigResolver(sources=[source])
+        config = StubConfig(resolver)
+
+        _ = config.region
+        _ = config.retry_mode
+
+        assert "_cache_region" in config.__dict__
+        assert "_cache_retry_mode" in config.__dict__
+        assert config.__dict__["_cache_region"] != config.__dict__["_cache_retry_mode"]

--- a/packages/smithy-core/tests/unit/config/test_property.py
+++ b/packages/smithy-core/tests/unit/config/test_property.py
@@ -132,7 +132,7 @@ class TestConfigPropertyValidation:
         config = ConfigWithValidator(resolver)
 
         with pytest.raises(ValueError, match="Invalid value"):
-            _ = config.region
+            config.region
 
     def test_validator_not_called_on_cached_access(self) -> None:
         call_count = 0
@@ -148,9 +148,9 @@ class TestConfigPropertyValidation:
         config = ConfigWithValidator(resolver)
 
         # Multiple accesses
-        _ = config.region
-        _ = config.region
-        _ = config.region
+        config.region
+        config.region
+        config.region
 
         # Only the first call accessed the validator
         assert call_count == 1  # Validator called only once
@@ -175,7 +175,7 @@ class TestConfigPropertySetter:
         config = StubConfig(resolver)
 
         # First access triggers resolution from environment source
-        _ = config.region
+        config.region
 
         # Modify after resolution
         config.region = "eu-west-1"
@@ -248,24 +248,10 @@ class TestConfigPropertyCaching:
         resolver = ConfigResolver(sources=[source])
         config = StubConfig(resolver)
 
-        _ = config.region
+        config.region
 
         cached: Any = getattr(config, "_cache_region")
         assert cached == ("us-west-2", "environment")
-
-    def test_cache_key_is_unique_per_property(self) -> None:
-        source = StubSource(
-            "environment", {"region": "us-west-2", "retry_mode": "adaptive"}
-        )
-        resolver = ConfigResolver(sources=[source])
-        config = StubConfig(resolver)
-
-        _ = config.region
-        _ = config.retry_mode
-
-        assert hasattr(config, "_cache_retry_mode")
-        assert hasattr(config, "_cache_region")
-        assert getattr(config, "_cache_region") != getattr(config, "_cache_retry_mode")
 
     def test_validator_called_on_default_value(self) -> None:
         call_log: list[tuple[Any, str | None]] = []
@@ -286,6 +272,6 @@ class TestConfigPropertyCaching:
         resolver = ConfigResolver(sources=[source])
         config = ConfigWithDefault(resolver)
 
-        _ = config.region
+        config.region
 
         assert call_log == [("us-default-1", "default")]

--- a/packages/smithy-core/tests/unit/config/test_property.py
+++ b/packages/smithy-core/tests/unit/config/test_property.py
@@ -169,7 +169,7 @@ class TestConfigPropertySetter:
         # Check the cached tuple
         assert getattr(config, "_cache_region") == ("eu-west-1", "instance")
 
-    def test_value_set_after_resolution_marks_source_as_plugin(self) -> None:
+    def test_value_set_after_resolution_marks_source_as_in_code(self) -> None:
         source = StubSource("environment", {"region": "us-west-2"})
         resolver = ConfigResolver(sources=[source])
         config = StubConfig(resolver)


### PR DESCRIPTION

*Issue #, if available:*

This PR adds a `ConfigProperty` descriptor that serves as the central instrument for configuration resolution. The descriptor is responsible for resolving config values from sources, applying custom resolvers for complex resolutions, validating values, caching them, and facilitating value updates. 

**The `ConfigProperty` descriptor implements the Python descriptor protocol to provide:**
  - Lazy resolution
  - Validation
  - Caching
  - Custom resolver
  - Source tracking

**Initial config variables:**
- `region` - demonstrates simple resolution
- `retry_strategy` - demonstrates complex resolution (aggregates retry_mode and max_attempts)

These two variables ensure that the design handles both simple and complex resolution.

**Tests**
- Verified that the unit tests for config property, validators and custom revolvers pass successfully.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
