### PR TITLE
Add Free Threading support to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.12", "3.13", "3.14", "3.14t", "3.15"]
 
     steps:
       - name: Checkout Repository

--- a/packages/aws-sdk-signers/pyproject.toml
+++ b/packages/aws-sdk-signers/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development :: Libraries"
 ]
 

--- a/packages/smithy-aws-core/pyproject.toml
+++ b/packages/smithy-aws-core/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [

--- a/packages/smithy-aws-event-stream/pyproject.toml
+++ b/packages/smithy-aws-event-stream/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [

--- a/packages/smithy-core/pyproject.toml
+++ b/packages/smithy-core/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = []

--- a/packages/smithy-http/pyproject.toml
+++ b/packages/smithy-http/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [

--- a/packages/smithy-json/pyproject.toml
+++ b/packages/smithy-json/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [

--- a/packages/smithy-xml/pyproject.toml
+++ b/packages/smithy-xml/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [


### PR DESCRIPTION
*Description of changes:*
The primary blocker for supporting [free threading](https://peps.python.org/pep-0779/) in Boto3/Botocore/Smithy Python was support in the upstream dependency, awscrt. Starting in awscrt 0.32.0 (https://github.com/awslabs/aws-crt-python/pull/725), releases began distributing artifacts for Python 3.13t and 3.14t. While 3.13t was released as experimental, 3.14t is starting to gain adoption.

Given there are no remaining blockers, this PR adds beta support for free threaded builds and makes sure that contract is validated in CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.