### PR TITLE
Fix missing signed empty end frame on event stream close

### DIFF
--- a/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-enhancement-d97ea923259e448da2f865cd60bb7768.json
+++ b/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-enhancement-d97ea923259e448da2f865cd60bb7768.json
@@ -1,4 +1,4 @@
 {
-  "type": "enhancement",
+  "type": "feature",
   "description": "Added `AsyncEventSigner.sign_empty` for SigV4-signed Amazon Event Stream terminator frames. This supports services that require a final signed empty message before the HTTP body stream closes."
 }

--- a/packages/smithy-aws-event-stream/.changes/next-release/smithy-aws-event-stream-bugfix-e80cb499b6b04551a1792cdaa2211752.json
+++ b/packages/smithy-aws-event-stream/.changes/next-release/smithy-aws-event-stream-bugfix-e80cb499b6b04551a1792cdaa2211752.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Fixed `AWSEventPublisher` to send signed empty end frame to signal event stream completion."
+}

--- a/packages/smithy-aws-event-stream/.changes/next-release/smithy-aws-event-stream-bugfix-e80cb499b6b04551a1792cdaa2211752.json
+++ b/packages/smithy-aws-event-stream/.changes/next-release/smithy-aws-event-stream-bugfix-e80cb499b6b04551a1792cdaa2211752.json
@@ -1,4 +1,4 @@
 {
-  "type": "bugfix",
-  "description": "Fixed `AWSEventPublisher` to send signed empty end frame to signal event stream completion."
+  "type": "feature",
+  "description": "Added a signed empty end frame to `AWSEventPublisher.close` to signal event stream completion. This supports services that require a final signed empty message before the HTTP body stream closes."
 }

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
@@ -17,7 +17,7 @@ from smithy_core.serializers import SerializeableShape
 
 from .._private.deserializers import EventDeserializer as _EventDeserializer
 from .._private.serializers import EventSerializer as _EventSerializer
-from ..events import Event
+from ..events import Event, EventMessage
 from ..exceptions import EventError
 
 logger = logging.getLogger(__name__)
@@ -84,6 +84,20 @@ class AWSEventPublisher[E: SerializeableShape](EventPublisher[E]):
         if self._closed:
             return
         self._closed = True
+
+        # Send a signed empty frame to signal stream completion.
+        if self._signing_config is not None:
+            end_frame = EventMessage()
+            identity = await self._signing_config.identity_resolver.get_identity(
+                properties=self._signing_config.identity_properties
+            )
+            end_frame = await self._signing_config.signer.sign(
+                event=end_frame,
+                identity=identity,
+                properties=self._signing_config.signing_properties,
+            )
+            logger.debug("Sending signed empty message to terminate the event stream")
+            await self._writer.write(end_frame.encode())
 
         if (close := getattr(self._writer, "close", None)) is not None:
             if asyncio.iscoroutine(result := close()):

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
@@ -91,12 +91,12 @@ class AWSEventPublisher[E: SerializeableShape](EventPublisher[E]):
             identity = await self._signing_config.identity_resolver.get_identity(
                 properties=self._signing_config.identity_properties
             )
-            end_frame = await self._signing_config.signer.sign(
+            end_frame = await self._signing_config.signer.sign_empty(
                 event=end_frame,
                 identity=identity,
                 properties=self._signing_config.signing_properties,
             )
-            logger.debug("Sending signed empty message to terminate the event stream")
+            logger.debug("Sending signed empty message to terminate the event stream.")
             await self._writer.write(end_frame.encode())
 
         if (close := getattr(self._writer, "close", None)) is not None:

--- a/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
+++ b/packages/smithy-aws-event-stream/src/smithy_aws_event_stream/aio/__init__.py
@@ -85,23 +85,26 @@ class AWSEventPublisher[E: SerializeableShape](EventPublisher[E]):
             return
         self._closed = True
 
-        # Send a signed empty frame to signal stream completion.
-        if self._signing_config is not None:
-            end_frame = EventMessage()
-            identity = await self._signing_config.identity_resolver.get_identity(
-                properties=self._signing_config.identity_properties
-            )
-            end_frame = await self._signing_config.signer.sign_empty(
-                event=end_frame,
-                identity=identity,
-                properties=self._signing_config.signing_properties,
-            )
-            logger.debug("Sending signed empty message to terminate the event stream.")
-            await self._writer.write(end_frame.encode())
-
-        if (close := getattr(self._writer, "close", None)) is not None:
-            if asyncio.iscoroutine(result := close()):
-                await result
+        try:
+            # Send a signed empty frame to signal stream completion.
+            if self._signing_config is not None:
+                end_frame = EventMessage()
+                identity = await self._signing_config.identity_resolver.get_identity(
+                    properties=self._signing_config.identity_properties
+                )
+                end_frame = await self._signing_config.signer.sign_empty(
+                    event=end_frame,
+                    identity=identity,
+                    properties=self._signing_config.signing_properties,
+                )
+                logger.debug(
+                    "Sending signed empty message to terminate the event stream."
+                )
+                await self._writer.write(end_frame.encode())
+        finally:
+            if (close := getattr(self._writer, "close", None)) is not None:
+                if asyncio.iscoroutine(result := close()):
+                    await result
 
     @property
     def closed(self) -> bool:

--- a/packages/smithy-aws-event-stream/tests/unit/_private/test_serializers.py
+++ b/packages/smithy-aws-event-stream/tests/unit/_private/test_serializers.py
@@ -1,12 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
+from io import BytesIO
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 from smithy_aws_event_stream._private.serializers import EventSerializer
 from smithy_aws_event_stream.aio import AWSEventPublisher
-from smithy_aws_event_stream.events import EventMessage
+from smithy_aws_event_stream.events import Event, EventMessage
 from smithy_core.aio.types import AsyncBytesProvider
 from smithy_core.serializers import SerializeableShape
 from smithy_json import JSONCodec
@@ -81,7 +83,7 @@ async def test_send_to_closed_writer():
 
 
 async def test_close_sends_empty_end_frame_when_signing():
-    writer = AsyncMock()
+    writer = AsyncBytesProvider()
     end_frame = EventMessage()
     signing_config = AsyncMock()
     signing_config.signer.sign_empty.return_value = end_frame
@@ -90,8 +92,21 @@ async def test_close_sends_empty_end_frame_when_signing():
         payload_codec=JSONCodec(), async_writer=writer, signing_config=signing_config
     )
 
+    # Read from the writer concurrently with close(), since close() flushes
+    # and blocks until all chunks are consumed.
+    reader = asyncio.create_task(_read(writer))
     await publisher.close()
+    written = await reader
 
     signing_config.signer.sign_empty.assert_awaited_once()
-    writer.write.assert_awaited_once_with(end_frame.encode())
     assert publisher.closed
+    assert writer.closed
+
+    decoded = Event.decode(BytesIO(written))
+    assert decoded is not None
+    assert decoded.message.payload == b""
+    assert decoded.message.headers == {}
+
+
+async def _read(source: AsyncBytesProvider) -> bytes:
+    return b"".join([chunk async for chunk in source])

--- a/packages/smithy-aws-event-stream/tests/unit/_private/test_serializers.py
+++ b/packages/smithy-aws-event-stream/tests/unit/_private/test_serializers.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 from smithy_aws_event_stream._private.serializers import EventSerializer
@@ -76,4 +77,20 @@ async def test_send_to_closed_writer():
     with pytest.raises(IOError):
         await publisher.send(EVENT_STREAM_SERDE_CASES[0][0])
 
+    assert publisher.closed
+
+
+async def test_close_with_signing_sends_end_frame():
+    writer = AsyncMock()
+    end_frame = EventMessage()
+    signing_config = AsyncMock()
+    signing_config.signer.sign.return_value = end_frame
+
+    publisher: AWSEventPublisher[Any] = AWSEventPublisher(
+        payload_codec=JSONCodec(), async_writer=writer, signing_config=signing_config
+    )
+
+    await publisher.close()
+
+    writer.write.assert_awaited_once_with(end_frame.encode())
     assert publisher.closed

--- a/packages/smithy-aws-event-stream/tests/unit/_private/test_serializers.py
+++ b/packages/smithy-aws-event-stream/tests/unit/_private/test_serializers.py
@@ -80,11 +80,11 @@ async def test_send_to_closed_writer():
     assert publisher.closed
 
 
-async def test_close_with_signing_sends_end_frame():
+async def test_close_sends_empty_end_frame_when_signing():
     writer = AsyncMock()
     end_frame = EventMessage()
     signing_config = AsyncMock()
-    signing_config.signer.sign.return_value = end_frame
+    signing_config.signer.sign_empty.return_value = end_frame
 
     publisher: AWSEventPublisher[Any] = AWSEventPublisher(
         payload_codec=JSONCodec(), async_writer=writer, signing_config=signing_config
@@ -92,5 +92,6 @@ async def test_close_with_signing_sends_end_frame():
 
     await publisher.close()
 
+    signing_config.signer.sign_empty.assert_awaited_once()
     writer.write.assert_awaited_once_with(end_frame.encode())
     assert publisher.closed

--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-857985c5f3a848ddbab3179678a57aa8.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-857985c5f3a848ddbab3179678a57aa8.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Added sign_empty method to EventSigner protocol for signing empty events."
+}

--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-857985c5f3a848ddbab3179678a57aa8.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-857985c5f3a848ddbab3179678a57aa8.json
@@ -1,4 +1,4 @@
 {
-  "type": "enhancement",
-  "description": "Added sign_empty method to EventSigner protocol for signing empty events."
+  "type": "feature",
+  "description": "Added `EventSigner.sign_empty` to the protocol for signing empty events."
 }

--- a/packages/smithy-core/src/smithy_core/aio/interfaces/auth.py
+++ b/packages/smithy-core/src/smithy_core/aio/interfaces/auth.py
@@ -31,6 +31,17 @@ class EventSigner[I, SP: Mapping[str, Any]](Protocol):
         """Get a signed version of the event.
 
         :param event: The event to be signed.
+        :param identity: The identity to use to sign the event.
+        :param properties: Additional properties used to sign the event.
+        """
+        ...
+
+    async def sign_empty(self, *, event: Any, identity: I, properties: SP) -> Any:
+        """Get a signed version of an empty event.
+
+        :param event: The empty event to be signed.
+        :param identity: The identity to use to sign the event.
+        :param properties: Additional properties used to sign the event.
         """
         ...
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-sdk-python/issues/46

*Description of changes:*
Fix `AWSEventPublisher.close()` to send a signed empty end frame to signal stream completion.

SigV4 signed event streams require a final signed empty message before the HTTP body stream closes. This fix:
1. Adds `sign_empty()` method to the `EventSigner` protocol in `smithy-core`.
2. Updates `AWSEventPublisher.close()` to call `sign_empty()` when sending the termination frame in `smithy-aws-event-stream`.

This eliminates the following errors:
- Transcribe Streaming: `BadRequestException: A complete signal was sent without the preceding empty frame.`
- Bedrock Runtime: `ValidationException: Invalid input request, please fix your input and try again.`

Related PR: https://github.com/smithy-lang/smithy-python/pull/692

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
