### PR TITLE
Add Python 3.15 to CI as non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,11 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.python-version == '3.15' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14", "3.15"]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Overview

Adds Python 3.15 to the CI matrix and marks that job as non-blocking with continue-on-error.

This keeps coverage on the upcoming interpreter version without making prerelease-specific failures block the workflow.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
