### PR TITLE
Add docstring for HTTPClient header validation contract

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
+++ b/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
@@ -64,7 +64,14 @@ class HTTPResponse(Response, Protocol):
 
 
 class HTTPClient(ClientTransport[HTTPRequest, HTTPResponse], Protocol):
-    """An asynchronous HTTP client interface."""
+    """An asynchronous HTTP client interface.
+
+    Header field names and values are not validated before reaching this
+    layer. Implementations of ``HTTPClient`` are responsible for this
+    validation: if a request's fields contain characters prohibited by
+    the HTTP specifications (such as CR or LF), the request MUST be
+    rejected.
+    """
 
     def __init__(self, *, client_config: HTTPClientConfiguration | None) -> None:
         """

--- a/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
+++ b/packages/smithy-http/src/smithy_http/aio/interfaces/__init__.py
@@ -67,10 +67,10 @@ class HTTPClient(ClientTransport[HTTPRequest, HTTPResponse], Protocol):
     """An asynchronous HTTP client interface.
 
     Header field names and values are not validated before reaching this
-    layer. Implementations of ``HTTPClient`` are responsible for this
-    validation: if a request's fields contain characters prohibited by
-    the HTTP specifications (such as CR or LF), the request MUST be
-    rejected.
+    layer. Implementations of ``HTTPClient`` are responsible for
+    validating and handling those invalid and dangerous characters (such
+    as CR, LF, or NUL) as defined in `RFC 9110, Section 5.5
+    <https://www.rfc-editor.org/rfc/rfc9110#section-5.5>`_.
     """
 
     def __init__(self, *, client_config: HTTPClientConfiguration | None) -> None:


### PR DESCRIPTION
*Description of changes:*
Add docstring for `HTTPClient` to specify: if a request's header fields contain characters prohibited by the HTTP specifications (e.g. CR, LF), it is implementer's responsibility that they must reject the request. The default clients (`AWSCRTHTTPClient`, `AIOHTTPClient`) already satisfy this via their underlying libraries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
