### PR TITLE
fix(smithy-json): escape control characters in write_string per RFC 8259 §7

### DIFF
--- a/packages/smithy-json/.changes/next-release/smithy-json-enhancement-37b9c0663ce84096905fd484478ce94d.json
+++ b/packages/smithy-json/.changes/next-release/smithy-json-enhancement-37b9c0663ce84096905fd484478ce94d.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Fixed string serialization to escape all control characters (U+0000-U+001F) per [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259#section-7), preventing invalid JSON output for multiline and other control-character-containing strings. ([#647](https://github.com/smithy-lang/smithy-python/pull/647))"
+}

--- a/packages/smithy-json/src/smithy_json/_private/serializers.py
+++ b/packages/smithy-json/src/smithy_json/_private/serializers.py
@@ -1,6 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
+import re
 from base64 import b64encode
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import AbstractContextManager
@@ -26,6 +27,30 @@ from . import Flushable
 
 _INF: float = float("inf")
 _NEG_INF: float = float("-inf")
+
+# RFC 8259 §7: All control characters U+0000 through U+001F MUST be escaped.
+_ESCAPE_MAP: dict[str, str] = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+    "\b": "\\b",
+    "\f": "\\f",
+}
+_CHARS_TO_ESCAPE = re.compile(r'[\\"\x00-\x1f]')
+
+
+def _escape_char(match: re.Match[str]) -> str:
+    c = match.group()
+    if c in _ESCAPE_MAP:
+        return _ESCAPE_MAP[c]
+    return f"\\u{ord(c):04x}"
+
+
+def _escape_string(value: str) -> str:
+    """Escape a string value per RFC 8259 §7."""
+    return _CHARS_TO_ESCAPE.sub(_escape_char, value)
 
 
 class JSONShapeSerializer(ShapeSerializer):
@@ -271,9 +296,7 @@ class StreamingJSONEncoder:
 
     def write_string(self, value: str) -> None:
         self._sink.write(b'"')
-        self._sink.write(
-            value.replace("\\", "\\\\").replace('"', '\\"').encode("utf-8")
-        )
+        self._sink.write(_escape_string(value).encode("utf-8"))
         self._sink.write(b'"')
 
     def write_int(self, value: int) -> None:

--- a/packages/smithy-json/tests/unit/__init__.py
+++ b/packages/smithy-json/tests/unit/__init__.py
@@ -349,6 +349,12 @@ JSON_SERDE_CASES = [
     (Decimal("1.1"), b"1.1"),
     (b"foo", b'"Zm9v"'),
     ("foo", b'"foo"'),
+    # RFC 8259 §7: control characters must be escaped
+    ("line 1\nline 2", b'"line 1\\nline 2"'),
+    ("col 1\tcol 2", b'"col 1\\tcol 2"'),
+    ("a\rb", b'"a\\rb"'),
+    ("a\\b", b'"a\\\\b"'),
+    ('a"b', b'"a\\"b"'),
     (datetime(2024, 5, 15, tzinfo=UTC), b'"2024-05-15T00:00:00Z"'),
     (None, b"null"),
     (["foo"], b'["foo"]'),

--- a/packages/smithy-json/tests/unit/test_serializers.py
+++ b/packages/smithy-json/tests/unit/test_serializers.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import json
 from datetime import datetime
 from decimal import Decimal
 from io import BytesIO
@@ -82,3 +83,59 @@ def test_json_serializer(given: Any, expected: bytes) -> None:
     sink.seek(0)
     actual = sink.read()
     assert actual == expected
+
+
+def _serialize_string(value: str) -> bytes:
+    """Serialize a string value through the JSON codec and return raw bytes."""
+    sink = BytesIO()
+    serializer = JSONCodec().create_serializer(sink)
+    serializer.write_string(STRING, value)
+    serializer.flush()
+    sink.seek(0)
+    return sink.read()
+
+
+class TestStringControlCharEscaping:
+    """RFC 8259 §7: All control characters U+0000-U+001F must be escaped."""
+
+    @pytest.mark.parametrize(
+        "char, escaped",
+        [
+            ("\n", "\\n"),
+            ("\r", "\\r"),
+            ("\t", "\\t"),
+            ("\b", "\\b"),
+            ("\f", "\\f"),
+        ],
+    )
+    def test_named_control_chars(self, char: str, escaped: str) -> None:
+        result = _serialize_string(f"a{char}b")
+        assert result == f'"a{escaped}b"'.encode()
+
+    def test_all_control_chars_produce_valid_json(self) -> None:
+        """Every U+0000-U+001F character must be escaped so output is valid JSON."""
+        for cp in range(0x20):
+            value = f"before{chr(cp)}after"
+            raw = _serialize_string(value)
+            # Must parse as valid JSON
+            parsed = json.loads(raw)
+            assert parsed == value, f"Round-trip failed for U+{cp:04X}"
+
+    def test_null_byte(self) -> None:
+        result = _serialize_string("a\x00b")
+        assert result == b'"a\\u0000b"'
+
+    def test_mixed_escapes(self) -> None:
+        result = _serialize_string('line 1\nline 2\t"quoted"\r\n')
+        assert result == b'"line 1\\nline 2\\t\\"quoted\\"\\r\\n"'
+
+    def test_existing_backslash_and_quote_still_escaped(self) -> None:
+        result = _serialize_string('a\\b"c')
+        assert result == b'"a\\\\b\\"c"'
+
+    def test_serialized_output_is_valid_json(self) -> None:
+        """Realistic multi-line prompt string produces valid JSON."""
+        value = "System: You are helpful.\nUser: Hello\nAssistant:"
+        raw = _serialize_string(value)
+        parsed = json.loads(raw)
+        assert parsed == value


### PR DESCRIPTION
## Title

fix(smithy-json): escape control characters in write_string per RFC 8259 §7

## Body

### Summary

`StreamingJSONEncoder.write_string()` only escapes `\` and `"`. Control characters U+0000–U+001F (`\n`, `\t`, `\r`, etc.) are written as raw bytes, producing invalid JSON.

This produces invalid JSON per [RFC 8259 §7](https://www.rfc-editor.org/rfc/rfc8259#section-7), causing `SerializationException` (HTTP 400) on any API call where a string field contains these characters.

### Root Cause

`serializers.py`, `write_string()`:
```python
value.replace("\\", "\\\\").replace('"', '\\"').encode("utf-8")
```
Missing escapes for `\n`, `\r`, `\t`, `\b`, `\f`, and other U+0000–U+001F characters required by [RFC 8259 §7](https://www.rfc-editor.org/rfc/rfc8259#section-7).

### Fix

Replace the inline `.replace()` chain with a regex-based `_escape_string()` that handles:
- Named escapes: `\n`, `\r`, `\t`, `\b`, `\f` (plus existing `\\` and `\"`)
- Generic escapes: `\uXXXX` for remaining U+0000–U+001F

### Tests

- 5 new serde round-trip cases (newline, tab, CR, backslash, quote) added to `JSON_SERDE_CASES`
- Dedicated `TestStringControlCharEscaping` class with:
  - Parametrized named control char tests
  - Exhaustive U+0000–U+001F round-trip via `json.loads` validation
  - Null byte, mixed escapes, and realistic multi-line prompt cases

All 126 tests pass (106 existing + 20 new).

### Impact

Affects all services using `smithy-json` for request serialization. Any string field containing control characters produces invalid JSON. For services where string fields commonly contain newlines — such as the Bedrock Runtime [Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) — this is the primary failure path.

### Prior Art

The Rust implementation in `smithy-rs` already handles this correctly in [`escape.rs`](https://github.com/smithy-lang/smithy-rs/blob/main/rust-runtime/aws-smithy-json/src/escape.rs):

```rust
fn escape_string_inner(start: &[u8], rest: &[u8]) -> String {
    let mut escaped = Vec::with_capacity(start.len() + rest.len() + 1);
    escaped.extend(start);
    for byte in rest {
        match byte {
            b'"' => escaped.extend(b"\\\""),
            b'\\' => escaped.extend(b"\\\\"),
            0x08 => escaped.extend(b"\\b"),
            0x0C => escaped.extend(b"\\f"),
            b'\n' => escaped.extend(b"\\n"),
            b'\r' => escaped.extend(b"\\r"),
            b'\t' => escaped.extend(b"\\t"),
            0..=0x1F => escaped.extend(format!("\\u{byte:04x}").bytes()),
            _ => escaped.push(*byte),
        }
    }
    // ...
}
```

This PR brings the Python implementation in line with the Rust behavior.

### Reproduction

```python
from io import BytesIO
from smithy_json import JSONCodec
from smithy_core.prelude import STRING

sink = BytesIO()
s = JSONCodec().create_serializer(sink)
s.write_string(STRING, "line 1\nline 2")
s.flush()
print(sink.getvalue())
# Before fix: b'"line 1\nline 2"'   (invalid JSON — raw 0x0A byte)
# After fix:  b'"line 1\\nline 2"'  (valid JSON)
```
