### PR TITLE
Stop iterating response body on error for bidirectional streams

### DIFF
--- a/packages/smithy-http/.changes/next-release/smithy-http-bugfix-cec2955f4e8e4c1cbd89918bf72de36a.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-bugfix-cec2955f4e8e4c1cbd89918bf72de36a.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Fix infinite hang when a bidirectional stream receives a non-2xx HTTP response from the server"
+}

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -102,6 +102,10 @@ class AWSCRTHTTPResponse(http_aio_interfaces.HTTPResponse):
             chunk = await self._stream.get_next_response_chunk()
             if chunk:
                 yield chunk
+                # CRT will hang infinitely and not close the stream if it is closed server side; to work around this,
+                # we need to break this loop ourselves after reading the first chunk.
+                if self._status >= 400:
+                    break
             else:
                 break
 

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -392,3 +392,21 @@ def test_response_properties() -> None:
     assert response.status == 404
     assert response.fields == fields
     assert response.reason is None
+
+
+async def test_error_response_chunks_stops_after_first_chunk() -> None:
+    """Test that error responses stop reading after the first chunk."""
+    mock_stream = AsyncMock()
+    mock_stream.get_next_response_chunk.side_effect = [
+        b"error body",
+        b"should not be read",
+        b"",
+    ]
+
+    response = AWSCRTHTTPResponse(status=500, fields=Fields(), stream=mock_stream)
+
+    chunks: list[bytes] = []
+    async for chunk in response.chunks():
+        chunks.append(chunk)
+
+    assert chunks == [b"error body"]


### PR DESCRIPTION
*Issue #, if available:*
#657 

*Description of changes:*
On bidirectional HTTP/2 streams, the CRT only signals response body completion when both sides of the stream have sent END_STREAM. When the server returns a non-2xx response (e.g., 429 ThrottlingException), the client side is still open sending events, so get_next_response_chunk() hangs forever waiting for a completion signal that never comes.

This PR updates the CRT HTTP client to break out of the chunks() loop after the first chunk when the response status is >= 400. The error body is already fully buffered by the CRT at that point, allowing the error to be deserialized and raised.

> Note: this is a workaround for the CRT not signaling response body completion on half-closed HTTP/2 streams. A complete fix requires the CRT breaking this loop on a half-closed stream. For typical error responses, the body arrives in a single chunk and is fully available before this code runs, but this code will truncate any error response in 2 or more chunks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
