### PR TITLE
Rename Config and Plugin to service-specific names

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
@@ -4,37 +4,19 @@
  */
 package software.amazon.smithy.python.aws.codegen;
 
-import java.util.Set;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.PythonSettings;
 import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.python.codegen.integrations.PythonIntegration;
 import software.amazon.smithy.utils.StringUtils;
 
 public final class AwsServiceIdIntegration implements PythonIntegration {
-
-    /**
-     * SDK IDs of the AWS clients that were published under the unprefixed
-     * {@code <SdkId>Client} name before the {@code Async} prefix was adopted.
-     *
-     * <p>Only these clients generate a deprecated alias for the old name so that
-     * existing imports keep working. New clients are generated with the
-     * {@code Async}-prefixed name from the start and need no alias. This set can
-     * be removed once the aliases are dropped.
-     */
-    private static final Set<String> LEGACY_ALIAS_SDK_IDS = Set.of(
-            "Bedrock Runtime",
-            "ConnectHealth",
-            "Lex Runtime V2",
-            "Polly",
-            "QBusiness",
-            "SageMaker Runtime HTTP2",
-            "Transcribe Streaming");
 
     @Override
     public SymbolProvider decorateSymbolProvider(Model model, PythonSettings settings, SymbolProvider symbolProvider) {
@@ -58,7 +40,7 @@ public final class AwsServiceIdIntegration implements PythonIntegration {
                 var symbolBuilder = symbol.toBuilder().name("Async" + baseClientName);
                 // Only clients that already shipped under the unprefixed name get a
                 // backwards-compatible alias; new clients start life Async-prefixed.
-                if (LEGACY_ALIAS_SDK_IDS.contains(serviceTrait.getSdkId())) {
+                if (CodegenUtils.LEGACY_ALIAS_SDK_IDS.contains(serviceTrait.getSdkId())) {
                     symbolBuilder.putProperty(SymbolProperties.DEPRECATED_ALIAS, baseClientName);
                 }
                 symbol = symbolBuilder.build();

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsUserAgentIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsUserAgentIntegration.java
@@ -97,7 +97,7 @@ public class AwsUserAgentIntegration implements PythonIntegration {
                                                 moduleName + ".",
                                                 writer -> {
                                                     writer.write(USER_AGENT_PLUGIN,
-                                                            CodegenUtils.getConfigSymbol(c.settings()),
+                                                            CodegenUtils.getConfigSymbol(c.settings(), c.model()),
                                                             userAgentInterceptor,
                                                             versionSymbol,
                                                             serviceId);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -50,7 +50,6 @@ final class ClientGenerator implements Runnable {
 
     private void generateService(PythonWriter writer) {
         var serviceSymbol = symbolProvider.toSymbol(service);
-        writer.addLocallyDefinedSymbol(serviceSymbol);
         var configSymbol = CodegenUtils.getConfigSymbol(context.settings(), context.model());
         var pluginSymbol = CodegenUtils.getPluginSymbol(context.settings(), context.model());
         writer.addLogger();
@@ -238,7 +237,7 @@ final class ClientGenerator implements Runnable {
 
         writer.write("""
                 operation_plugins: list[${plugin:T}] = [
-                    $C
+                    $1C
                 ]
                 if plugins:
                     operation_plugins.extend(plugins)

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -51,8 +51,8 @@ final class ClientGenerator implements Runnable {
     private void generateService(PythonWriter writer) {
         var serviceSymbol = symbolProvider.toSymbol(service);
         writer.addLocallyDefinedSymbol(serviceSymbol);
-        var configSymbol = CodegenUtils.getConfigSymbol(context.settings());
-        var pluginSymbol = CodegenUtils.getPluginSymbol(context.settings());
+        var configSymbol = CodegenUtils.getConfigSymbol(context.settings(), context.model());
+        var pluginSymbol = CodegenUtils.getPluginSymbol(context.settings(), context.model());
         writer.addLogger();
 
         writer.openBlock("class $L:", "", serviceSymbol.getName(), () -> {
@@ -159,7 +159,7 @@ final class ClientGenerator implements Runnable {
     private void generateOperation(PythonWriter writer, OperationShape operation) {
         var operationSymbol = symbolProvider.toSymbol(operation);
         var operationMethodSymbol = operationSymbol.expectProperty(OPERATION_METHOD);
-        var pluginSymbol = CodegenUtils.getPluginSymbol(context.settings());
+        var pluginSymbol = CodegenUtils.getPluginSymbol(context.settings(), context.model());
 
         var input = model.expectShape(operation.getInputShape());
         var inputSymbol = symbolProvider.toSymbol(input);
@@ -237,8 +237,8 @@ final class ClientGenerator implements Runnable {
         writer.addStdlibImport("copy", "deepcopy");
 
         writer.write("""
-                operation_plugins: list[Plugin] = [
-                    $1C
+                operation_plugins: list[${plugin:T}] = [
+                    $C
                 ]
                 if plugins:
                     operation_plugins.extend(plugins)
@@ -283,7 +283,7 @@ final class ClientGenerator implements Runnable {
         writer.putContext("operation", operationSymbol);
         var operationMethodSymbol = operationSymbol.expectProperty(OPERATION_METHOD);
         writer.putContext("operationName", operationMethodSymbol.getName());
-        var pluginSymbol = CodegenUtils.getPluginSymbol(context.settings());
+        var pluginSymbol = CodegenUtils.getPluginSymbol(context.settings(), context.model());
         writer.putContext("plugin", pluginSymbol);
 
         var input = model.expectShape(operation.getInputShape());

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NullableIndex;
 import software.amazon.smithy.model.node.Node;
@@ -64,24 +65,46 @@ public final class CodegenUtils {
     private CodegenUtils() {}
 
     /**
+     * Gets the configuration object symbol for the service.
+     *
+     * <p>For AWS services with a {@code ServiceTrait}, this derives the name from the SDK ID
+     * (e.g., "Bedrock Runtime" becomes "BedrockRuntimeConfig"). For services without a
+     * {@code ServiceTrait}, falls back to the generic "Config" name.
+     *
      * @param settings The client settings, used to account for module configuration.
+     * @param model The model containing the service shape.
      * @return Returns the client's configuration object symbol.
      */
-    public static Symbol getConfigSymbol(PythonSettings settings) {
+    public static Symbol getConfigSymbol(PythonSettings settings, Model model) {
+        var service = settings.service(model);
+        var name = service.getTrait(ServiceTrait.class)
+                .map(trait -> StringUtils.capitalize(trait.getSdkId()).replace(" ", "") + "Config")
+                .orElse("Config");
         return Symbol.builder()
-                .name("Config")
+                .name(name)
                 .namespace(String.format("%s.config", settings.moduleName()), ".")
                 .definitionFile(String.format("./src/%s/config.py", settings.moduleName()))
                 .build();
     }
 
     /**
+     * Gets the plugin type hint symbol for the service.
+     *
+     * <p>For AWS services with a {@code ServiceTrait}, this derives the name from the SDK ID
+     * (e.g., "Bedrock Runtime" becomes "BedrockRuntimePlugin"). For services without a
+     * {@code ServiceTrait}, falls back to the generic "Plugin" name.
+     *
      * @param settings The client settings, used to account for module configuration.
+     * @param model The model containing the service shape.
      * @return Returns the client's plugin type hint symbol.
      */
-    public static Symbol getPluginSymbol(PythonSettings settings) {
+    public static Symbol getPluginSymbol(PythonSettings settings, Model model) {
+        var service = settings.service(model);
+        var name = service.getTrait(ServiceTrait.class)
+                .map(trait -> StringUtils.capitalize(trait.getSdkId()).replace(" ", "") + "Plugin")
+                .orElse("Plugin");
         return Symbol.builder()
-                .name("Plugin")
+                .name(name)
                 .namespace(String.format("%s.config", settings.moduleName()), ".")
                 .definitionFile(String.format("./src/%s/config.py", settings.moduleName()))
                 .build();

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -128,14 +128,24 @@ public final class CodegenUtils {
      */
     public static Symbol getPluginSymbol(PythonSettings settings, Model model) {
         var service = settings.service(model);
-        var name = service.getTrait(ServiceTrait.class)
+        var serviceTrait = service.getTrait(ServiceTrait.class);
+        var name = serviceTrait
                 .map(trait -> StringUtils.capitalize(trait.getSdkId()).replace(" ", "") + "Plugin")
                 .orElse("Plugin");
-        return Symbol.builder()
+        var builder = Symbol.builder()
                 .name(name)
                 .namespace(String.format("%s.config", settings.moduleName()), ".")
-                .definitionFile(String.format("./src/%s/config.py", settings.moduleName()))
-                .build();
+                .definitionFile(String.format("./src/%s/config.py", settings.moduleName()));
+
+        // Only services that already shipped under the unprefixed name get a
+        // backwards-compatible alias; new services start life with the service-prefixed name.
+        serviceTrait.ifPresent(trait -> {
+            if (LEGACY_ALIAS_SDK_IDS.contains(trait.getSdkId())) {
+                builder.putProperty(SymbolProperties.DEPRECATED_ALIAS, "Plugin");
+            }
+        });
+
+        return builder.build();
     }
 
     /**

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -65,10 +65,28 @@ public final class CodegenUtils {
     private CodegenUtils() {}
 
     /**
+     * SDK IDs of the AWS services that were published before the {@code Async}
+     * prefix was adopted for client and config class names.
+     *
+     * <p>Only these services generate deprecated aliases for the old names so that
+     * existing imports keep working. New services are generated with the
+     * {@code Async}-prefixed names from the start and need no alias. This set can
+     * be removed once the aliases are dropped.
+     */
+    public static final Set<String> LEGACY_ALIAS_SDK_IDS = Set.of(
+            "Bedrock Runtime",
+            "ConnectHealth",
+            "Lex Runtime V2",
+            "Polly",
+            "QBusiness",
+            "SageMaker Runtime HTTP2",
+            "Transcribe Streaming");
+
+    /**
      * Gets the configuration object symbol for the service.
      *
      * <p>For AWS services with a {@code ServiceTrait}, this derives the name from the SDK ID
-     * (e.g., "Bedrock Runtime" becomes "BedrockRuntimeConfig"). For services without a
+     * (e.g., "Bedrock Runtime" becomes "AsyncBedrockRuntimeConfig"). For services without a
      * {@code ServiceTrait}, falls back to the generic "Config" name.
      *
      * @param settings The client settings, used to account for module configuration.
@@ -77,14 +95,24 @@ public final class CodegenUtils {
      */
     public static Symbol getConfigSymbol(PythonSettings settings, Model model) {
         var service = settings.service(model);
-        var name = service.getTrait(ServiceTrait.class)
-                .map(trait -> StringUtils.capitalize(trait.getSdkId()).replace(" ", "") + "Config")
+        var serviceTrait = service.getTrait(ServiceTrait.class);
+        var name = serviceTrait
+                .map(trait -> "Async" + StringUtils.capitalize(trait.getSdkId()).replace(" ", "") + "Config")
                 .orElse("Config");
-        return Symbol.builder()
+        var builder = Symbol.builder()
                 .name(name)
                 .namespace(String.format("%s.config", settings.moduleName()), ".")
-                .definitionFile(String.format("./src/%s/config.py", settings.moduleName()))
-                .build();
+                .definitionFile(String.format("./src/%s/config.py", settings.moduleName()));
+
+        // Only services that already shipped under the unprefixed name get a
+        // backwards-compatible alias; new services start life Async-ServiceName-prefixed.
+        serviceTrait.ifPresent(trait -> {
+            if (LEGACY_ALIAS_SDK_IDS.contains(trait.getSdkId())) {
+                builder.putProperty(SymbolProperties.DEPRECATED_ALIAS, "Config");
+            }
+        });
+
+        return builder.build();
     }
 
     /**
@@ -92,7 +120,7 @@ public final class CodegenUtils {
      *
      * <p>For AWS services with a {@code ServiceTrait}, this derives the name from the SDK ID
      * (e.g., "Bedrock Runtime" becomes "BedrockRuntimePlugin"). For services without a
-     * {@code ServiceTrait}, falls back to the generic "Plugin" name.
+     * {@code ServiceTrait} (non-AWS SDKs), falls back to the generic "Plugin" name.
      *
      * @param settings The client settings, used to account for module configuration.
      * @param model The model containing the service shape.

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -191,7 +191,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                                     ${C|}
                                 )
                                 """,
-                                CodegenUtils.getConfigSymbol(context.settings()),
+                                CodegenUtils.getConfigSymbol(context.settings(), context.model()),
                                 host,
                                 path,
                                 REQUEST_TEST_ASYNC_HTTP_CLIENT_SYMBOL,
@@ -452,7 +452,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                                     ${C|}
                                 )
                                 """,
-                                CodegenUtils.getConfigSymbol(context.settings()),
+                                CodegenUtils.getConfigSymbol(context.settings(), context.model()),
                                 RESPONSE_TEST_ASYNC_HTTP_CLIENT_SYMBOL,
                                 testCase.getCode(),
                                 CodegenUtils.toTuples(testCase.getHeaders()),
@@ -507,7 +507,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                                     ${C|}
                                 )
                                 """,
-                                CodegenUtils.getConfigSymbol(context.settings()),
+                                CodegenUtils.getConfigSymbol(context.settings(), context.model()),
                                 RESPONSE_TEST_ASYNC_HTTP_CLIENT_SYMBOL,
                                 testCase.getCode(),
                                 CodegenUtils.toTuples(testCase.getHeaders()),

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -259,21 +259,57 @@ public final class ConfigGenerator implements Runnable {
 
     @Override
     public void run() {
-        var config = CodegenUtils.getConfigSymbol(context.settings());
+        var model = context.model();
+        var config = CodegenUtils.getConfigSymbol(context.settings(), model);
+        var genericConfigName = "Config";
         context.writerDelegator().useFileWriter(config.getDefinitionFile(), config.getNamespace(), writer -> {
             writeInterceptorsType(writer);
             generateConfig(context, writer);
+
+            // Generate deprecated Config alias if name differs from the generic name
+            if (!config.getName().equals(genericConfigName)) {
+                writer.addStdlibImport("warnings", "warn");
+                writer.addStdlibImport("typing", "Any");
+                writer.write("""
+
+
+                        class $1L($2L):
+                            \"""Deprecated: Use :class:`$2L` instead.\"""
+
+                            def __init__(self, *args: Any, **kwargs: Any):
+                                warn(
+                                    "Importing '$1L' is deprecated. Use '$2L' instead.",
+                                    DeprecationWarning,
+                                    stacklevel=2,
+                                )
+                                super().__init__(*args, **kwargs)
+                        """,
+                        genericConfigName,
+                        config.getName());
+            }
         });
 
         // Generate the plugin symbol. This is just a callable. We could do something
         // like have a class to implement, but that seems unnecessarily burdensome for
         // a single function.
-        var plugin = CodegenUtils.getPluginSymbol(context.settings());
+        var plugin = CodegenUtils.getPluginSymbol(context.settings(), model);
+        var genericPluginName = "Plugin";
         context.writerDelegator().useFileWriter(plugin.getDefinitionFile(), plugin.getNamespace(), writer -> {
             writer.addStdlibImport("typing", "Callable");
             writer.addStdlibImport("typing", "TypeAlias");
             writer.write("$L: TypeAlias = Callable[[$T], None]", plugin.getName(), config);
             writer.writeDocs("A callable that allows customizing the config object on each request.", context);
+
+            // Generate deprecated Plugin alias if name differs from the generic name
+            if (!plugin.getName().equals(genericPluginName)) {
+                writer.write("""
+
+                        $1L: TypeAlias = $2L
+                        \"""Deprecated: Use :data:`$2L` instead.\"""
+                        """,
+                        genericPluginName,
+                        plugin.getName());
+            }
         });
     }
 
@@ -305,7 +341,7 @@ public final class ConfigGenerator implements Runnable {
     }
 
     private void generateConfig(GenerationContext context, PythonWriter writer) {
-        var configSymbol = CodegenUtils.getConfigSymbol(context.settings());
+        var configSymbol = CodegenUtils.getConfigSymbol(context.settings(), context.model());
 
         // Initialize a set of config properties with our base properties.
         var properties = new TreeSet<>(Comparator.comparing(ConfigProperty::name));

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -261,55 +261,46 @@ public final class ConfigGenerator implements Runnable {
     public void run() {
         var model = context.model();
         var config = CodegenUtils.getConfigSymbol(context.settings(), model);
-        var genericConfigName = "Config";
         context.writerDelegator().useFileWriter(config.getDefinitionFile(), config.getNamespace(), writer -> {
             writeInterceptorsType(writer);
             generateConfig(context, writer);
 
-            // Generate deprecated Config alias if name differs from the generic name
-            if (!config.getName().equals(genericConfigName)) {
-                writer.addStdlibImport("warnings", "warn");
+            // Generate deprecated Config alias using __getattr__ if name differs
+            config.getProperty(SymbolProperties.DEPRECATED_ALIAS).ifPresent(alias -> {
+                writer.addStdlibImport("typing", "TYPE_CHECKING");
                 writer.addStdlibImport("typing", "Any");
+                writer.addStdlibImport("warnings");
                 writer.write("""
 
 
-                        class $1L($2L):
-                            \"""Deprecated: Use :class:`$2L` instead.\"""
+                        if TYPE_CHECKING:
+                            # Deprecated alias for backwards compatibility, to be removed.
+                            $1L = $2L
 
-                            def __init__(self, *args: Any, **kwargs: Any):
-                                warn(
-                                    "Importing '$1L' is deprecated. Use '$2L' instead.",
+
+                        def __getattr__(name: str) -> Any:
+                            if name == $1S:
+                                warnings.warn(
+                                    "$1L is deprecated, use $2L instead. "
+                                    "This alias will be removed in a future version.",
                                     DeprecationWarning,
                                     stacklevel=2,
                                 )
-                                super().__init__(*args, **kwargs)
-                        """,
-                        genericConfigName,
-                        config.getName());
-            }
+                                return $2L
+                            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+                        """, alias, config.getName());
+            });
         });
 
         // Generate the plugin symbol. This is just a callable. We could do something
         // like have a class to implement, but that seems unnecessarily burdensome for
         // a single function.
         var plugin = CodegenUtils.getPluginSymbol(context.settings(), model);
-        var genericPluginName = "Plugin";
         context.writerDelegator().useFileWriter(plugin.getDefinitionFile(), plugin.getNamespace(), writer -> {
             writer.addStdlibImport("typing", "Callable");
             writer.addStdlibImport("typing", "TypeAlias");
             writer.write("$L: TypeAlias = Callable[[$T], None]", plugin.getName(), config);
             writer.writeDocs("A callable that allows customizing the config object on each request.", context);
-
-            // Generate deprecated Plugin alias if name differs from the generic name
-            if (!plugin.getName().equals(genericPluginName)) {
-                writer.write("""
-
-                        $1L: TypeAlias = $2L
-                        \"""Deprecated: Use :data:`$2L` instead.\"""
-                        """,
-                        genericPluginName,
-                        plugin.getName());
-            }
         });
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -261,46 +261,70 @@ public final class ConfigGenerator implements Runnable {
     public void run() {
         var model = context.model();
         var config = CodegenUtils.getConfigSymbol(context.settings(), model);
+        var plugin = CodegenUtils.getPluginSymbol(context.settings(), model);
         context.writerDelegator().useFileWriter(config.getDefinitionFile(), config.getNamespace(), writer -> {
             writeInterceptorsType(writer);
             generateConfig(context, writer);
 
-            // Generate deprecated Config alias using __getattr__ if name differs
-            config.getProperty(SymbolProperties.DEPRECATED_ALIAS).ifPresent(alias -> {
+            // Generate the plugin type alias
+            writer.addStdlibImport("typing", "Callable");
+            writer.addStdlibImport("typing", "TypeAlias");
+            writer.write("");
+            writer.write("");
+            writer.write("$L: TypeAlias = Callable[[$T], None]", plugin.getName(), config);
+            writer.writeDocs("A callable that allows customizing the config object on each request.", context);
+
+            // Generate deprecated aliases using __getattr__ for backwards compatibility
+            var configAlias = config.getProperty(SymbolProperties.DEPRECATED_ALIAS);
+            var pluginAlias = plugin.getProperty(SymbolProperties.DEPRECATED_ALIAS);
+
+            if (configAlias.isPresent() || pluginAlias.isPresent()) {
                 writer.addStdlibImport("typing", "TYPE_CHECKING");
                 writer.addStdlibImport("typing", "Any");
                 writer.addStdlibImport("warnings");
-                writer.write("""
 
+                writer.write("");
+                writer.write("");
+                writer.openBlock("if TYPE_CHECKING:");
+                if (configAlias.isPresent()) {
+                    writer.write("# Deprecated alias for backwards compatibility, to be removed.");
+                    writer.write("$L = $L", configAlias.get(), config.getName());
+                }
+                if (pluginAlias.isPresent()) {
+                    writer.write("# Deprecated alias for backwards compatibility, to be removed.");
+                    writer.write("$L = $L", pluginAlias.get(), plugin.getName());
+                }
+                writer.closeBlock("");
 
-                        if TYPE_CHECKING:
-                            # Deprecated alias for backwards compatibility, to be removed.
-                            $1L = $2L
-
-
-                        def __getattr__(name: str) -> Any:
-                            if name == $1S:
-                                warnings.warn(
-                                    "$1L is deprecated, use $2L instead. "
-                                    "This alias will be removed in a future version.",
-                                    DeprecationWarning,
-                                    stacklevel=2,
-                                )
-                                return $2L
-                            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-                        """, alias, config.getName());
-            });
-        });
-
-        // Generate the plugin symbol. This is just a callable. We could do something
-        // like have a class to implement, but that seems unnecessarily burdensome for
-        // a single function.
-        var plugin = CodegenUtils.getPluginSymbol(context.settings(), model);
-        context.writerDelegator().useFileWriter(plugin.getDefinitionFile(), plugin.getNamespace(), writer -> {
-            writer.addStdlibImport("typing", "Callable");
-            writer.addStdlibImport("typing", "TypeAlias");
-            writer.write("$L: TypeAlias = Callable[[$T], None]", plugin.getName(), config);
-            writer.writeDocs("A callable that allows customizing the config object on each request.", context);
+                writer.write("");
+                writer.openBlock("def __getattr__(name: str) -> Any:");
+                if (configAlias.isPresent()) {
+                    writer.openBlock("if name == $S:", configAlias.get());
+                    writer.write("""
+                            warnings.warn(
+                                "$1L is deprecated, use $2L instead. "
+                                "This alias will be removed in a future version.",
+                                DeprecationWarning,
+                                stacklevel=2,
+                            )
+                            return $2L""", configAlias.get(), config.getName());
+                    writer.closeBlock("");
+                }
+                if (pluginAlias.isPresent()) {
+                    writer.openBlock("if name == $S:", pluginAlias.get());
+                    writer.write("""
+                            warnings.warn(
+                                "$1L is deprecated, use $2L instead. "
+                                "This alias will be removed in a future version.",
+                                DeprecationWarning,
+                                stacklevel=2,
+                            )
+                            return $2L""", pluginAlias.get(), plugin.getName());
+                    writer.closeBlock("");
+                }
+                writer.write("raise AttributeError(f\"module {__name__!r} has no attribute {name!r}\")");
+                writer.closeBlock("");
+            }
         });
     }
 

--- a/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-breaking-f95518e3e1b54466bc635067abb27987.json
+++ b/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-breaking-f95518e3e1b54466bc635067abb27987.json
@@ -1,0 +1,4 @@
+{
+  "type": "breaking",
+  "description": "Renamed generated Config to <ServiceName>Config and Plugin to <ServiceName>Plugin. Deprecated aliases are provided."
+}

--- a/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-breaking-c0f0f75e892f411bbacfa24be658c8ba.json
+++ b/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-breaking-c0f0f75e892f411bbacfa24be658c8ba.json
@@ -1,0 +1,4 @@
+{
+  "type": "breaking",
+  "description": "Renamed generated Config to <ServiceName>Config and Plugin to <ServiceName>Plugin. Deprecated aliases are provided."
+}

--- a/packages/smithy-aws-event-stream/.changes/next-release/smithy-aws-event-stream-breaking-231f43d52ea2468a8f2a07074310ee40.json
+++ b/packages/smithy-aws-event-stream/.changes/next-release/smithy-aws-event-stream-breaking-231f43d52ea2468a8f2a07074310ee40.json
@@ -1,0 +1,4 @@
+{
+  "type": "breaking",
+  "description": "Renamed generated Config to <ServiceName>Config and Plugin to <ServiceName>Plugin. Deprecated aliases are provided."
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Rename generated Config class to service-specific names derived from ServiceTrait sdkId (e.g., `BedrockRuntimeConfig`). Similarly rename Plugin to `<ServiceName>Plugin`. Deprecated aliases with `DeprecationWarning` are generated for backwards compatibility. Generic (Non-AWS SDKs) remain unchanged.

*Testing*
- Verified that all tests pass (`make test-py` and `make test-protocols`)
- Verified that “deprecation warning” is emitted when deprecated `Config` is used
- Verified that both `Config` and `BedrockRuntimeConfig` successfully make requests and receive responses
- Compared the diffs and verified that there are no changes for non-AWS sdks
- Compared the diffs and verified that capybara sdk generates `BedrockRuntimeConfig/BedrockRuntimePlugin` with deprecated aliases as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
