### PR TITLE
Implement client error correction

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -15,5 +15,5 @@
 
 allprojects {
     group = "software.amazon.smithy.python"
-    version = "0.3.0"
+    version = "0.3.1"
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/CodegenUtils.java
@@ -31,6 +31,7 @@ import software.amazon.smithy.model.knowledge.NullableIndex;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
@@ -126,6 +127,18 @@ public final class CodegenUtils {
     public static boolean isErrorMessage(Model model, MemberShape shape) {
         return ERROR_MESSAGE_MEMBER_NAMES.contains(shape.getMemberName().toLowerCase(Locale.US))
                 && model.expectShape(shape.getContainer()).hasTrait(ErrorTrait.class);
+    }
+
+    /**
+     * Determines whether a member is required in the generated Python constructor — that is,
+     * neither nullable nor carrying a default value.
+     *
+     * @param index A nullable index for the model.
+     * @param member The member to check.
+     * @return Returns whether the member is required in generated code.
+     */
+    public static boolean isRequiredMember(NullableIndex index, MemberShape member) {
+        return !index.isMemberNullable(member) && !member.hasTrait(DefaultTrait.class);
     }
 
     /**

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -763,12 +763,15 @@ public final class HttpProtocolTestGenerator implements Runnable {
 
         @Override
         public Void numberNode(NumberNode node) {
-            // TODO: Add support for timestamp, int-enum, and others
             if (inputShape.isTimestampShape()) {
                 var parsed = CodegenUtils.parseTimestampNode(model, inputShape, node);
                 writer.writeInline(CodegenUtils.getDatetimeConstructor(writer, parsed));
             } else if (inputShape.isFloatShape() || inputShape.isDoubleShape()) {
                 writer.writeInline("float($L)", node.getValue());
+            } else if (inputShape.isIntEnumShape()) {
+                var enumSymbol =
+                        context.symbolProvider().toSymbol(inputShape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+                writer.writeInline("$T($L)", enumSymbol, node.getValue());
             } else {
                 writer.writeInline("$L", node.getValue());
             }
@@ -800,6 +803,10 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 };
 
                 writer.writeInline("float($S)", value);
+            } else if (inputShape.isEnumShape()) {
+                var enumSymbol =
+                        context.symbolProvider().toSymbol(inputShape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+                writer.writeInline("$T($S)", enumSymbol, node.getValue());
             } else {
                 writer.writeInline("$S", node.getValue());
             }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -770,7 +770,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 writer.writeInline("float($L)", node.getValue());
             } else if (inputShape.isIntEnumShape()) {
                 var enumSymbol =
-                        context.symbolProvider().toSymbol(inputShape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+                        context.symbolProvider().toSymbol(inputShape);
                 writer.writeInline("$T($L)", enumSymbol, node.getValue());
             } else {
                 writer.writeInline("$L", node.getValue());
@@ -805,7 +805,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 writer.writeInline("float($S)", value);
             } else if (inputShape.isEnumShape()) {
                 var enumSymbol =
-                        context.symbolProvider().toSymbol(inputShape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+                        context.symbolProvider().toSymbol(inputShape);
                 writer.writeInline("$T($S)", enumSymbol, node.getValue());
             } else {
                 writer.writeInline("$S", node.getValue());

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
@@ -329,15 +329,9 @@ public final class PythonSymbolProvider implements SymbolProvider, ShapeVisitor<
     }
 
     private Symbol genericEnum(Shape shape) {
-        var enumSymbol = createGeneratedSymbolBuilder(shape, getDefaultShapeName(shape), SHAPES_FILE).build();
-
-        // We add this enum symbol as a property on a generic string/int symbol
-        // rather than returning the enum symbol directly because we only
-        // generate the enum constants for convenience. We actually want
-        // to pass around plain types rather than what is effectively
-        // a namespace class.
-        return createSymbolBuilder(shape, shape.isEnumShape() ? "str" : "int")
-                .putProperty(SymbolProperties.ENUM_SYMBOL, escaper.escapeSymbol(shape, enumSymbol))
+        Symbol symbol = createGeneratedSymbolBuilder(shape, getDefaultShapeName(shape), SHAPES_FILE).build();
+        return symbol.toBuilder()
+                .putProperty(SymbolProperties.ENUM_SYMBOL, escaper.escapeSymbol(shape, symbol))
                 .build();
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
@@ -330,9 +330,7 @@ public final class PythonSymbolProvider implements SymbolProvider, ShapeVisitor<
 
     private Symbol genericEnum(Shape shape) {
         Symbol symbol = createGeneratedSymbolBuilder(shape, getDefaultShapeName(shape), SHAPES_FILE).build();
-        return symbol.toBuilder()
-                .putProperty(SymbolProperties.ENUM_SYMBOL, escaper.escapeSymbol(shape, symbol))
-                .build();
+        return escaper.escapeSymbol(shape, symbol);
     }
 
     @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/RequiredMemberTargetIndex.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/RequiredMemberTargetIndex.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.python.codegen;
+
+import java.util.HashSet;
+import java.util.Set;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.KnowledgeIndex;
+import software.amazon.smithy.model.knowledge.NullableIndex;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Knowledge index of all shapes that are the target of a python-required structure member,
+ * i.e. the shapes that may need a synthesized default during client error correction.
+ *
+ * <p>Computed once per model and cached via {@link Model#getKnowledge}.
+ */
+@SmithyInternalApi
+public final class RequiredMemberTargetIndex implements KnowledgeIndex {
+
+    private final Set<ShapeId> targets = new HashSet<>();
+
+    private RequiredMemberTargetIndex(Model model) {
+        var index = NullableIndex.of(model);
+        for (var struct : model.getStructureShapes()) {
+            for (var member : struct.members()) {
+                if (CodegenUtils.isRequiredMember(index, member)) {
+                    targets.add(member.getTarget());
+                }
+            }
+        }
+    }
+
+    public static RequiredMemberTargetIndex of(Model model) {
+        return model.getKnowledge(RequiredMemberTargetIndex.class, RequiredMemberTargetIndex::new);
+    }
+
+    /**
+     * @param shape The shape to check.
+     * @return Returns whether the shape is the target of any python-required structure member.
+     */
+    public boolean isRequiredMemberTarget(ShapeId shape) {
+        return targets.contains(shape);
+    }
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
@@ -36,13 +36,6 @@ public final class SymbolProperties {
     public static final Property<Boolean> STDLIB = Property.named("stdlib");
 
     /**
-     * Contains a symbol representing the class containing known enum values for the symbol.
-     *
-     * <p>In type signatures, the base int or str is used instead for forwards compatibility.
-     */
-    public static final Property<Symbol> ENUM_SYMBOL = Property.named("enumSymbol");
-
-    /**
      * Contains a symbol representing the unknown variant of a union.
      */
     public static final Property<Symbol> UNION_UNKNOWN = Property.named("unknown");

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/EnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/EnumGenerator.java
@@ -13,7 +13,23 @@ import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
- * Renders enums.
+ * Renders enums as a {@code StrEnum} subclass.
+ *
+ * <p>Beyond the named members, the generated class has:
+ * <ul>
+ *   <li>{@code is_unknown} — public. {@code True} when the value didn't come
+ *       from a known member: either the service returned a value newer than
+ *       this SDK or client error correction filled in a placeholder.</li>
+ *   <li>{@code _missing_} — invoked when deserializing a value the SDK
+ *       doesn't recognize.</li>
+ *   <li>{@code _unknown} — invoked from {@link MemberErrorCorrectionGenerator}
+ *       to fill a missing required member.</li>
+ *   <li>{@code __eq__} / {@code __hash__} — overridden so an unknown value
+ *       is not equal to any known member, even if its underlying string
+ *       happens to match one.</li>
+ * </ul>
+ *
+ * @see <a href="https://smithy.io/2.0/spec/simple-types.html#enum">Smithy spec: enum</a>
  */
 @SmithyInternalApi
 public final class EnumGenerator implements Runnable {
@@ -30,6 +46,7 @@ public final class EnumGenerator implements Runnable {
         var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
         context.writerDelegator().useShapeWriter(shape, writer -> {
             writer.addStdlibImport("enum", "StrEnum");
+            writer.addStdlibImport("typing", "Self");
             writer.openBlock("class $L(StrEnum):", "", enumSymbol.getName(), () -> {
                 shape.getTrait(DocumentationTrait.class).ifPresent(trait -> {
                     writer.writeDocs(trait.getValue(), context);
@@ -43,6 +60,43 @@ public final class EnumGenerator implements Runnable {
                         writer.writeDocs(trait.getValue(), context);
                     });
                 }
+
+                writer.write("""
+
+                        @classmethod
+                        def _unknown(cls, value: str) -> "Self":
+                            pseudo = str.__new__(cls, value)
+                            pseudo._name_ = f"<smithy-unknown:{value}>"
+                            pseudo._value_ = value
+                            return pseudo
+
+                        @classmethod
+                        def _missing_(cls, value: object) -> "Self | None":
+                            if isinstance(value, str):
+                                return cls._unknown(value)
+                            return None
+
+                        @property
+                        def is_unknown(self) -> bool:
+                            \"""True if this value was not known at SDK generation time.\"""
+                            return self._name_ not in type(self).__members__
+
+                        def __eq__(self, other: object) -> bool:
+                            if self.is_unknown:
+                                return (
+                                    isinstance(other, type(self))
+                                    and other.is_unknown
+                                    and self._value_ == other._value_
+                                )
+                            if isinstance(other, type(self)) and other.is_unknown:
+                                return False
+                            return super().__eq__(other)
+
+                        def __hash__(self) -> int:
+                            if self.is_unknown:
+                                return hash(("<smithy-unknown>", type(self).__name__, self._value_))
+                            return super().__hash__()
+                        """);
             });
         });
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/EnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/EnumGenerator.java
@@ -9,25 +9,17 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.python.codegen.GenerationContext;
-import software.amazon.smithy.python.codegen.SymbolProperties;
+import software.amazon.smithy.python.codegen.SmithyPythonDependency;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Renders enums as a {@code StrEnum} subclass.
  *
- * <p>Beyond the named members, the generated class has:
- * <ul>
- *   <li>{@code is_unknown} — public. {@code True} when the value didn't come
- *       from a known member: either the service returned a value newer than
- *       this SDK or client error correction filled in a placeholder.</li>
- *   <li>{@code _missing_} — invoked when deserializing a value the SDK
- *       doesn't recognize.</li>
- *   <li>{@code _unknown} — invoked from {@link MemberErrorCorrectionGenerator}
- *       to fill a missing required member.</li>
- *   <li>{@code __eq__} / {@code __hash__} — overridden so an unknown value
- *       is not equal to any known member, even if its underlying string
- *       happens to match one.</li>
- * </ul>
+ * <p>The {@code UnknownEnumMixin} base from smithy-core handles values that
+ * weren't known at generation time: deserializing an unrecognized value (or
+ * filling a missing required member during client error correction, see
+ * {@link MemberErrorCorrectionGenerator}) produces a pseudo-member with
+ * {@code is_unknown} set rather than raising.
  *
  * @see <a href="https://smithy.io/2.0/spec/simple-types.html#enum">Smithy spec: enum</a>
  */
@@ -43,11 +35,12 @@ public final class EnumGenerator implements Runnable {
 
     @Override
     public void run() {
-        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+        var enumSymbol = context.symbolProvider().toSymbol(shape);
         context.writerDelegator().useShapeWriter(shape, writer -> {
             writer.addStdlibImport("enum", "StrEnum");
-            writer.addStdlibImport("typing", "Self");
-            writer.openBlock("class $L(StrEnum):", "", enumSymbol.getName(), () -> {
+            writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
+            writer.addImport("smithy_core.types", "UnknownEnumMixin");
+            writer.openBlock("class $L(UnknownEnumMixin, StrEnum):", "", enumSymbol.getName(), () -> {
                 shape.getTrait(DocumentationTrait.class).ifPresent(trait -> {
                     writer.writeDocs(trait.getValue(), context);
                 });
@@ -60,43 +53,6 @@ public final class EnumGenerator implements Runnable {
                         writer.writeDocs(trait.getValue(), context);
                     });
                 }
-
-                writer.write("""
-
-                        @classmethod
-                        def _unknown(cls, value: str) -> "Self":
-                            pseudo = str.__new__(cls, value)
-                            pseudo._name_ = f"<smithy-unknown:{value}>"
-                            pseudo._value_ = value
-                            return pseudo
-
-                        @classmethod
-                        def _missing_(cls, value: object) -> "Self | None":
-                            if isinstance(value, str):
-                                return cls._unknown(value)
-                            return None
-
-                        @property
-                        def is_unknown(self) -> bool:
-                            \"""True if this value was not known at SDK generation time.\"""
-                            return self._name_ not in type(self).__members__
-
-                        def __eq__(self, other: object) -> bool:
-                            if self.is_unknown:
-                                return (
-                                    isinstance(other, type(self))
-                                    and other.is_unknown
-                                    and self._value_ == other._value_
-                                )
-                            if isinstance(other, type(self)) and other.is_unknown:
-                                return False
-                            return super().__eq__(other)
-
-                        def __hash__(self) -> int:
-                            if self.is_unknown:
-                                return hash(("<smithy-unknown>", type(self).__name__, self._value_))
-                            return super().__hash__()
-                        """);
             });
         });
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/IntEnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/IntEnumGenerator.java
@@ -13,6 +13,25 @@ import software.amazon.smithy.python.codegen.PythonSettings;
 import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
+/**
+ * Renders intEnums as an {@code IntEnum} subclass.
+ *
+ * <p>Beyond the named members, the generated class has:
+ * <ul>
+ *   <li>{@code is_unknown} — public. {@code True} when the value didn't come
+ *       from a known member: either the service returned a value newer than
+ *       this SDK or client error correction filled in a placeholder.</li>
+ *   <li>{@code _missing_} — invoked when deserializing a value the SDK
+ *       doesn't recognize.</li>
+ *   <li>{@code _unknown} — invoked from {@link MemberErrorCorrectionGenerator}
+ *       to fill a missing required member.</li>
+ *   <li>{@code __eq__} / {@code __hash__} — overridden so an unknown value
+ *       is not equal to any known member, even if its underlying integer
+ *       happens to match one.</li>
+ * </ul>
+ *
+ * @see <a href="https://smithy.io/2.0/spec/simple-types.html#intenum">Smithy spec: intEnum</a>
+ */
 @SmithyInternalApi
 public final class IntEnumGenerator implements Runnable {
 
@@ -27,6 +46,7 @@ public final class IntEnumGenerator implements Runnable {
         var enumSymbol = directive.symbol().expectProperty(SymbolProperties.ENUM_SYMBOL);
         directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
             writer.addStdlibImport("enum", "IntEnum");
+            writer.addStdlibImport("typing", "Self");
             writer.openBlock("class $L(IntEnum):", "", enumSymbol.getName(), () -> {
                 directive.shape().getTrait(DocumentationTrait.class).ifPresent(trait -> {
                     writer.writeDocs(trait.getValue(), directive.context());
@@ -35,11 +55,48 @@ public final class IntEnumGenerator implements Runnable {
                 for (MemberShape member : directive.shape().members()) {
                     var name = directive.symbolProvider().toMemberName(member);
                     var value = member.expectTrait(EnumValueTrait.class).expectIntValue();
-                    writer.write("$L = $L\n", name, value);
+                    writer.write("$L = $L", name, value);
                     member.getTrait(DocumentationTrait.class).ifPresent(trait -> {
                         writer.writeDocs(trait.getValue(), directive.context());
                     });
                 }
+
+                writer.write("""
+
+                        @classmethod
+                        def _unknown(cls, value: int) -> "Self":
+                            pseudo = int.__new__(cls, value)
+                            pseudo._name_ = f"<smithy-unknown:{value}>"
+                            pseudo._value_ = value
+                            return pseudo
+
+                        @classmethod
+                        def _missing_(cls, value: object) -> "Self | None":
+                            if isinstance(value, int):
+                                return cls._unknown(value)
+                            return None
+
+                        @property
+                        def is_unknown(self) -> bool:
+                            \"""True if this value was not known at SDK generation time.\"""
+                            return self._name_ not in type(self).__members__
+
+                        def __eq__(self, other: object) -> bool:
+                            if self.is_unknown:
+                                return (
+                                    isinstance(other, type(self))
+                                    and other.is_unknown
+                                    and self._value_ == other._value_
+                                )
+                            if isinstance(other, type(self)) and other.is_unknown:
+                                return False
+                            return super().__eq__(other)
+
+                        def __hash__(self) -> int:
+                            if self.is_unknown:
+                                return hash(("<smithy-unknown>", type(self).__name__, self._value_))
+                            return super().__hash__()
+                        """);
             });
         });
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/IntEnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/IntEnumGenerator.java
@@ -10,25 +10,17 @@ import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.PythonSettings;
-import software.amazon.smithy.python.codegen.SymbolProperties;
+import software.amazon.smithy.python.codegen.SmithyPythonDependency;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Renders intEnums as an {@code IntEnum} subclass.
  *
- * <p>Beyond the named members, the generated class has:
- * <ul>
- *   <li>{@code is_unknown} — public. {@code True} when the value didn't come
- *       from a known member: either the service returned a value newer than
- *       this SDK or client error correction filled in a placeholder.</li>
- *   <li>{@code _missing_} — invoked when deserializing a value the SDK
- *       doesn't recognize.</li>
- *   <li>{@code _unknown} — invoked from {@link MemberErrorCorrectionGenerator}
- *       to fill a missing required member.</li>
- *   <li>{@code __eq__} / {@code __hash__} — overridden so an unknown value
- *       is not equal to any known member, even if its underlying integer
- *       happens to match one.</li>
- * </ul>
+ * <p>The {@code UnknownEnumMixin} base from smithy-core handles values that
+ * weren't known at generation time: deserializing an unrecognized value (or
+ * filling a missing required member during client error correction, see
+ * {@link MemberErrorCorrectionGenerator}) produces a pseudo-member with
+ * {@code is_unknown} set rather than raising.
  *
  * @see <a href="https://smithy.io/2.0/spec/simple-types.html#intenum">Smithy spec: intEnum</a>
  */
@@ -43,11 +35,12 @@ public final class IntEnumGenerator implements Runnable {
 
     @Override
     public void run() {
-        var enumSymbol = directive.symbol().expectProperty(SymbolProperties.ENUM_SYMBOL);
+        var enumSymbol = directive.symbol();
         directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
             writer.addStdlibImport("enum", "IntEnum");
-            writer.addStdlibImport("typing", "Self");
-            writer.openBlock("class $L(IntEnum):", "", enumSymbol.getName(), () -> {
+            writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
+            writer.addImport("smithy_core.types", "UnknownEnumMixin");
+            writer.openBlock("class $L(UnknownEnumMixin, IntEnum):", "", enumSymbol.getName(), () -> {
                 directive.shape().getTrait(DocumentationTrait.class).ifPresent(trait -> {
                     writer.writeDocs(trait.getValue(), directive.context());
                 });
@@ -60,43 +53,6 @@ public final class IntEnumGenerator implements Runnable {
                         writer.writeDocs(trait.getValue(), directive.context());
                     });
                 }
-
-                writer.write("""
-
-                        @classmethod
-                        def _unknown(cls, value: int) -> "Self":
-                            pseudo = int.__new__(cls, value)
-                            pseudo._name_ = f"<smithy-unknown:{value}>"
-                            pseudo._value_ = value
-                            return pseudo
-
-                        @classmethod
-                        def _missing_(cls, value: object) -> "Self | None":
-                            if isinstance(value, int):
-                                return cls._unknown(value)
-                            return None
-
-                        @property
-                        def is_unknown(self) -> bool:
-                            \"""True if this value was not known at SDK generation time.\"""
-                            return self._name_ not in type(self).__members__
-
-                        def __eq__(self, other: object) -> bool:
-                            if self.is_unknown:
-                                return (
-                                    isinstance(other, type(self))
-                                    and other.is_unknown
-                                    and self._value_ == other._value_
-                                )
-                            if isinstance(other, type(self)) and other.is_unknown:
-                                return False
-                            return super().__eq__(other)
-
-                        def __hash__(self) -> int:
-                            if self.is_unknown:
-                                return hash(("<smithy-unknown>", type(self).__name__, self._value_))
-                            return super().__hash__()
-                        """);
             });
         });
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberDeserializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberDeserializerGenerator.java
@@ -136,7 +136,7 @@ public class MemberDeserializerGenerator extends ShapeVisitor.DataShapeVisitor<V
     @Override
     public Void intEnumShape(IntEnumShape shape) {
         pushMemberState();
-        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+        var enumSymbol = context.symbolProvider().toSymbol(shape);
         writer.write("$T(${deserializer:L}.read_integer(${C|}))",
                 enumSymbol,
                 writer.consumer(w -> writeSchema()));
@@ -188,7 +188,7 @@ public class MemberDeserializerGenerator extends ShapeVisitor.DataShapeVisitor<V
     @Override
     public Void enumShape(EnumShape shape) {
         pushMemberState();
-        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+        var enumSymbol = context.symbolProvider().toSymbol(shape);
         writer.write("$T(${deserializer:L}.read_string(${C|}))",
                 enumSymbol,
                 writer.consumer(w -> writeSchema()));

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberDeserializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberDeserializerGenerator.java
@@ -135,7 +135,11 @@ public class MemberDeserializerGenerator extends ShapeVisitor.DataShapeVisitor<V
 
     @Override
     public Void intEnumShape(IntEnumShape shape) {
-        writeDeserializer("integer");
+        pushMemberState();
+        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+        writer.write("$T(${deserializer:L}.read_integer(${C|}))",
+                enumSymbol,
+                writer.consumer(w -> writeSchema()));
         return null;
     }
 
@@ -183,7 +187,11 @@ public class MemberDeserializerGenerator extends ShapeVisitor.DataShapeVisitor<V
 
     @Override
     public Void enumShape(EnumShape shape) {
-        writeDeserializer("string");
+        pushMemberState();
+        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+        writer.write("$T(${deserializer:L}.read_string(${C|}))",
+                enumSymbol,
+                writer.consumer(w -> writeSchema()));
         return null;
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
@@ -151,7 +151,7 @@ public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShape
         var enumSymbol = context.symbolProvider().toSymbol(shape);
         return writer -> {
             writer.addImport(enumSymbol, enumSymbol.getName());
-            writer.writeInline("$L._unknown(\"\")", enumSymbol.getName());
+            writer.writeInline("$L._corrected(\"\")", enumSymbol.getName());
         };
     }
 
@@ -160,7 +160,9 @@ public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShape
         var enumSymbol = context.symbolProvider().toSymbol(shape);
         return writer -> {
             writer.addImport(enumSymbol, enumSymbol.getName());
-            writer.writeInline("$L._unknown(0)", enumSymbol.getName());
+            // -1 is used (rather than 0) as the placeholder because it is least likely to
+            // collide with a real member value.
+            writer.writeInline("$L._corrected(-1)", enumSymbol.getName());
         };
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.python.codegen.generators;
+
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.EnumShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.python.codegen.GenerationContext;
+import software.amazon.smithy.python.codegen.SymbolProperties;
+import software.amazon.smithy.python.codegen.writer.PythonWriter;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Emits the Python expression used to fill a missing required member during client error
+ * correction.
+ *
+ * @see <a href="https://smithy.io/2.0/spec/aggregate-types.html#client-error-correction">Smithy
+ *     spec: Client error correction</a>
+ */
+@SmithyInternalApi
+public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShapeVisitor<Boolean> {
+
+    private final GenerationContext context;
+    private final PythonWriter writer;
+
+    public MemberErrorCorrectionGenerator(GenerationContext context, PythonWriter writer) {
+        this.context = context;
+        this.writer = writer;
+    }
+
+    /**
+     * @return {@code true} if the visitor will emit a default expression for this shape.
+     */
+    public static boolean hasDefault(Shape target) {
+        return switch (target.getType()) {
+            // Note on streaming shapes:
+            //   - Streaming unions (event streams) are filtered out earlier by
+            //     StructureGenerator#filterEventStreamMember and never reach this visitor,
+            //     so UNION can unconditionally return true here.
+            //   - Streaming blobs are NOT filtered earlier, so we explicitly exclude them
+            //     below. Per Smithy spec § 13.3.1, a missing streaming blob is already
+            //     handled by the deserializer (an empty HTTP body becomes a zero-length
+            //     AsyncBytesReader), so client error correction is unnecessary.
+            case BOOLEAN, BYTE, SHORT, INTEGER, LONG, BIG_INTEGER, FLOAT, DOUBLE, BIG_DECIMAL,
+                    STRING, TIMESTAMP, DOCUMENT, LIST, MAP, ENUM, INT_ENUM, STRUCTURE, UNION ->
+                true;
+            case BLOB -> !target.hasTrait(StreamingTrait.class);
+            default -> false;
+        };
+    }
+
+    @Override
+    public Boolean booleanShape(BooleanShape shape) {
+        writer.writeInline("False");
+        return true;
+    }
+
+    @Override
+    public Boolean byteShape(ByteShape shape) {
+        writer.writeInline("0");
+        return true;
+    }
+
+    @Override
+    public Boolean shortShape(ShortShape shape) {
+        writer.writeInline("0");
+        return true;
+    }
+
+    @Override
+    public Boolean integerShape(IntegerShape shape) {
+        writer.writeInline("0");
+        return true;
+    }
+
+    @Override
+    public Boolean longShape(LongShape shape) {
+        writer.writeInline("0");
+        return true;
+    }
+
+    @Override
+    public Boolean bigIntegerShape(BigIntegerShape shape) {
+        writer.writeInline("0");
+        return true;
+    }
+
+    @Override
+    public Boolean floatShape(FloatShape shape) {
+        writer.writeInline("0.0");
+        return true;
+    }
+
+    @Override
+    public Boolean doubleShape(DoubleShape shape) {
+        writer.writeInline("0.0");
+        return true;
+    }
+
+    @Override
+    public Boolean bigDecimalShape(BigDecimalShape shape) {
+        writer.addStdlibImport("decimal", "Decimal");
+        writer.writeInline("Decimal(0)");
+        return true;
+    }
+
+    @Override
+    public Boolean stringShape(StringShape shape) {
+        writer.writeInline("\"\"");
+        return true;
+    }
+
+    @Override
+    public Boolean blobShape(BlobShape shape) {
+        writer.writeInline("b\"\"");
+        return true;
+    }
+
+    @Override
+    public Boolean timestampShape(TimestampShape shape) {
+        writer.addStdlibImport("datetime", "datetime");
+        writer.addStdlibImport("datetime", "timezone");
+        writer.writeInline("datetime.fromtimestamp(0, tz=timezone.utc)");
+        return true;
+    }
+
+    @Override
+    public Boolean documentShape(DocumentShape shape) {
+        writer.addImport("smithy_core.documents", "Document");
+        writer.writeInline("Document(None)");
+        return true;
+    }
+
+    @Override
+    public Boolean listShape(ListShape shape) {
+        writer.writeInline("[]");
+        return true;
+    }
+
+    @Override
+    public Boolean mapShape(MapShape shape) {
+        writer.writeInline("{}");
+        return true;
+    }
+
+    @Override
+    public Boolean enumShape(EnumShape shape) {
+        // TODO: the Smithy spec recommends enum types define an unknown variant. If a
+        //   future change adds an unknown variant to the generated enum class (e.g.
+        //   MyEnum.unknown(value)), revisit this to emit it instead of the bare "".
+        writer.writeInline("\"\"");
+        return true;
+    }
+
+    @Override
+    public Boolean intEnumShape(IntEnumShape shape) {
+        // TODO: the Smithy spec recommends intEnum types define an unknown variant. If a
+        //   future change adds an unknown variant to the generated intEnum class (e.g.
+        //   MyIntEnum.unknown(value)), revisit this to emit it instead of the bare 0.
+        writer.writeInline("0");
+        return true;
+    }
+
+    @Override
+    public Boolean unionShape(UnionShape shape) {
+        var unknownSymbol = context.symbolProvider()
+                .toSymbol(shape)
+                .expectProperty(SymbolProperties.UNION_UNKNOWN);
+        writer.addImport(unknownSymbol, unknownSymbol.getName());
+        writer.writeInline("$L(tag=\"\")", unknownSymbol.getName());
+        return true;
+    }
+
+    @Override
+    public Boolean structureShape(StructureShape shape) {
+        // Delegate to the target struct's _smithy_default() so nested required fields are
+        // also filled in. Recursion terminates because Smithy forbids recursive paths whose
+        // members are all @required:
+        // https://smithy.io/2.0/spec/aggregate-types.html#recursive-shape-definitions
+        var symbol = context.symbolProvider().toSymbol(shape);
+        writer.addImport(symbol, symbol.getName());
+        writer.writeInline("$L._smithy_default()", symbol.getName());
+        return true;
+    }
+
+    @Override
+    public Boolean memberShape(MemberShape shape) {
+        return context.model().expectShape(shape.getTarget()).accept(this);
+    }
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
@@ -4,7 +4,7 @@
  */
 package software.amazon.smithy.python.codegen.generators;
 
-import software.amazon.smithy.model.Model;
+import java.util.function.Consumer;
 import software.amazon.smithy.model.knowledge.NullableIndex;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
@@ -21,57 +21,162 @@ import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.LongShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.ShortShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
-import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.python.codegen.writer.PythonWriter;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
- * Emits the Python expression used to fill a missing required member during client error
+ * Produces the Python expression used to fill a missing required member during client error
  * correction.
+ *
+ * <p>Visiting a shape returns a consumer that writes the default expression, or {@code null}
+ * if no default can be synthesized for the shape (a streaming shape, or a structure with a
+ * required member that itself has no synthesizable default). Callers decide what to do with
+ * unsynthesizable members; the visitor is the single source of truth for what is synthesizable.
  *
  * @see <a href="https://smithy.io/2.0/spec/aggregate-types.html#client-error-correction">Smithy
  *     spec: Client error correction</a>
  */
 @SmithyInternalApi
-public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShapeVisitor<Void> {
+public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShapeVisitor<Consumer<PythonWriter>> {
 
     private final GenerationContext context;
-    private final PythonWriter writer;
 
-    public MemberErrorCorrectionGenerator(GenerationContext context, PythonWriter writer) {
+    public MemberErrorCorrectionGenerator(GenerationContext context) {
         this.context = context;
-        this.writer = writer;
     }
 
-    /**
-     * @return {@code true} if the visitor will emit a default expression for this shape.
-     */
-    public static boolean hasDefault(Shape target, Model model) {
-        return switch (target.getType()) {
-            // Note on streaming shapes:
-            //   - Streaming unions (event streams) are filtered out earlier by
-            //     StructureGenerator#filterEventStreamMember and never reach this visitor,
-            //     so UNION can unconditionally return true here.
-            //   - Streaming blobs are NOT filtered earlier, so we explicitly exclude them
-            //     below. Per Smithy spec § 13.3.1, a missing streaming blob is already
-            //     handled by the deserializer (an empty HTTP body becomes a zero-length
-            //     AsyncBytesReader), so client error correction is unnecessary.
-            case BOOLEAN, BYTE, SHORT, INTEGER, LONG, BIG_INTEGER, FLOAT, DOUBLE, BIG_DECIMAL,
-                    STRING, TIMESTAMP, DOCUMENT, LIST, MAP, ENUM, INT_ENUM, UNION ->
-                true;
-            case BLOB -> !target.hasTrait(StreamingTrait.class);
-            case STRUCTURE -> structHasDefault((StructureShape) target, model);
-            default -> false;
+    @Override
+    public Consumer<PythonWriter> booleanShape(BooleanShape shape) {
+        return writer -> writer.writeInline("False");
+    }
+
+    @Override
+    public Consumer<PythonWriter> byteShape(ByteShape shape) {
+        return writer -> writer.writeInline("0");
+    }
+
+    @Override
+    public Consumer<PythonWriter> shortShape(ShortShape shape) {
+        return writer -> writer.writeInline("0");
+    }
+
+    @Override
+    public Consumer<PythonWriter> integerShape(IntegerShape shape) {
+        return writer -> writer.writeInline("0");
+    }
+
+    @Override
+    public Consumer<PythonWriter> longShape(LongShape shape) {
+        return writer -> writer.writeInline("0");
+    }
+
+    @Override
+    public Consumer<PythonWriter> bigIntegerShape(BigIntegerShape shape) {
+        return writer -> writer.writeInline("0");
+    }
+
+    @Override
+    public Consumer<PythonWriter> floatShape(FloatShape shape) {
+        return writer -> writer.writeInline("0.0");
+    }
+
+    @Override
+    public Consumer<PythonWriter> doubleShape(DoubleShape shape) {
+        return writer -> writer.writeInline("0.0");
+    }
+
+    @Override
+    public Consumer<PythonWriter> bigDecimalShape(BigDecimalShape shape) {
+        return writer -> {
+            writer.addStdlibImport("decimal", "Decimal");
+            writer.writeInline("Decimal(0)");
+        };
+    }
+
+    @Override
+    public Consumer<PythonWriter> stringShape(StringShape shape) {
+        return writer -> writer.writeInline("\"\"");
+    }
+
+    @Override
+    public Consumer<PythonWriter> blobShape(BlobShape shape) {
+        // Per Smithy spec § 13.3.1, a missing streaming blob is already handled by the
+        // deserializer (an empty HTTP body becomes a zero-length AsyncBytesReader), so
+        // client error correction is unnecessary.
+        if (shape.hasTrait(StreamingTrait.class)) {
+            return null;
+        }
+        return writer -> writer.writeInline("b\"\"");
+    }
+
+    @Override
+    public Consumer<PythonWriter> timestampShape(TimestampShape shape) {
+        return writer -> {
+            writer.addStdlibImport("datetime", "datetime");
+            writer.addStdlibImport("datetime", "timezone");
+            writer.writeInline("datetime.fromtimestamp(0, tz=timezone.utc)");
+        };
+    }
+
+    @Override
+    public Consumer<PythonWriter> documentShape(DocumentShape shape) {
+        return writer -> {
+            writer.addImport("smithy_core.documents", "Document");
+            writer.writeInline("Document(None)");
+        };
+    }
+
+    @Override
+    public Consumer<PythonWriter> listShape(ListShape shape) {
+        return writer -> writer.writeInline("[]");
+    }
+
+    @Override
+    public Consumer<PythonWriter> mapShape(MapShape shape) {
+        return writer -> writer.writeInline("{}");
+    }
+
+    @Override
+    public Consumer<PythonWriter> enumShape(EnumShape shape) {
+        var enumSymbol = context.symbolProvider().toSymbol(shape);
+        return writer -> {
+            writer.addImport(enumSymbol, enumSymbol.getName());
+            writer.writeInline("$L._unknown(\"\")", enumSymbol.getName());
+        };
+    }
+
+    @Override
+    public Consumer<PythonWriter> intEnumShape(IntEnumShape shape) {
+        var enumSymbol = context.symbolProvider().toSymbol(shape);
+        return writer -> {
+            writer.addImport(enumSymbol, enumSymbol.getName());
+            writer.writeInline("$L._unknown(0)", enumSymbol.getName());
+        };
+    }
+
+    @Override
+    public Consumer<PythonWriter> unionShape(UnionShape shape) {
+        // Streaming unions (event streams) have no synthesizable default; they also never
+        // appear as dataclass properties, so missing ones don't need correction.
+        if (shape.hasTrait(StreamingTrait.class)) {
+            return null;
+        }
+        var unknownSymbol = context.symbolProvider()
+                .toSymbol(shape)
+                .expectProperty(SymbolProperties.UNION_UNKNOWN);
+        return writer -> {
+            writer.addImport(unknownSymbol, unknownSymbol.getName());
+            writer.writeInline("$L(tag=\"\")", unknownSymbol.getName());
         };
     }
 
@@ -83,149 +188,26 @@ public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShape
      *
      * See https://smithy.io/2.0/spec/aggregate-types.html#recursive-shape-definitions
      */
-    private static boolean structHasDefault(StructureShape struct, Model model) {
-        var index = NullableIndex.of(model);
-        for (MemberShape member : struct.members()) {
-            if (index.isMemberNullable(member) || member.hasTrait(DefaultTrait.class)) {
+    @Override
+    public Consumer<PythonWriter> structureShape(StructureShape shape) {
+        var index = NullableIndex.of(context.model());
+        for (MemberShape member : shape.members()) {
+            if (!CodegenUtils.isRequiredMember(index, member)) {
                 continue;
             }
-            if (!hasDefault(model.expectShape(member.getTarget()), model)) {
-                return false;
+            if (context.model().expectShape(member.getTarget()).accept(this) == null) {
+                return null;
             }
         }
-        return true;
-    }
-
-    @Override
-    public Void booleanShape(BooleanShape shape) {
-        writer.writeInline("False");
-        return null;
-    }
-
-    @Override
-    public Void byteShape(ByteShape shape) {
-        writer.writeInline("0");
-        return null;
-    }
-
-    @Override
-    public Void shortShape(ShortShape shape) {
-        writer.writeInline("0");
-        return null;
-    }
-
-    @Override
-    public Void integerShape(IntegerShape shape) {
-        writer.writeInline("0");
-        return null;
-    }
-
-    @Override
-    public Void longShape(LongShape shape) {
-        writer.writeInline("0");
-        return null;
-    }
-
-    @Override
-    public Void bigIntegerShape(BigIntegerShape shape) {
-        writer.writeInline("0");
-        return null;
-    }
-
-    @Override
-    public Void floatShape(FloatShape shape) {
-        writer.writeInline("0.0");
-        return null;
-    }
-
-    @Override
-    public Void doubleShape(DoubleShape shape) {
-        writer.writeInline("0.0");
-        return null;
-    }
-
-    @Override
-    public Void bigDecimalShape(BigDecimalShape shape) {
-        writer.addStdlibImport("decimal", "Decimal");
-        writer.writeInline("Decimal(0)");
-        return null;
-    }
-
-    @Override
-    public Void stringShape(StringShape shape) {
-        writer.writeInline("\"\"");
-        return null;
-    }
-
-    @Override
-    public Void blobShape(BlobShape shape) {
-        writer.writeInline("b\"\"");
-        return null;
-    }
-
-    @Override
-    public Void timestampShape(TimestampShape shape) {
-        writer.addStdlibImport("datetime", "datetime");
-        writer.addStdlibImport("datetime", "timezone");
-        writer.writeInline("datetime.fromtimestamp(0, tz=timezone.utc)");
-        return null;
-    }
-
-    @Override
-    public Void documentShape(DocumentShape shape) {
-        writer.addImport("smithy_core.documents", "Document");
-        writer.writeInline("Document(None)");
-        return null;
-    }
-
-    @Override
-    public Void listShape(ListShape shape) {
-        writer.writeInline("[]");
-        return null;
-    }
-
-    @Override
-    public Void mapShape(MapShape shape) {
-        writer.writeInline("{}");
-        return null;
-    }
-
-    @Override
-    public Void enumShape(EnumShape shape) {
-        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
-        writer.addImport(enumSymbol, enumSymbol.getName());
-        writer.writeInline("$L._unknown(\"\")", enumSymbol.getName());
-        return null;
-    }
-
-    @Override
-    public Void intEnumShape(IntEnumShape shape) {
-        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
-        writer.addImport(enumSymbol, enumSymbol.getName());
-        writer.writeInline("$L._unknown(0)", enumSymbol.getName());
-        return null;
-    }
-
-    @Override
-    public Void unionShape(UnionShape shape) {
-        var unknownSymbol = context.symbolProvider()
-                .toSymbol(shape)
-                .expectProperty(SymbolProperties.UNION_UNKNOWN);
-        writer.addImport(unknownSymbol, unknownSymbol.getName());
-        writer.writeInline("$L(tag=\"\")", unknownSymbol.getName());
-        return null;
-    }
-
-    @Override
-    public Void structureShape(StructureShape shape) {
         var symbol = context.symbolProvider().toSymbol(shape);
-        writer.addImport(symbol, symbol.getName());
-        writer.writeInline("$L._smithy_default()", symbol.getName());
-        return null;
+        return writer -> {
+            writer.addImport(symbol, symbol.getName());
+            writer.writeInline("$L._smithy_default()", symbol.getName());
+        };
     }
 
     @Override
-    public Void memberShape(MemberShape shape) {
+    public Consumer<PythonWriter> memberShape(MemberShape shape) {
         return context.model().expectShape(shape.getTarget()).accept(this);
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
@@ -4,6 +4,8 @@
  */
 package software.amazon.smithy.python.codegen.generators;
 
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.NullableIndex;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
 import software.amazon.smithy.model.shapes.BlobShape;
@@ -26,6 +28,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.SymbolProperties;
@@ -40,7 +43,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  *     spec: Client error correction</a>
  */
 @SmithyInternalApi
-public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShapeVisitor<Boolean> {
+public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShapeVisitor<Void> {
 
     private final GenerationContext context;
     private final PythonWriter writer;
@@ -53,7 +56,7 @@ public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShape
     /**
      * @return {@code true} if the visitor will emit a default expression for this shape.
      */
-    public static boolean hasDefault(Shape target) {
+    public static boolean hasDefault(Shape target, Model model) {
         return switch (target.getType()) {
             // Note on streaming shapes:
             //   - Streaming unions (event streams) are filtered out earlier by
@@ -64,149 +67,165 @@ public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShape
             //     handled by the deserializer (an empty HTTP body becomes a zero-length
             //     AsyncBytesReader), so client error correction is unnecessary.
             case BOOLEAN, BYTE, SHORT, INTEGER, LONG, BIG_INTEGER, FLOAT, DOUBLE, BIG_DECIMAL,
-                    STRING, TIMESTAMP, DOCUMENT, LIST, MAP, ENUM, INT_ENUM, STRUCTURE, UNION ->
+                    STRING, TIMESTAMP, DOCUMENT, LIST, MAP, ENUM, INT_ENUM, UNION ->
                 true;
             case BLOB -> !target.hasTrait(StreamingTrait.class);
+            case STRUCTURE -> structHasDefault((StructureShape) target, model);
             default -> false;
         };
     }
 
+    /**
+     * We can build a default for a struct only when we can build a default for each of its
+     * required members, so we have to recurse into nested structs. The recursion is safe
+     * because Smithy doesn't allow cycles where every member along the path is @required;
+     * we'll always reach a base case (a primitive, list, map, etc.) before looping back.
+     *
+     * See https://smithy.io/2.0/spec/aggregate-types.html#recursive-shape-definitions
+     */
+    private static boolean structHasDefault(StructureShape struct, Model model) {
+        var index = NullableIndex.of(model);
+        for (MemberShape member : struct.members()) {
+            if (index.isMemberNullable(member) || member.hasTrait(DefaultTrait.class)) {
+                continue;
+            }
+            if (!hasDefault(model.expectShape(member.getTarget()), model)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
-    public Boolean booleanShape(BooleanShape shape) {
+    public Void booleanShape(BooleanShape shape) {
         writer.writeInline("False");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean byteShape(ByteShape shape) {
+    public Void byteShape(ByteShape shape) {
         writer.writeInline("0");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean shortShape(ShortShape shape) {
+    public Void shortShape(ShortShape shape) {
         writer.writeInline("0");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean integerShape(IntegerShape shape) {
+    public Void integerShape(IntegerShape shape) {
         writer.writeInline("0");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean longShape(LongShape shape) {
+    public Void longShape(LongShape shape) {
         writer.writeInline("0");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean bigIntegerShape(BigIntegerShape shape) {
+    public Void bigIntegerShape(BigIntegerShape shape) {
         writer.writeInline("0");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean floatShape(FloatShape shape) {
+    public Void floatShape(FloatShape shape) {
         writer.writeInline("0.0");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean doubleShape(DoubleShape shape) {
+    public Void doubleShape(DoubleShape shape) {
         writer.writeInline("0.0");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean bigDecimalShape(BigDecimalShape shape) {
+    public Void bigDecimalShape(BigDecimalShape shape) {
         writer.addStdlibImport("decimal", "Decimal");
         writer.writeInline("Decimal(0)");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean stringShape(StringShape shape) {
+    public Void stringShape(StringShape shape) {
         writer.writeInline("\"\"");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean blobShape(BlobShape shape) {
+    public Void blobShape(BlobShape shape) {
         writer.writeInline("b\"\"");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean timestampShape(TimestampShape shape) {
+    public Void timestampShape(TimestampShape shape) {
         writer.addStdlibImport("datetime", "datetime");
         writer.addStdlibImport("datetime", "timezone");
         writer.writeInline("datetime.fromtimestamp(0, tz=timezone.utc)");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean documentShape(DocumentShape shape) {
+    public Void documentShape(DocumentShape shape) {
         writer.addImport("smithy_core.documents", "Document");
         writer.writeInline("Document(None)");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean listShape(ListShape shape) {
+    public Void listShape(ListShape shape) {
         writer.writeInline("[]");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean mapShape(MapShape shape) {
+    public Void mapShape(MapShape shape) {
         writer.writeInline("{}");
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean enumShape(EnumShape shape) {
-        // TODO: the Smithy spec recommends enum types define an unknown variant. If a
-        //   future change adds an unknown variant to the generated enum class (e.g.
-        //   MyEnum.unknown(value)), revisit this to emit it instead of the bare "".
-        writer.writeInline("\"\"");
-        return true;
+    public Void enumShape(EnumShape shape) {
+        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+        writer.addImport(enumSymbol, enumSymbol.getName());
+        writer.writeInline("$L._unknown(\"\")", enumSymbol.getName());
+        return null;
     }
 
     @Override
-    public Boolean intEnumShape(IntEnumShape shape) {
-        // TODO: the Smithy spec recommends intEnum types define an unknown variant. If a
-        //   future change adds an unknown variant to the generated intEnum class (e.g.
-        //   MyIntEnum.unknown(value)), revisit this to emit it instead of the bare 0.
-        writer.writeInline("0");
-        return true;
+    public Void intEnumShape(IntEnumShape shape) {
+        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
+        writer.addImport(enumSymbol, enumSymbol.getName());
+        writer.writeInline("$L._unknown(0)", enumSymbol.getName());
+        return null;
     }
 
     @Override
-    public Boolean unionShape(UnionShape shape) {
+    public Void unionShape(UnionShape shape) {
         var unknownSymbol = context.symbolProvider()
                 .toSymbol(shape)
                 .expectProperty(SymbolProperties.UNION_UNKNOWN);
         writer.addImport(unknownSymbol, unknownSymbol.getName());
         writer.writeInline("$L(tag=\"\")", unknownSymbol.getName());
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean structureShape(StructureShape shape) {
-        // Delegate to the target struct's _smithy_default() so nested required fields are
-        // also filled in. Recursion terminates because Smithy forbids recursive paths whose
-        // members are all @required:
-        // https://smithy.io/2.0/spec/aggregate-types.html#recursive-shape-definitions
+    public Void structureShape(StructureShape shape) {
         var symbol = context.symbolProvider().toSymbol(shape);
         writer.addImport(symbol, symbol.getName());
         writer.writeInline("$L._smithy_default()", symbol.getName());
-        return true;
+        return null;
     }
 
     @Override
-    public Boolean memberShape(MemberShape shape) {
+    public Void memberShape(MemberShape shape) {
         return context.model().expectShape(shape.getTarget()).accept(this);
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -9,8 +9,11 @@ import static software.amazon.smithy.python.codegen.CodegenUtils.isErrorMessage;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -374,6 +377,9 @@ public final class StructureGenerator implements Runnable {
         var schemaSymbol = symbolProvider.toSymbol(shape).expectProperty(SymbolProperties.SCHEMA);
         writer.putContext("schema", schemaSymbol);
 
+        var corrections = errorCorrections();
+        writer.putContext("errorCorrection", !corrections.isEmpty());
+
         // TODO: either formalize deserialize_kwargs or remove it when http serde is converted
         writer.write("""
                 @classmethod
@@ -391,38 +397,49 @@ public final class StructureGenerator implements Runnable {
                                 logger.debug("Unexpected member schema: %s", schema)
 
                     deserializer.read_struct($T, consumer=_consumer)
+                    ${?errorCorrection}
                     ${C|}
+                    ${/errorCorrection}
                     return kwargs
 
                 """,
                 writer.consumer(w -> deserializeMembers(shape.members())),
                 schemaSymbol,
-                writer.consumer(w -> writeErrorCorrection()));
+                writer.consumer(w -> writeErrorCorrection(corrections)));
         writer.popState();
     }
 
     /**
-     * Emits client error correction for required members the server failed to serialize.
+     * Collects client error correction defaults for required members the server failed
+     * to serialize, keyed by member name. Members whose targets have no synthesizable
+     * default (e.g. a streaming blob) are omitted; the dataclass will raise for those.
      *
      * @see <a href="https://smithy.io/2.0/spec/aggregate-types.html#client-error-correction">Smithy
      *     spec: Client error correction</a>
      */
-    private void writeErrorCorrection() {
+    private Map<String, Consumer<PythonWriter>> errorCorrections() {
         var visitor = new MemberErrorCorrectionGenerator(context);
+        var corrections = new LinkedHashMap<String, Consumer<PythonWriter>>();
         for (MemberShape member : requiredMembers) {
             var defaultExpression = model.expectShape(member.getTarget()).accept(visitor);
             if (defaultExpression == null) {
-                // No synthesizable default (e.g. a streaming blob); let the dataclass raise.
                 continue;
             }
+            corrections.put(symbolProvider.toMemberName(member), defaultExpression);
+        }
+        return corrections;
+    }
+
+    private void writeErrorCorrection(Map<String, Consumer<PythonWriter>> corrections) {
+        corrections.forEach((memberName, defaultExpression) -> {
             writer.pushState();
-            writer.putContext("memberName", symbolProvider.toMemberName(member));
+            writer.putContext("memberName", memberName);
             writer.write("""
                     if ${memberName:S} not in kwargs:
                         kwargs[${memberName:S}] = ${C|}""",
                     writer.consumer(defaultExpression));
             writer.popState();
-        }
+        });
     }
 
     /**

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -104,12 +104,15 @@ public final class StructureGenerator implements Runnable {
 
                     ${C|}
 
+                    ${C|}
+
                 """,
                 symbol.getName(),
                 writer.consumer(w -> writeClassDocs()),
                 writer.consumer(w -> writeProperties()),
                 writer.consumer(w -> generateSerializeMethod()),
-                writer.consumer(w -> generateDeserializeMethod()));
+                writer.consumer(w -> generateDeserializeMethod()),
+                writer.consumer(w -> generateSmithyDefaultMethod()));
     }
 
     private void renderError() {
@@ -147,6 +150,8 @@ public final class StructureGenerator implements Runnable {
 
                     ${7C|}
 
+                    ${8C|}
+
                 """,
                 symbol.getName(),
                 baseError,
@@ -154,7 +159,8 @@ public final class StructureGenerator implements Runnable {
                 writer.consumer(w -> writeClassDocs()),
                 writer.consumer(w -> writeProperties()),
                 writer.consumer(w -> generateSerializeMethod()),
-                writer.consumer(w -> generateDeserializeMethod()));
+                writer.consumer(w -> generateDeserializeMethod()),
+                writer.consumer(w -> generateSmithyDefaultMethod()));
     }
 
     private void writeClassDocs() {
@@ -375,12 +381,76 @@ public final class StructureGenerator implements Runnable {
                                 logger.debug("Unexpected member schema: %s", schema)
 
                     deserializer.read_struct($T, consumer=_consumer)
+                    ${C|}
                     return kwargs
 
                 """,
                 writer.consumer(w -> deserializeMembers(shape.members())),
-                schemaSymbol);
+                schemaSymbol,
+                writer.consumer(w -> writeErrorCorrection()));
         writer.popState();
+    }
+
+    /**
+     * Emits client error correction for required members the server failed to serialize.
+     *
+     * @see <a href="https://smithy.io/2.0/spec/aggregate-types.html#client-error-correction">Smithy
+     *     spec: Client error correction</a>
+     */
+    private void writeErrorCorrection() {
+        var visitor = new MemberErrorCorrectionGenerator(context, writer);
+        for (MemberShape member : requiredMembers) {
+            var target = model.expectShape(member.getTarget());
+            if (!MemberErrorCorrectionGenerator.hasDefault(target)) {
+                // Streaming shapes have no synthesizable default; let the dataclass raise.
+                continue;
+            }
+            writer.pushState();
+            writer.putContext("memberName", symbolProvider.toMemberName(member));
+            writer.write("""
+                    if ${memberName:S} not in kwargs:
+                        kwargs[${memberName:S}] = ${C|}""",
+                    writer.consumer(w -> target.accept(visitor)));
+            writer.popState();
+        }
+    }
+
+    /**
+     * Emits a {@code _smithy_default()} classmethod that constructs an instance with all
+     * required members filled in via client error correction. Used to fill nested structure
+     * members per the Smithy spec. If the structure has any required member whose target has
+     * no synthesizable default (i.e. a streaming blob), {@code _smithy_default()} is omitted:
+     * a generated {@code cls()} call would be missing a required argument. But such structures
+     * can only appear as a top-level operation input or output (per spec § 13.3), never as a
+     * nested-struct member, so {@code _smithy_default()} would never be invoked on them anyway.
+     */
+    private void generateSmithyDefaultMethod() {
+        for (MemberShape member : requiredMembers) {
+            var target = model.expectShape(member.getTarget());
+            if (!MemberErrorCorrectionGenerator.hasDefault(target)) {
+                return;
+            }
+        }
+        writer.write("""
+                @classmethod
+                def _smithy_default(cls) -> Self:
+                    return cls(${C|})
+                """,
+                writer.consumer(w -> writeSmithyDefaultArguments()));
+    }
+
+    private void writeSmithyDefaultArguments() {
+        var visitor = new MemberErrorCorrectionGenerator(context, writer);
+        var first = true;
+        for (MemberShape member : requiredMembers) {
+            var target = model.expectShape(member.getTarget());
+            if (!first) {
+                writer.writeInline(", ");
+            }
+            first = false;
+            writer.writeInline("$L=", symbolProvider.toMemberName(member));
+            target.accept(visitor);
+        }
     }
 
     private void deserializeMembers(Collection<MemberShape> members) {

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.PythonSettings;
+import software.amazon.smithy.python.codegen.RequiredMemberTargetIndex;
 import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.python.codegen.writer.PythonWriter;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -67,10 +68,10 @@ public final class StructureGenerator implements Runnable {
         var optional = new ArrayList<MemberShape>();
         var index = NullableIndex.of(context.model());
         for (MemberShape member : shape.members()) {
-            if (index.isMemberNullable(member) || member.hasTrait(DefaultTrait.class)) {
-                optional.add(member);
-            } else {
+            if (CodegenUtils.isRequiredMember(index, member)) {
                 required.add(member);
+            } else {
+                optional.add(member);
             }
         }
         this.requiredMembers = filterPropertyMembers(required);
@@ -280,11 +281,11 @@ public final class StructureGenerator implements Runnable {
             return String.format("b'%s'", defaultNode.expectStringNode().getValue());
         } else if (target.isEnumShape()) {
             // Wrap rather than emit a bare string so the value matches the field type.
-            var enumSymbol = symbolProvider.toSymbol(target).expectProperty(SymbolProperties.ENUM_SYMBOL);
+            var enumSymbol = symbolProvider.toSymbol(target);
             writer.addImport(enumSymbol, enumSymbol.getName());
             return String.format("%s(\"%s\")", enumSymbol.getName(), defaultNode.expectStringNode().getValue());
         } else if (target.isIntEnumShape()) {
-            var enumSymbol = symbolProvider.toSymbol(target).expectProperty(SymbolProperties.ENUM_SYMBOL);
+            var enumSymbol = symbolProvider.toSymbol(target);
             writer.addImport(enumSymbol, enumSymbol.getName());
             return String.format("%s(%s)", enumSymbol.getName(), defaultNode.expectNumberNode().getValue());
         }
@@ -407,11 +408,11 @@ public final class StructureGenerator implements Runnable {
      *     spec: Client error correction</a>
      */
     private void writeErrorCorrection() {
-        var visitor = new MemberErrorCorrectionGenerator(context, writer);
+        var visitor = new MemberErrorCorrectionGenerator(context);
         for (MemberShape member : requiredMembers) {
-            var target = model.expectShape(member.getTarget());
-            if (!MemberErrorCorrectionGenerator.hasDefault(target, model)) {
-                // Streaming shapes have no synthesizable default; let the dataclass raise.
+            var defaultExpression = model.expectShape(member.getTarget()).accept(visitor);
+            if (defaultExpression == null) {
+                // No synthesizable default (e.g. a streaming blob); let the dataclass raise.
                 continue;
             }
             writer.pushState();
@@ -419,7 +420,7 @@ public final class StructureGenerator implements Runnable {
             writer.write("""
                     if ${memberName:S} not in kwargs:
                         kwargs[${memberName:S}] = ${C|}""",
-                    writer.consumer(w -> target.accept(visitor)));
+                    writer.consumer(defaultExpression));
             writer.popState();
         }
     }
@@ -434,52 +435,30 @@ public final class StructureGenerator implements Runnable {
      * {@code _smithy_default()} is also omitted.
      */
     private void generateSmithyDefaultMethod() {
-        if (!isRequiredStructMemberTarget()) {
+        if (!RequiredMemberTargetIndex.of(model).isRequiredMemberTarget(shape.getId())) {
             return;
         }
-        for (MemberShape member : requiredMembers) {
-            var target = model.expectShape(member.getTarget());
-            if (!MemberErrorCorrectionGenerator.hasDefault(target, model)) {
-                return;
-            }
+        var visitor = new MemberErrorCorrectionGenerator(context);
+        if (shape.accept(visitor) == null) {
+            return;
         }
         writer.write("""
                 @classmethod
                 def _smithy_default(cls) -> Self:
                     return cls(${C|})
                 """,
-                writer.consumer(w -> writeSmithyDefaultArguments()));
+                writer.consumer(w -> writeSmithyDefaultArguments(visitor)));
     }
 
-    /**
-     * Returns true if any structure in the model has a python-required member whose target
-     * is this shape.
-     */
-    private boolean isRequiredStructMemberTarget() {
-        var index = NullableIndex.of(model);
-        for (var struct : model.getStructureShapes()) {
-            for (var member : struct.members()) {
-                if (!index.isMemberNullable(member)
-                        && !member.hasTrait(DefaultTrait.class)
-                        && member.getTarget().equals(shape.getId())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private void writeSmithyDefaultArguments() {
-        var visitor = new MemberErrorCorrectionGenerator(context, writer);
+    private void writeSmithyDefaultArguments(MemberErrorCorrectionGenerator visitor) {
         var first = true;
         for (MemberShape member : requiredMembers) {
-            var target = model.expectShape(member.getTarget());
             if (!first) {
                 writer.writeInline(", ");
             }
             first = false;
             writer.writeInline("$L=", symbolProvider.toMemberName(member));
-            target.accept(visitor);
+            model.expectShape(member.getTarget()).accept(visitor).accept(writer);
         }
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -278,6 +278,15 @@ public final class StructureGenerator implements Runnable {
             return CodegenUtils.getDatetimeConstructor(writer, value);
         } else if (target.isBlobShape()) {
             return String.format("b'%s'", defaultNode.expectStringNode().getValue());
+        } else if (target.isEnumShape()) {
+            // Wrap rather than emit a bare string so the value matches the field type.
+            var enumSymbol = symbolProvider.toSymbol(target).expectProperty(SymbolProperties.ENUM_SYMBOL);
+            writer.addImport(enumSymbol, enumSymbol.getName());
+            return String.format("%s(\"%s\")", enumSymbol.getName(), defaultNode.expectStringNode().getValue());
+        } else if (target.isIntEnumShape()) {
+            var enumSymbol = symbolProvider.toSymbol(target).expectProperty(SymbolProperties.ENUM_SYMBOL);
+            writer.addImport(enumSymbol, enumSymbol.getName());
+            return String.format("%s(%s)", enumSymbol.getName(), defaultNode.expectNumberNode().getValue());
         }
 
         if (target.isDocumentShape()) {
@@ -401,7 +410,7 @@ public final class StructureGenerator implements Runnable {
         var visitor = new MemberErrorCorrectionGenerator(context, writer);
         for (MemberShape member : requiredMembers) {
             var target = model.expectShape(member.getTarget());
-            if (!MemberErrorCorrectionGenerator.hasDefault(target)) {
+            if (!MemberErrorCorrectionGenerator.hasDefault(target, model)) {
                 // Streaming shapes have no synthesizable default; let the dataclass raise.
                 continue;
             }
@@ -418,16 +427,19 @@ public final class StructureGenerator implements Runnable {
     /**
      * Emits a {@code _smithy_default()} classmethod that constructs an instance with all
      * required members filled in via client error correction. Used to fill nested structure
-     * members per the Smithy spec. If the structure has any required member whose target has
-     * no synthesizable default (i.e. a streaming blob), {@code _smithy_default()} is omitted:
-     * a generated {@code cls()} call would be missing a required argument. But such structures
-     * can only appear as a top-level operation input or output (per spec § 13.3), never as a
-     * nested-struct member, so {@code _smithy_default()} would never be invoked on them anyway.
+     * members per the Smithy spec. Only emitted when this structure is actually referenced
+     * as the target of a required structure member elsewhere in the model. If the structure
+     * has any required member whose target has no synthesizable default (a streaming blob,
+     * or another structure whose own required members transitively have no default),
+     * {@code _smithy_default()} is also omitted.
      */
     private void generateSmithyDefaultMethod() {
+        if (!isRequiredStructMemberTarget()) {
+            return;
+        }
         for (MemberShape member : requiredMembers) {
             var target = model.expectShape(member.getTarget());
-            if (!MemberErrorCorrectionGenerator.hasDefault(target)) {
+            if (!MemberErrorCorrectionGenerator.hasDefault(target, model)) {
                 return;
             }
         }
@@ -437,6 +449,24 @@ public final class StructureGenerator implements Runnable {
                     return cls(${C|})
                 """,
                 writer.consumer(w -> writeSmithyDefaultArguments()));
+    }
+
+    /**
+     * Returns true if any structure in the model has a python-required member whose target
+     * is this shape.
+     */
+    private boolean isRequiredStructMemberTarget() {
+        var index = NullableIndex.of(model);
+        for (var struct : model.getStructureShapes()) {
+            for (var member : struct.members()) {
+                if (!index.isMemberNullable(member)
+                        && !member.hasTrait(DefaultTrait.class)
+                        && member.getTarget().equals(shape.getId())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private void writeSmithyDefaultArguments() {

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/PythonDelegator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/PythonDelegator.java
@@ -5,13 +5,9 @@
 package software.amazon.smithy.python.codegen.writer;
 
 import software.amazon.smithy.build.FileManifest;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.WriterDelegator;
-import software.amazon.smithy.model.shapes.MemberShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.python.codegen.PythonSettings;
-import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -27,30 +23,7 @@ public final class PythonDelegator extends WriterDelegator<PythonWriter> {
     ) {
         super(
                 fileManifest,
-                new EnumSymbolProviderWrapper(symbolProvider),
+                symbolProvider,
                 new PythonWriter.PythonWriterFactory(settings));
-    }
-
-    private static final class EnumSymbolProviderWrapper implements SymbolProvider {
-
-        private final SymbolProvider wrapped;
-
-        EnumSymbolProviderWrapper(SymbolProvider wrapped) {
-            this.wrapped = wrapped;
-        }
-
-        @Override
-        public Symbol toSymbol(Shape shape) {
-            Symbol symbol = wrapped.toSymbol(shape);
-            if (shape.isEnumShape() || shape.isIntEnumShape()) {
-                symbol = symbol.expectProperty(SymbolProperties.ENUM_SYMBOL);
-            }
-            return symbol;
-        }
-
-        @Override
-        public String toMemberName(MemberShape shape) {
-            return wrapped.toMemberName(shape);
-        }
     }
 }

--- a/packages/smithy-core/.changes/next-release/smithy-core-feature-a6b53cf89aa64daa8f9c25cc52c20875.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-feature-a6b53cf89aa64daa8f9c25cc52c20875.json
@@ -1,0 +1,4 @@
+{
+  "type": "feature",
+  "description": "Added `UnknownEnumMixin` for representing unknown and error-corrected enum/intEnum variants."
+}

--- a/packages/smithy-core/src/smithy_core/types.py
+++ b/packages/smithy-core/src/smithy_core/types.py
@@ -69,16 +69,11 @@ class JsonBlob(bytes):
 class UnknownEnumMixin:
     """Adds unknown-value support to a generated enum.
 
-    Must be mixed into an :class:`enum.Enum` with a data type, e.g.
-    ``class Color(UnknownEnumMixin, StrEnum)``. A value that doesn't match any
-    known member — because the service is newer than the SDK, or because client
-    error correction filled in a placeholder — is represented as a pseudo-member
-    with :attr:`is_unknown` set instead of raising ``ValueError``. Pseudo-members
-    keep the native ``str``/``int`` semantics, so they still compare equal to
-    their raw value.
-
-    See `Smithy's docs <https://smithy.io/2.0/spec/aggregate-types.html#client-error-correction>`_
-    for more details on client error correction.
+    Mixed into an :class:`enum.Enum` with a data type, e.g.
+    ``class Color(UnknownEnumMixin, StrEnum)``. Unrecognized values become
+    pseudo-members (flagged by :attr:`is_unknown`) instead of raising. A value
+    from the wire keeps native equality; an error-correction placeholder
+    (:meth:`_corrected`) equals only itself.
     """
 
     if TYPE_CHECKING:
@@ -88,6 +83,7 @@ class UnknownEnumMixin:
         _value_: Any
 
     _smithy_unknown: bool = False
+    _smithy_corrected: bool = False
 
     @classmethod
     def _unknown(cls, value: Any) -> Self:
@@ -99,10 +95,28 @@ class UnknownEnumMixin:
         return pseudo
 
     @classmethod
+    def _corrected(cls, value: Any) -> Self:
+        pseudo = cls._unknown(value)
+        pseudo._smithy_corrected = True
+        return pseudo
+
+    @classmethod
     def _missing_(cls, value: object) -> Self | None:
         if isinstance(value, cls._member_type_):
             return cls._unknown(value)
         return None
+
+    def __eq__(self, other: object) -> bool:
+        if self._smithy_corrected or getattr(other, "_smithy_corrected", False):
+            return self is other
+        return super().__eq__(other)
+
+    def __ne__(self, other: object) -> bool:
+        result = self.__eq__(other)
+        return result if result is NotImplemented else not result
+
+    def __hash__(self) -> int:
+        return super().__hash__()
 
     @property
     def is_unknown(self) -> bool:

--- a/packages/smithy-core/src/smithy_core/types.py
+++ b/packages/smithy-core/src/smithy_core/types.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from email.utils import format_datetime, parsedate_to_datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Self, overload
 
 from .exceptions import ExpectationNotMetError
 from .interfaces import PropertyKey as _PropertyKey
@@ -64,6 +64,50 @@ class JsonBlob(bytes):
         json_string = JsonBlob(json.dumps(j).encode(encoding="utf-8"))
         json_string._json = j
         return json_string
+
+
+class UnknownEnumMixin:
+    """Adds unknown-value support to a generated enum.
+
+    Must be mixed into an :class:`enum.Enum` with a data type, e.g.
+    ``class Color(UnknownEnumMixin, StrEnum)``. A value that doesn't match any
+    known member — because the service is newer than the SDK, or because client
+    error correction filled in a placeholder — is represented as a pseudo-member
+    with :attr:`is_unknown` set instead of raising ``ValueError``. Pseudo-members
+    keep the native ``str``/``int`` semantics, so they still compare equal to
+    their raw value.
+
+    See `Smithy's docs <https://smithy.io/2.0/spec/aggregate-types.html#client-error-correction>`_
+    for more details on client error correction.
+    """
+
+    if TYPE_CHECKING:
+        # Set by EnumType when this is mixed into an enum with a data type.
+        _member_type_: ClassVar[type[Any]]
+        _name_: str
+        _value_: Any
+
+    _smithy_unknown: bool = False
+
+    @classmethod
+    def _unknown(cls, value: Any) -> Self:
+        member_type: Any = cls._member_type_
+        pseudo: Self = member_type.__new__(cls, value)
+        pseudo._name_ = f"<smithy-unknown:{value}>"
+        pseudo._value_ = value
+        pseudo._smithy_unknown = True
+        return pseudo
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self | None:
+        if isinstance(value, cls._member_type_):
+            return cls._unknown(value)
+        return None
+
+    @property
+    def is_unknown(self) -> bool:
+        """True if this value was not known at SDK generation time."""
+        return self._smithy_unknown
 
 
 class TimestampFormat(Enum):

--- a/packages/smithy-core/tests/unit/test_types.py
+++ b/packages/smithy-core/tests/unit/test_types.py
@@ -3,6 +3,7 @@
 
 # pyright: reportPrivateUsage=false
 from datetime import UTC, datetime
+from enum import IntEnum, StrEnum
 from typing import Any, assert_type
 
 import pytest
@@ -14,6 +15,7 @@ from smithy_core.types import (
     PropertyKey,
     TimestampFormat,
     TypedProperties,
+    UnknownEnumMixin,
 )
 
 
@@ -351,3 +353,63 @@ def test_parametric_property() -> None:
     properties[parametric] = {"foo": "bar"}
 
     assert assert_type(properties[parametric], dict[str, str]) == {"foo": "bar"}
+
+
+class _Color(UnknownEnumMixin, StrEnum):
+    RED = "RED"
+    GREEN = "GREEN"
+
+
+class _Code(UnknownEnumMixin, IntEnum):
+    OK = 200
+    NOT_FOUND = 404
+
+
+def test_unknown_enum_known_values_resolve_to_members() -> None:
+    assert _Color("RED") is _Color.RED
+    assert _Code(200) is _Code.OK
+    assert not _Color.RED.is_unknown
+    assert not _Code.OK.is_unknown
+
+
+def test_unknown_enum_unrecognized_value_does_not_raise() -> None:
+    color = _Color("CHARTREUSE")
+    assert color.is_unknown
+    assert color.value == "CHARTREUSE"
+
+    code = _Code(418)
+    assert code.is_unknown
+    assert code.value == 418
+
+
+def test_unknown_enum_keeps_native_equality() -> None:
+    assert _Color("CHARTREUSE") == "CHARTREUSE"
+    assert _Code(418) == 418
+    assert _Color("CHARTREUSE") == _Color("CHARTREUSE")
+    assert _Color("CHARTREUSE") != _Color.RED
+
+    # Pseudo-members hash like their raw value, so dict lookups by raw value work.
+    codes: dict[Any, str] = {_Code(418): "teapot"}
+    assert codes[418] == "teapot"
+
+
+def test_unknown_enum_placeholder_for_error_correction() -> None:
+    color = _Color._unknown("")
+    assert color.is_unknown
+    assert color == ""
+
+    code = _Code._unknown(0)
+    assert code.is_unknown
+    assert code == 0
+
+
+def test_unknown_enum_rejects_mismatched_type() -> None:
+    with pytest.raises(ValueError):
+        _Color(0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        _Code("RED")  # type: ignore[arg-type]
+
+
+def test_unknown_enum_str_and_serialization_behavior() -> None:
+    assert str(_Color("CHARTREUSE")) == "CHARTREUSE"
+    assert int(_Code(418)) == 418

--- a/packages/smithy-core/tests/unit/test_types.py
+++ b/packages/smithy-core/tests/unit/test_types.py
@@ -361,6 +361,7 @@ class _Color(UnknownEnumMixin, StrEnum):
 
 
 class _Code(UnknownEnumMixin, IntEnum):
+    ZERO = 0
     OK = 200
     NOT_FOUND = 404
 
@@ -393,14 +394,45 @@ def test_unknown_enum_keeps_native_equality() -> None:
     assert codes[418] == "teapot"
 
 
-def test_unknown_enum_placeholder_for_error_correction() -> None:
-    color = _Color._unknown("")
-    assert color.is_unknown
-    assert color == ""
+def test_wire_unknown_keeps_native_equality() -> None:
+    # A value the SDK doesn't recognize keeps native equality (forwards-compatible).
+    wire = _Code(418)
+    assert wire.is_unknown
+    assert not wire._smithy_corrected
+    assert wire == 418
 
-    code = _Code._unknown(0)
+
+def test_error_corrected_placeholder_is_equal_to_nothing() -> None:
+    # An invented placeholder for a missing required member equals only itself —
+    # not its raw value, not a known member sharing it, not another placeholder.
+    color = _Color._corrected("")
+    assert color.is_unknown
+    assert color._smithy_corrected
+    assert color != ""
+    assert color != _Color.RED
+    assert color != _Color._corrected("")
+    assert color == color
+
+    code = _Code._corrected(0)
     assert code.is_unknown
-    assert code == 0
+    assert code._smithy_corrected
+    assert code != 0
+    assert code != _Code.ZERO
+    assert code != _Code._corrected(0)
+    assert code == code
+
+    assert {_Code.ZERO: "zero"}.get(code) is None
+
+
+def test_wire_unknown_and_corrected_differ_on_equality() -> None:
+    # Both report is_unknown, but the wire-unknown value keeps native equality
+    # while the invented placeholder matches nothing.
+    wire = _Code(418)
+    corrected = _Code._corrected(418)
+    assert wire.is_unknown and corrected.is_unknown
+    assert wire == 418
+    assert corrected != 418
+    assert wire != corrected
 
 
 def test_unknown_enum_rejects_mismatched_type() -> None:

--- a/packages/smithy-json/.changes/next-release/smithy-json-bugfix-2eaf1f49875f4690b7c58f7735f1de7d.json
+++ b/packages/smithy-json/.changes/next-release/smithy-json-bugfix-2eaf1f49875f4690b7c58f7735f1de7d.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Serialize `IntEnum` members as their underlying integer instead of their `repr`."
+}

--- a/packages/smithy-json/src/smithy_json/_private/serializers.py
+++ b/packages/smithy-json/src/smithy_json/_private/serializers.py
@@ -300,7 +300,8 @@ class StreamingJSONEncoder:
         self._sink.write(b'"')
 
     def write_int(self, value: int) -> None:
-        self._sink.write(repr(value).encode("utf-8"))
+        # int() unwraps IntEnum members; otherwise repr would emit "<MyEnum.A: 1>".
+        self._sink.write(str(int(value)).encode("utf-8"))
 
     def write_float(self, value: float | Decimal) -> None:
         if not self._write_non_numeric_float(value=value):


### PR DESCRIPTION
## Description of changes

This codegen generates Python clients from Smithy service models. For each operation's input and output shape, it produces a Python `@dataclass` whose fields mirror the model members. Members that the service model marks as `@required` are emitted as non-default keyword-only arguments, meaning the dataclass cannot be constructed without them.

After an operation completes, the SDK's deserialization layer reads the response body and calls the dataclass constructor with the parsed values. When the response follows the model, this works fine. **However**, when the response is *missing a `@required` member*, the constructor raises a Python `TypeError` for the missing keyword-only argument. The SDK pipeline catches that, classifies it as non-retryable, and re-raises as `smithy_core.exceptions.SmithyError`. The user sees something like:

```text
smithy_core.exceptions.SmithyError: SomeOutput.__init__() missing 1 required keyword-only argument: 'foo'
```

This happens in two practical situations:

- **A successful response is missing one of the response shape's `@required` members.** For example, [Connect Health](https://github.com/aws/api-models-aws/blob/main/models/connecthealth/service/2025-01-29/connecthealth-2025-01-29.json) `CreateSubscription` returns an HTTP 200 response that omits the `@required lastUpdatedAt` field of `CreateSubscriptionOutput`. The subscription is created server-side, but the SDK call fails because the output dataclass cannot be constructed without `last_updated_at`.
- **An error response is missing one of the error shape's `@required` members.** For example, [Q Business](https://github.com/aws/api-models-aws/blob/main/models/qbusiness/service/2023-11-27/qbusiness-2023-11-27.json) `ChatSync`, when rejecting a request with `ValidationException`, returns an exception body that omits the `@required reason` field of `ValidationException`. The user sees a generic message about a missing kwarg instead of the actual service-side error message: the real reason the request was rejected is masked.

The Smithy spec accounts for this in [§ 3.3.3.1.1 Client error correction](https://smithy.io/2.0/spec/aggregate-types.html#client-error-correction): clients MAY substitute a zero-value default for a missing required member to avoid downtime. This PR implements that policy in the Python codegen. Each shape type gets the spec's prescribed default. The implementation lives in a new `MemberErrorCorrectionGenerator` (a `ShapeVisitor`) plus two hooks in `StructureGenerator`: error correction at the end of the generated `deserialize_kwargs`, and a generated `_smithy_default()` classmethod used when a parent's required nested-struct member is missing on the wire.

**Note**: enum and intEnum currently fall back to placeholder zero values (`""` and `0`). Spec § 3.3.3.1.1 recommends (SHOULD) that these types define a structured unknown variant for receiving wire values not known at SDK-generation time. Implementing it requires redesigning the generated enum/intEnum classes: today they are plain `StrEnum` / `IntEnum` subclasses with no room for an unknown member, so if necessary, a follow-up would need to change `EnumGenerator` / `IntEnumGenerator` (and likely `PythonSymbolProvider`, `MemberDeserializerGenerator`) to emit a wrapper type that exposes something like `MyEnum.unknown(value)` and `is_unknown`. The two enum visitor methods in `MemberErrorCorrectionGenerator` have TODO comments documenting this.

## Testing

`:core:test`, `:core:integ`, `:core:spotlessCheck`, the `aws-query` and `rest-json-1` protocol-test suites all pass.

Also, two real-world cases were verified before/after:

**Amazon Connect Health `CreateSubscription`.** Before this PR:
```text
Traceback (most recent call last):
  File ".../smithy_http/aio/protocols.py", line 152, in deserialize_response
    return operation.output.deserialize(deserializer)
  File ".../aws_sdk_connecthealth/models.py", line 1491, in deserialize
    return cls(**cls.deserialize_kwargs(deserializer))
TypeError: CreateSubscriptionOutput.__init__() missing 1 required keyword-only argument: 'last_updated_at'

The above exception was the direct cause of the following exception:
  File ".../smithy_core/aio/client.py", line 258, in _execute_request
    raise SmithyError(e) from e
smithy_core.exceptions.SmithyError: CreateSubscriptionOutput.__init__() missing 1 required keyword-only argument: 'last_updated_at'
```

After this PR, `last_updated_at` is filled with `datetime.fromtimestamp(0, tz=timezone.utc)`, the call returns normally.

**Amazon Q Business `ChatSync`.** Before this PR:

```text
smithy_core.exceptions.SmithyError: ValidationException.__init__() missing 1 required keyword-only argument: 'reason'
```

After this PR:

```text
aws_sdk_qbusiness.models.ValidationException: Please provide a unique clientToken that can be used as an idempotency attribute.
```

`reason` is filled with `""`, the `ValidationException` constructs cleanly, and the actual validation message reaches the caller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.