### PR TITLE
Add SigV4 event stream empty-frame signing

### DIFF
--- a/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-enhancement-d97ea923259e448da2f865cd60bb7768.json
+++ b/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-enhancement-d97ea923259e448da2f865cd60bb7768.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Added `AsyncEventSigner.sign_empty` for SigV4-signed Amazon Event Stream terminator frames. This supports services that require a final signed empty message before the HTTP body stream closes."
+}

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
@@ -835,6 +835,7 @@ class AsyncEventSigner:
         self._prior_signature = initial_signature
         self._signing_lock = asyncio.Lock()
         self._event_encoder_cls = event_encoder_cls
+        self._is_finalized = False
 
     async def sign(
         self,
@@ -859,18 +860,25 @@ class AsyncEventSigner:
     ) -> "EventMessage":
         """Sign an Amazon Event Stream final empty message.
 
-        The terminator must have a zero-byte outer payload. Calling ``sign``
-        with an empty event message is not equivalent because ``sign`` wraps the
-        encoded event message as the payload.
+        The supplied ``event`` must have no headers and an empty payload.
+        Calling ``sign`` with an empty event message is not equivalent because
+        ``sign`` wraps the encoded event message as the payload.
 
         The returned message contains ``:date`` and ``:chunk-signature``
-        headers and advances the running signature chain.
+        headers and advances the running signature chain. After this method
+        returns, the signer cannot sign additional event stream messages.
         """
+        if event.headers or event.payload:
+            raise ValueError(
+                "sign_empty requires an event with no headers and an empty payload."
+            )
+
         return await self._sign_payload(
             event=event,
             payload=b"",
             identity=identity,
             properties=properties,
+            is_final=True,
         )
 
     async def _sign_payload(
@@ -880,8 +888,15 @@ class AsyncEventSigner:
         payload: bytes,
         identity: _AWSCredentialsIdentity,
         properties: SigV4SigningProperties,
+        is_final: bool = False,
     ) -> "EventMessage":
         async with self._signing_lock:
+            if self._is_finalized:
+                raise RuntimeError(
+                    "Cannot sign event stream messages after the final empty event "
+                    "has been signed."
+                )
+
             # Copy and prepopulate any missing values in the signing properties.
             new_signing_properties = SigV4SigningProperties(  # type: ignore
                 **properties
@@ -919,6 +934,8 @@ class AsyncEventSigner:
 
             # Set new prior signature before releasing the lock.
             self._prior_signature = hexlify(event_signature)
+            if is_final:
+                self._is_finalized = True
 
         return event
 

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
@@ -843,9 +843,53 @@ class AsyncEventSigner:
         identity: _AWSCredentialsIdentity,
         properties: SigV4SigningProperties,
     ) -> "EventMessage":
+        return await self._sign_payload(
+            event=event,
+            payload=event.encode(),
+            identity=identity,
+            properties=properties,
+        )
+
+    async def sign_empty(
+        self,
+        *,
+        event: "EventMessage",
+        identity: _AWSCredentialsIdentity,
+        properties: SigV4SigningProperties,
+    ) -> "EventMessage":
+        """Produce the SigV4 event-stream terminator frame.
+
+        The terminator is a signed event-stream message whose outer payload is
+        zero bytes (not a nested encoded empty event). The AWS auth handler
+        requires exactly one such frame immediately before the HTTP body stream
+        is closed; without it the service returns
+        ``InvalidSignatureException: "A complete signal was sent without the
+        preceding empty frame."``.
+
+        The caller must pass an ``EventMessage`` with no headers and no
+        payload (or whose headers/payload will be overwritten). The returned
+        event carries ``:date`` and ``:chunk-signature`` headers on the outer
+        event-stream envelope and an empty payload, and chains from
+        ``self._prior_signature`` (updating it) so subsequent signed frames
+        continue the chain correctly.
+        """
+        return await self._sign_payload(
+            event=event,
+            payload=b"",
+            identity=identity,
+            properties=properties,
+        )
+
+    async def _sign_payload(
+        self,
+        *,
+        event: "EventMessage",
+        payload: bytes,
+        identity: _AWSCredentialsIdentity,
+        properties: SigV4SigningProperties,
+    ) -> "EventMessage":
         async with self._signing_lock:
-            # Copy and prepopulate any missing values in the
-            # signing properties.
+            # Copy and prepopulate any missing values in the signing properties.
             new_signing_properties = SigV4SigningProperties(  # type: ignore
                 **properties
             )
@@ -861,8 +905,6 @@ class AsyncEventSigner:
             encoder = self._event_encoder_cls()
             encoder.encode_headers(headers)
             encoded_headers = encoder.get_result()
-
-            payload = event.encode()
 
             string_to_sign = await self._event_string_to_sign(
                 timestamp=timestamp,
@@ -882,7 +924,7 @@ class AsyncEventSigner:
             event.headers = headers
             event.payload = payload
 
-            # set new prior signature before releasing the lock
+            # Set new prior signature before releasing the lock.
             self._prior_signature = hexlify(event_signature)
 
         return event

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
@@ -857,21 +857,14 @@ class AsyncEventSigner:
         identity: _AWSCredentialsIdentity,
         properties: SigV4SigningProperties,
     ) -> "EventMessage":
-        """Produce the SigV4 event-stream terminator frame.
+        """Sign an Amazon Event Stream final empty message.
 
-        The terminator is a signed event-stream message whose outer payload is
-        zero bytes (not a nested encoded empty event). The AWS auth handler
-        requires exactly one such frame immediately before the HTTP body stream
-        is closed; without it the service returns
-        ``InvalidSignatureException: "A complete signal was sent without the
-        preceding empty frame."``.
+        The terminator must have a zero-byte outer payload. Calling ``sign``
+        with an empty event message is not equivalent because ``sign`` wraps the
+        encoded event message as the payload.
 
-        The caller must pass an ``EventMessage`` with no headers and no
-        payload (or whose headers/payload will be overwritten). The returned
-        event carries ``:date`` and ``:chunk-signature`` headers on the outer
-        event-stream envelope and an empty payload, and chains from
-        ``self._prior_signature`` (updating it) so subsequent signed frames
-        continue the chain correctly.
+        The returned message contains ``:date`` and ``:chunk-signature``
+        headers and advances the running signature chain.
         """
         return await self._sign_payload(
             event=event,

--- a/packages/aws-sdk-signers/tests/unit/test_signers.py
+++ b/packages/aws-sdk-signers/tests/unit/test_signers.py
@@ -199,6 +199,59 @@ class TestAsyncEventSigner:
         assert ":date" in decoded.message.headers
         assert ":chunk-signature" in decoded.message.headers
 
+    async def test_sign_empty_rejects_non_empty_event(
+        self,
+        aws_identity: AWSCredentialIdentity,
+    ) -> None:
+        signer = AsyncEventSigner(
+            initial_signature=b"initial-signature",
+            event_encoder_cls=EventHeaderEncoder,
+        )
+
+        with pytest.raises(ValueError):
+            await signer.sign_empty(
+                event=EventMessage(headers={"foo": "bar"}),
+                identity=aws_identity,
+                properties=SigV4SigningProperties(
+                    region="us-west-2", service="transcribe"
+                ),
+            )
+
+        with pytest.raises(ValueError):
+            await signer.sign_empty(
+                event=EventMessage(payload=b"audio"),
+                identity=aws_identity,
+                properties=SigV4SigningProperties(
+                    region="us-west-2", service="transcribe"
+                ),
+            )
+
+    async def test_sign_rejects_events_after_empty_event(
+        self,
+        aws_identity: AWSCredentialIdentity,
+    ) -> None:
+        signer = AsyncEventSigner(
+            initial_signature=b"initial-signature",
+            event_encoder_cls=EventHeaderEncoder,
+        )
+        properties = SigV4SigningProperties(region="us-west-2", service="transcribe")
+
+        await signer.sign_empty(
+            event=EventMessage(),
+            identity=aws_identity,
+            properties=properties,
+        )
+
+        with pytest.raises(RuntimeError, match="final empty event"):
+            await signer.sign(
+                event=EventMessage(
+                    headers={":message-type": "event", ":event-type": "AudioEvent"},
+                    payload=b"audio",
+                ),
+                identity=aws_identity,
+                properties=properties,
+            )
+
 
 class TestAsyncSigV4Signer:
     SIGV4_ASYNC_SIGNER = AsyncSigV4Signer()

--- a/packages/aws-sdk-signers/tests/unit/test_signers.py
+++ b/packages/aws-sdk-signers/tests/unit/test_signers.py
@@ -9,6 +9,7 @@ from io import BytesIO
 
 import pytest
 from aws_sdk_signers import (
+    AsyncEventSigner,
     AsyncSigV4Signer,
     AWSCredentialIdentity,
     AWSRequest,
@@ -18,6 +19,7 @@ from aws_sdk_signers import (
     SigV4SigningProperties,
     URI,
 )
+from smithy_aws_event_stream.events import Event, EventHeaderEncoder, EventMessage
 
 SIGV4_RE = re.compile(
     r"AWS4-HMAC-SHA256 "
@@ -144,6 +146,58 @@ class UnreadableAsyncStream:
 
     async def __anext__(self) -> bytes:
         raise Exception("Read should not have been called!")
+
+
+class TestAsyncEventSigner:
+    async def test_sign_wraps_event_message_payload(
+        self,
+        aws_identity: AWSCredentialIdentity,
+    ) -> None:
+        signer = AsyncEventSigner(
+            initial_signature=b"initial-signature",
+            event_encoder_cls=EventHeaderEncoder,
+        )
+        message = EventMessage(
+            headers={":message-type": "event", ":event-type": "AudioEvent"},
+            payload=b"audio",
+        )
+
+        signed = await signer.sign(
+            event=message,
+            identity=aws_identity,
+            properties=SigV4SigningProperties(region="us-west-2", service="transcribe"),
+        )
+
+        assert (
+            signed.payload
+            == EventMessage(
+                headers={":message-type": "event", ":event-type": "AudioEvent"},
+                payload=b"audio",
+            ).encode()
+        )
+        assert ":date" in signed.headers
+        assert ":chunk-signature" in signed.headers
+
+    async def test_sign_empty_uses_zero_byte_outer_payload(
+        self,
+        aws_identity: AWSCredentialIdentity,
+    ) -> None:
+        signer = AsyncEventSigner(
+            initial_signature=b"initial-signature",
+            event_encoder_cls=EventHeaderEncoder,
+        )
+
+        signed = await signer.sign_empty(
+            event=EventMessage(),
+            identity=aws_identity,
+            properties=SigV4SigningProperties(region="us-west-2", service="transcribe"),
+        )
+
+        decoded = Event.decode(BytesIO(signed.encode()))
+        assert decoded is not None
+        assert decoded.message.payload == b""
+        assert ":date" in decoded.message.headers
+        assert ":chunk-signature" in decoded.message.headers
 
 
 class TestAsyncSigV4Signer:


### PR DESCRIPTION
Related Issue: https://github.com/awslabs/aws-sdk-python/issues/46
Related PR: https://github.com/smithy-lang/smithy-python/pull/691

### Summary
Adds `AsyncEventSigner.sign_empty` for producing SigV4-signed Amazon Event Stream terminator frames with zero-byte payloads.

### Details
Normal event signing wraps an encoded event message as the payload. Some AWS event stream services require a final signed empty frame before the HTTP body stream closes, which must use an actual zero-byte payload instead.

This keeps normal `sign()` behavior unchanged and shares the common signing logic through a private helper.

### Testing

I ported a modified version https://github.com/smithy-lang/smithy-python/pull/691 that calls `sign_empty` before closing the stream and confirmed that the [simple_file.py](https://github.com/awslabs/aws-sdk-python/blob/develop/clients/aws-sdk-transcribe-streaming/examples/simple_file.py) script ran successfully with just a `stream.close()` following the completion of sending all audio chunks. 

- Added coverage for normal event signing payload wrapping
- Added coverage for signed empty-frame payload behavior



---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
