### PR TITLE
fix: Strip backslash before ^ in generated docstrings

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownConverter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownConverter.java
@@ -170,7 +170,7 @@ public final class MarkdownConverter {
 
         // Remove unnecessary backslash escapes that pandoc adds for markdown
         // These characters don't need escaping in Python docstrings
-        output = output.replaceAll("\\\\([\\[\\]'{}()<>`@_*|!~$#])", "$1");
+        output = output.replaceAll("\\\\([\\[\\]'{}()<>`@_*|!~$#^])", "$1");
 
         // Replace <note> and <important> tags with admonitions for mkdocstrings
         output = replaceAdmonitionTags(output, "note", "Note");


### PR DESCRIPTION
*Description of changes:*
The `MarkdownConverter` strips unnecessary backslash escapes that pandoc adds for markdown syntax characters. However, `^` was missing from the strip list. When pandoc converts service documentation containing a literal `^` character, it escapes it to `\^` because `^` is a markdown superscript marker in some extensions. This `\^` then ends up in the generated Python docstring as an invalid escape sequence, causing pyright `reportInvalidStringEscapeSequence` errors.

This issue was identified during generation of DynamoDB client using [its model file](https://github.com/aws/api-models-aws/blob/75d1a543dd4a4d2a54d3529ffe77da4f544a6046/models/dynamodb/service/2012-08-10/dynamodb-2012-08-10.json#L21457): one of its `smithy.api#documentation` contains a sequence: `<p>4500-6500 third sleep/delay (500 * 2^2)</p>\n`.

This PR adds `^` to the regex character class in `postProcessPandocOutput()` so that `\^` is correctly stripped to `^` in generated docstrings. This aligns with how we handled a similar issue before in another [PR](https://github.com/smithy-lang/smithy-python/pull/677).

Verified by generating the DynamoDB client with the fix. `smithy build --aut` passes ruff and pyright cleanly, and there is no `\^` in generated code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
