### PR TITLE
Fix SigV4 signature for URIs with literal query parameters

### DIFF
--- a/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-bugfix-23a4eca5165f48efb1524b95f8498299.json
+++ b/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-bugfix-23a4eca5165f48efb1524b95f8498299.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Fixed SigV4 signature computation for URIs with literal query parameters (e.g., ?sync). parse_qsl was silently dropping query keys without values, causing InvalidSignatureException."
+}

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
@@ -315,7 +315,7 @@ class SigV4Signer:
         if query is None:
             return ""
 
-        query_params = parse_qsl(qs=query)
+        query_params = parse_qsl(qs=query, keep_blank_values=True)
         query_parts = (
             (quote(string=key, safe=""), quote(string=value, safe=""))
             for key, value in query_params
@@ -695,7 +695,7 @@ class AsyncSigV4Signer:
         if query is None:
             return ""
 
-        query_params = parse_qsl(qs=query)
+        query_params = parse_qsl(qs=query, keep_blank_values=True)
         query_parts = (
             (quote(string=key, safe=""), quote(string=value, safe=""))
             for key, value in query_params

--- a/packages/aws-sdk-signers/tests/unit/test_signers.py
+++ b/packages/aws-sdk-signers/tests/unit/test_signers.py
@@ -125,6 +125,18 @@ class TestSigV4Signer:
                 identity=identity,
             )
 
+    def test_format_canonical_query_keeps_blank_values(self) -> None:
+        canonical_query = self.SIGV4_SYNC_SIGNER._format_canonical_query(
+            query="foo=bar&baz="
+        )
+        assert canonical_query == "baz=&foo=bar"
+
+    def test_format_canonical_query_with_literal_query_param(self) -> None:
+        canonical_query = self.SIGV4_SYNC_SIGNER._format_canonical_query(
+            query="sync"
+        )
+        assert canonical_query == "sync="
+
 
 class UnreadableAsyncStream:
     def __aiter__(self) -> typing.Self:
@@ -231,3 +243,15 @@ class TestAsyncSigV4Signer:
         assert "X-Amz-Content-SHA256" in signed.fields
         payload_hash = signed.fields["X-Amz-Content-SHA256"].as_string()
         assert payload_hash == "STREAMING-AWS4-HMAC-SHA256-EVENTS"
+
+    async def test_format_canonical_query_keeps_blank_values(self) -> None:
+        canonical_query = await self.SIGV4_ASYNC_SIGNER._format_canonical_query(
+            query="foo=bar&baz="
+        )
+        assert canonical_query == "baz=&foo=bar"
+
+    async def test_format_canonical_query_with_literal_query_param(self) -> None:
+        canonical_query = await self.SIGV4_ASYNC_SIGNER._format_canonical_query(
+            query="sync"
+        )
+        assert canonical_query == "sync="

--- a/packages/aws-sdk-signers/tests/unit/test_signers.py
+++ b/packages/aws-sdk-signers/tests/unit/test_signers.py
@@ -126,13 +126,13 @@ class TestSigV4Signer:
             )
 
     def test_format_canonical_query_keeps_blank_values(self) -> None:
-        canonical_query = self.SIGV4_SYNC_SIGNER._format_canonical_query(
+        canonical_query = self.SIGV4_SYNC_SIGNER._format_canonical_query(  # pyright: ignore[reportPrivateUsage]
             query="foo=bar&baz="
         )
         assert canonical_query == "baz=&foo=bar"
 
     def test_format_canonical_query_with_literal_query_param(self) -> None:
-        canonical_query = self.SIGV4_SYNC_SIGNER._format_canonical_query(
+        canonical_query = self.SIGV4_SYNC_SIGNER._format_canonical_query(  # pyright: ignore[reportPrivateUsage]
             query="sync"
         )
         assert canonical_query == "sync="
@@ -245,13 +245,13 @@ class TestAsyncSigV4Signer:
         assert payload_hash == "STREAMING-AWS4-HMAC-SHA256-EVENTS"
 
     async def test_format_canonical_query_keeps_blank_values(self) -> None:
-        canonical_query = await self.SIGV4_ASYNC_SIGNER._format_canonical_query(
+        canonical_query = await self.SIGV4_ASYNC_SIGNER._format_canonical_query(  # pyright: ignore[reportPrivateUsage]
             query="foo=bar&baz="
         )
         assert canonical_query == "baz=&foo=bar"
 
     async def test_format_canonical_query_with_literal_query_param(self) -> None:
-        canonical_query = await self.SIGV4_ASYNC_SIGNER._format_canonical_query(
+        canonical_query = await self.SIGV4_ASYNC_SIGNER._format_canonical_query(  # pyright: ignore[reportPrivateUsage]
             query="sync"
         )
         assert canonical_query == "sync="


### PR DESCRIPTION
## Problem

When generating a client for Amazon Q Business using smithy-python, the `ChatSync` operation fails with `InvalidSignatureException`. The same request succeeds with boto3 using identical credentials and endpoint.

The root cause is that `ChatSync` has a literal query parameter in its Smithy HTTP trait:
```json
"smithy.api#http": {
    "uri": "/applications/{applicationId}/conversations?sync",
    "method": "POST"
}
```

Link to the model file: https://github.com/aws/api-models-aws/blob/9eafbc359b1c6a7187ac921009b9eef85de71d91/models/qbusiness/service/2023-11-27/qbusiness-2023-11-27.json#L2244-L2250

The `?sync` query parameter (no `=` sign, no value) is dropped during SigV4 canonical query string computation. `parse_qsl("sync")` returns `[]` because it ignores keys without values by default. The server includes `sync=` in its canonical query string, so the signatures don't match.

## Fix

Add `keep_blank_values=True` to both sync and async `_format_canonical_query` methods. This makes `parse_qsl("sync", keep_blank_values=True)` return `[('sync', '')]`, which correctly produces `sync=` in the canonical query string.

## Testing

1. Generate a Q Business client using smithy-python
2. Create a Q Business anonymous application and pass the application id to an environment variable:
```
export QBUSINESS_APPLICATION_ID=<application-id>
```
3. Run a test like the following:
```python
async def test_chat_sync():
    client = QBusinessClient(config=Config(
        endpoint_uri="https://qbusiness.us-east-1.api.aws",
        region="us-east-1",
        aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
    ))
    response = await client.chat_sync(ChatSyncInput(
        application_id=APPLICATION_ID,
        user_message="Hello",
        client_token=str(uuid.uuid4()),
    ))
```
4. Without this fix: `InvalidSignatureException`
5. With this fix: `200 OK` with valid response

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.