### PR TITLE
Add xml binding traits to smithy-core

### DIFF
--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-80e80edee8a7461d99ca5f28c2547e59.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-80e80edee8a7461d99ca5f28c2547e59.json
@@ -1,4 +1,4 @@
 {
   "type": "enhancement",
-  "description": "Added XML binding traits: `XMNameTrait`, `XMLNamespaceTrait`, `XMLFlattenedTrait`, and `XMLAttributeTrait`."
+  "description": "Added XML binding traits: `XMLNameTrait`, `XMLNamespaceTrait`, `XMLFlattenedTrait`, and `XMLAttributeTrait`."
 }

--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-80e80edee8a7461d99ca5f28c2547e59.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-80e80edee8a7461d99ca5f28c2547e59.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Added XML binding traits: `XMNameTrait`, `XMLNamespaceTrait`, `XMLFlattenedTrait`, and `XMLAttributeTrait`."
+}

--- a/packages/smithy-core/src/smithy_core/traits.py
+++ b/packages/smithy-core/src/smithy_core/traits.py
@@ -350,3 +350,43 @@ class HTTPAPIKeyAuthTrait(Trait, id=ShapeID("smithy.api#httpApiKeyAuth")):
     @property
     def scheme(self) -> str | None:
         return self.document_value.get("scheme")  # type: ignore
+
+
+@dataclass(init=False, frozen=True)
+class XMLNameTrait(Trait, id=ShapeID("smithy.api#xmlName")):
+    document_value: str | None = None
+
+    def __post_init__(self):
+        assert isinstance(self.document_value, str)
+
+    @property
+    def value(self) -> str:
+        return self.document_value  # type: ignore
+
+
+@dataclass(init=False, frozen=True)
+class XMLNamespaceTrait(Trait, id=ShapeID("smithy.api#xmlNamespace")):
+    def __post_init__(self):
+        assert isinstance(self.document_value, Mapping)
+        assert isinstance(self.document_value["uri"], str)
+        assert isinstance(self.document_value.get("prefix"), str | None)
+
+    @property
+    def uri(self) -> str:
+        return self.document_value["uri"]  # type: ignore
+
+    @property
+    def prefix(self) -> str | None:
+        return self.document_value.get("prefix")  # type: ignore
+
+
+@dataclass(init=False, frozen=True)
+class XMLFlattenedTrait(Trait, id=ShapeID("smithy.api#xmlFlattened")):
+    def __post_init__(self):
+        assert self.document_value is None
+
+
+@dataclass(init=False, frozen=True)
+class XMLAttributeTrait(Trait, id=ShapeID("smithy.api#xmlAttribute")):
+    def __post_init__(self):
+        assert self.document_value is None


### PR DESCRIPTION
### Description
This PR adds  XML binding trait classes (`XMLNameTrait`, `XMLNamespaceTrait`, `XMLFlattenedTrait`, `XMLAttributeTrait`) to `smithy-core`.

These correspond to the XML binding traits defined in the [Smithy specification](https://smithy.io/2.0/spec/protocol-traits.html#xml-bindings).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
