### PR TITLE
Handle unknown event types gracefully instead of crashing

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
@@ -166,7 +166,6 @@ public final class UnionGenerator implements Runnable {
                         match schema.expect_member_index():
                             ${4C|}
                             case _:
-                                logger.debug("Unexpected member schema: %s", schema)
                                 self._set_result($5L(tag=schema.expect_member_name()))
 
                     def _set_result(self, value: $2T) -> None:

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
@@ -144,8 +144,6 @@ public final class UnionGenerator implements Runnable {
         writer.addImport("smithy_core.deserializers", "ShapeDeserializer");
         writer.addImport("smithy_core.exceptions", "SerializationError");
 
-        // TODO: add in unknown handling
-
         var symbol = symbolProvider.toSymbol(shape);
         var deserializerSymbol = symbol.expectProperty(SymbolProperties.DESERIALIZER);
         var schemaSymbol = symbol.expectProperty(SymbolProperties.SCHEMA);
@@ -169,7 +167,7 @@ public final class UnionGenerator implements Runnable {
                             ${4C|}
                             case _:
                                 logger.debug("Unexpected member schema: %s", schema)
-                                self._set_result($5L(tag=schema.member_name or ""))
+                                self._set_result($5L(tag=schema.expect_member_name()))
 
                     def _set_result(self, value: $2T) -> None:
                         if self._result is not None:

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
@@ -149,6 +149,7 @@ public final class UnionGenerator implements Runnable {
         var symbol = symbolProvider.toSymbol(shape);
         var deserializerSymbol = symbol.expectProperty(SymbolProperties.DESERIALIZER);
         var schemaSymbol = symbol.expectProperty(SymbolProperties.SCHEMA);
+        var unknownSymbol = symbol.expectProperty(SymbolProperties.UNION_UNKNOWN);
         writer.putContext("schema", schemaSymbol);
         writer.write("""
                 class $1L:
@@ -168,6 +169,7 @@ public final class UnionGenerator implements Runnable {
                             ${4C|}
                             case _:
                                 logger.debug("Unexpected member schema: %s", schema)
+                                self._set_result($5L(tag=schema.member_name or ""))
 
                     def _set_result(self, value: $2T) -> None:
                         if self._result is not None:
@@ -177,7 +179,8 @@ public final class UnionGenerator implements Runnable {
                 deserializerSymbol.getName(),
                 symbol,
                 schemaSymbol,
-                writer.consumer(w -> deserializeMembers()));
+                writer.consumer(w -> deserializeMembers()),
+                unknownSymbol.getName());
     }
 
     private void deserializeMembers() {

--- a/packages/smithy-aws-event-stream/.changes/next-release/smithy-aws-event-stream-enhancement-93f4aa27846a4d3596fde5f79f912718.json
+++ b/packages/smithy-aws-event-stream/.changes/next-release/smithy-aws-event-stream-enhancement-93f4aa27846a4d3596fde5f79f912718.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Handle unknown event types gracefully instead of crashing."
+}

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/deserializers.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/deserializers.py
@@ -10,7 +10,7 @@ from smithy_core.deserializers import (
     SpecificShapeDeserializer,
 )
 from smithy_core.schemas import Schema
-from smithy_core.shapes import ShapeType
+from smithy_core.shapes import ShapeID, ShapeType
 from smithy_core.traits import EventHeaderTrait
 from smithy_core.utils import expect_type
 
@@ -57,19 +57,14 @@ class EventDeserializer(SpecificShapeDeserializer):
                         # member_name and a member_index of -1 so the
                         # generated default branch constructs the unknown
                         # variant with the correct tag.
-                        logger.debug(
-                            "Unknown event type: %s", member_name
-                        )
-                        from smithy_core.shapes import ShapeID
+                        logger.debug("Unknown event type: %s", member_name)
 
                         _UNKNOWN_TARGET = Schema(
                             id=ShapeID("smithy.unknown#Unknown"),
                             shape_type=ShapeType.STRUCTURE,
                         )
                         unknown_schema = Schema(
-                            id=ShapeID(
-                                f"smithy.unknown#Unknown${member_name}"
-                            ),
+                            id=ShapeID(f"smithy.unknown#Unknown${member_name}"),
                             shape_type=ShapeType.STRUCTURE,
                             member_target=_UNKNOWN_TARGET,
                             member_index=-1,

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/deserializers.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/deserializers.py
@@ -50,11 +50,39 @@ class EventDeserializer(SpecificShapeDeserializer):
                     message_deserializer = self._create_deserializer(schema, headers)
                     message_deserializer.read_struct(schema, consumer)
                 else:
-                    member_schema = schema.members[member_name]
-                    message_deserializer = self._create_deserializer(
-                        member_schema, headers
-                    )
-                    consumer(member_schema, message_deserializer)
+                    member_schema = schema.members.get(member_name)
+                    if member_schema is None:
+                        # Unknown event type. Call the consumer with a
+                        # schema that carries the event type name as
+                        # member_name and a member_index of -1 so the
+                        # generated default branch constructs the unknown
+                        # variant with the correct tag.
+                        logger.debug(
+                            "Unknown event type: %s", member_name
+                        )
+                        from smithy_core.shapes import ShapeID
+
+                        _UNKNOWN_TARGET = Schema(
+                            id=ShapeID("smithy.unknown#Unknown"),
+                            shape_type=ShapeType.STRUCTURE,
+                        )
+                        unknown_schema = Schema(
+                            id=ShapeID(
+                                f"smithy.unknown#Unknown${member_name}"
+                            ),
+                            shape_type=ShapeType.STRUCTURE,
+                            member_target=_UNKNOWN_TARGET,
+                            member_index=-1,
+                        )
+                        consumer(
+                            unknown_schema,
+                            self._payload_codec.create_deserializer(b"{}"),
+                        )
+                    else:
+                        message_deserializer = self._create_deserializer(
+                            member_schema, headers
+                        )
+                        consumer(member_schema, message_deserializer)
             case "exception":
                 member_name = expect_type(str, headers[":exception-type"])
                 member_schema = schema.members[member_name]

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/deserializers.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/deserializers.py
@@ -10,7 +10,7 @@ from smithy_core.deserializers import (
     SpecificShapeDeserializer,
 )
 from smithy_core.schemas import Schema
-from smithy_core.shapes import ShapeID, ShapeType
+from smithy_core.shapes import ShapeType
 from smithy_core.traits import EventHeaderTrait
 from smithy_core.utils import expect_type
 
@@ -50,34 +50,11 @@ class EventDeserializer(SpecificShapeDeserializer):
                     message_deserializer = self._create_deserializer(schema, headers)
                     message_deserializer.read_struct(schema, consumer)
                 else:
-                    member_schema = schema.members.get(member_name)
-                    if member_schema is None:
-                        # Unknown event type. Call the consumer with a
-                        # schema that carries the event type name as
-                        # member_name and a member_index of -1 so the
-                        # generated default branch constructs the unknown
-                        # variant with the correct tag.
-                        logger.debug("Unknown event type: %s", member_name)
-
-                        _UNKNOWN_TARGET = Schema(
-                            id=ShapeID("smithy.unknown#Unknown"),
-                            shape_type=ShapeType.STRUCTURE,
-                        )
-                        unknown_schema = Schema(
-                            id=ShapeID(f"smithy.unknown#Unknown${member_name}"),
-                            shape_type=ShapeType.STRUCTURE,
-                            member_target=_UNKNOWN_TARGET,
-                            member_index=-1,
-                        )
-                        consumer(
-                            unknown_schema,
-                            self._payload_codec.create_deserializer(b"{}"),
-                        )
-                    else:
-                        message_deserializer = self._create_deserializer(
-                            member_schema, headers
-                        )
-                        consumer(member_schema, message_deserializer)
+                    member_schema = self._resolve_member_schema(schema, member_name)
+                    message_deserializer = self._create_deserializer(
+                        member_schema, headers
+                    )
+                    consumer(member_schema, message_deserializer)
             case "exception":
                 member_name = expect_type(str, headers[":exception-type"])
                 member_schema = schema.members[member_name]
@@ -93,6 +70,21 @@ class EventDeserializer(SpecificShapeDeserializer):
                 )
             case _:
                 raise EventError(f"Unknown event structure: {self._event}")
+
+    def _resolve_member_schema(self, schema: Schema, member_name: str) -> Schema:
+        if member_schema := schema.members.get(member_name):
+            return member_schema
+
+        logger.debug(
+            "Received unmodeled event stream member %s for union %s",
+            member_name,
+            schema.id,
+        )
+        return Schema.member(
+            id=schema.id.with_member(member_name),
+            target=schema,
+            index=-1,
+        )
 
     def _create_deserializer(
         self, schema: Schema, headers: HEADERS_DICT

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
@@ -132,7 +132,7 @@ class AWSEventReceiver[E: DeserializeableShape](EventReceiver[E]):
         )
         result = self._deserializer(deserializer)
         logger.debug("Successfully deserialized event: %s", result)
-        if isinstance(getattr(result, "value"), Exception):
+        if isinstance(getattr(result, "value", None), Exception):
             raise result.value  # type: ignore
         return result
 

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
@@ -132,8 +132,9 @@ class AWSEventReceiver[E: DeserializeableShape](EventReceiver[E]):
         )
         result = self._deserializer(deserializer)
         logger.debug("Successfully deserialized event: %s", result)
-        if isinstance(getattr(result, "value", None), Exception):
-            raise result.value  # type: ignore
+        value = getattr(result, "value", None)
+        if isinstance(value, Exception):
+            raise value
         return result
 
     async def close(self) -> None:

--- a/packages/smithy-aws-event-stream/tests/unit/_private/__init__.py
+++ b/packages/smithy-aws-event-stream/tests/unit/_private/__init__.py
@@ -429,7 +429,7 @@ class EventStreamDeserializer:
                 self._set_result(EventStreamErrorEvent(ErrorEvent.deserialize(de)))
 
             case _:
-                self._set_result(EventStreamUnknown(tag=schema.member_name or ""))
+                self._set_result(EventStreamUnknown(tag=schema.expect_member_name()))
 
     def _set_result(self, value: EventStream) -> None:
         if self._result is not None:
@@ -636,11 +636,11 @@ EVENT_STREAM_SERDE_CASES = [
 
 
 UNKNOWN_EVENT_CASE = (
-    EventStreamUnknown(tag="intermediateGroupEvent"),
+    EventStreamUnknown(tag="unmodeledEvent"),
     EventMessage(
         headers={
             ":message-type": "event",
-            ":event-type": "intermediateGroupEvent",
+            ":event-type": "unmodeledEvent",
             ":content-type": "application/json",
         },
         payload=b"{}",

--- a/packages/smithy-aws-event-stream/tests/unit/_private/__init__.py
+++ b/packages/smithy-aws-event-stream/tests/unit/_private/__init__.py
@@ -381,7 +381,7 @@ class EventStreamErrorEvent:
 
 
 @dataclass
-class EventStreamUnknownEvent:
+class EventStreamUnknown:
     tag: str
 
     def serialize(self, serializer: ShapeSerializer):
@@ -396,7 +396,7 @@ type EventStream = (
     | EventStreamPayloadEvent
     | EventStreamBlobPayloadEvent
     | EventStreamErrorEvent
-    | EventStreamUnknownEvent
+    | EventStreamUnknown
 )
 
 
@@ -429,7 +429,7 @@ class EventStreamDeserializer:
                 self._set_result(EventStreamErrorEvent(ErrorEvent.deserialize(de)))
 
             case _:
-                raise SmithyError(f"Unexpected member schema: {schema}")
+                self._set_result(EventStreamUnknown(tag=schema.member_name or ""))
 
     def _set_result(self, value: EventStream) -> None:
         if self._result is not None:
@@ -633,6 +633,19 @@ EVENT_STREAM_SERDE_CASES = [
         ),
     ),
 ]
+
+
+UNKNOWN_EVENT_CASE = (
+    EventStreamUnknown(tag="intermediateGroupEvent"),
+    EventMessage(
+        headers={
+            ":message-type": "event",
+            ":event-type": "intermediateGroupEvent",
+            ":content-type": "application/json",
+        },
+        payload=b"{}",
+    ),
+)
 
 
 INITIAL_REQUEST_CASE = (

--- a/packages/smithy-aws-event-stream/tests/unit/_private/test_deserializers.py
+++ b/packages/smithy-aws-event-stream/tests/unit/_private/test_deserializers.py
@@ -20,6 +20,7 @@ from . import (
     EventStreamDeserializer,
     EventStreamErrorEvent,
     EventStreamOperationInputOutput,
+    EventStreamUnknown,
 )
 
 
@@ -126,3 +127,20 @@ async def test_read_closed_receiver_source() -> None:
     with pytest.raises(IOError):
         await receiver.receive()
     assert receiver.closed
+
+
+def test_deserialize_unknown_event_type():
+    message = EventMessage(
+        headers={
+            ":message-type": "event",
+            ":event-type": "intermediateGroupEvent",
+            ":content-type": "application/json",
+        },
+        payload=b"{}",
+    )
+    source = Event.decode(BytesIO(message.encode()))
+    assert source is not None
+    deserializer = EventDeserializer(event=source, payload_codec=JSONCodec())
+    result = EventStreamDeserializer().deserialize(deserializer)
+    assert isinstance(result, EventStreamUnknown)
+    assert result.tag == "intermediateGroupEvent"

--- a/packages/smithy-aws-event-stream/tests/unit/_private/test_deserializers.py
+++ b/packages/smithy-aws-event-stream/tests/unit/_private/test_deserializers.py
@@ -133,7 +133,7 @@ def test_deserialize_unknown_event_type():
     message = EventMessage(
         headers={
             ":message-type": "event",
-            ":event-type": "intermediateGroupEvent",
+            ":event-type": "unmodeledEvent",
             ":content-type": "application/json",
         },
         payload=b"{}",
@@ -143,4 +143,4 @@ def test_deserialize_unknown_event_type():
     deserializer = EventDeserializer(event=source, payload_codec=JSONCodec())
     result = EventStreamDeserializer().deserialize(deserializer)
     assert isinstance(result, EventStreamUnknown)
-    assert result.tag == "intermediateGroupEvent"
+    assert result.tag == "unmodeledEvent"


### PR DESCRIPTION
### Background

The Smithy spec ([streaming.html#client-behavior](https://smithy.io/2.0/spec/streaming.html#client-behavior)) states:

> "Adding new events to an event stream union is considered a backward compatible change; clients SHOULD NOT fail when an unknown event is received."

Currently, in `smithy-aws-event-stream` [`deserializers.py`](https://github.com/smithy-lang/smithy-python/blob/3e54be044faa0d38e75aa37972db7e236fb80d2e/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/deserializers.py#L53), `EventDeserializer.read_struct()` does a hard dictionary lookup (`schema.members[member_name]`) which raises `KeyError` when the service sends an event type not present in the generated model. So we have to add some logic to handle unknown event types.

Additionally, although smithy-python automatically creates unknown variants for streams, these variants only have a `tag` field unlike normal events that have a `value` field. When `AWSEventReceiver.receive()` calls `getattr(result, "value")` without a default, it raises `AttributeError` for unknown variants.

These were discovered during Q Business Chat streaming integration testing. The service sends `intermediateGroupEvent` and `intermediateMessageEvent` events not in any published SDK model, causing the `async for event in output_stream` loop to crash.

**Reference implementations in other Smithy SDKs:**

Both smithy-java and smithy-rs (Rust) already handle unknown event types gracefully:

- **smithy-java** ([`TestEventStream.java`](https://github.com/smithy-lang/smithy-java/blob/main/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/TestEventStream.java)): Generates a `$Unknown(String memberName)` record for each event stream union. The builder has an `$unknownMember(String memberName)` method that the deserializer calls when it encounters an unrecognized event type. The unknown variant preserves the event type name.

- **smithy-rs** ([`EventStreamUnmarshallerGenerator.kt`](https://github.com/smithy-lang/smithy-rs/blob/main/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt)): The generated unmarshaller has an `_unknown_variant` match arm that returns `Ok(UnmarshalledMessage::Event(Output::Unknown))` for client targets. Unlike Java, the Rust unknown variant does not preserve the event type name.

This PR follows the smithy-java approach of preserving the event type name in the unknown variant's `tag` field, so users can identify which unmodeled event was received (e.g., `ChatOutputStreamUnknown(tag="intermediateGroupEvent")`).

### Description of Changes

1. **smithy-aws-event-stream** ([`deserializers.py`](https://github.com/smithy-lang/smithy-python/blob/3e54be044faa0d38e75aa37972db7e236fb80d2e/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/_private/deserializers.py#L53)): When `member_name` is not in `schema.members`, construct a synthetic `Schema` with `member_index=-1` and call the consumer, which triggers the generated `case _:` branch in [`UnionGenerator.java`](https://github.com/smithy-lang/smithy-python/blob/3e54be044faa0d38e75aa37972db7e236fb80d2e/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java#L169-L170).
2. **smithy-python codegen** ([`UnionGenerator.java`](https://github.com/smithy-lang/smithy-python/blob/3e54be044faa0d38e75aa37972db7e236fb80d2e/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java#L169-L170)): The `case _:` branch (previously just logging) now also constructs the per-union unknown variant with the event type name as `tag`.
3. **smithy-aws-event-stream** ([`aio/__init__.py`](https://github.com/smithy-lang/smithy-python/blob/3e54be044faa0d38e75aa37972db7e236fb80d2e/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py#L135)): Change `getattr(result, "value")` to `getattr(result, "value", None)` to prevent `AttributeError` on unknown variants.


### Testing
Regenerated all existing clients locally and all their integration tests passed. Also, verified with Q Business Chat streaming — unknown events (`intermediateGroupEvent`, `intermediateMessageEvent`) are now handled gracefully instead of crashing. Users can identify unknown events via `isinstance` and access the event type name:

```python
from aws_sdk_qbusiness.models import ChatOutputStreamUnknown

async for event in output_stream:
    if isinstance(event, ChatOutputStreamUnknown):
        print(f"Unknown event: {event.tag}")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
