### PR TITLE
smithy-http: Disable auto-decompression in aiohttp client

### DIFF
--- a/packages/smithy-http/.changes/next-release/smithy-http-bugfix-0c383aa7346a4eb4b21cef8e2e0f201a.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-bugfix-0c383aa7346a4eb4b21cef8e2e0f201a.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Disabled automatic response decompression in `AIOHTTPClient`."
+}

--- a/packages/smithy-http/src/smithy_http/aio/aiohttp.py
+++ b/packages/smithy-http/src/smithy_http/aio/aiohttp.py
@@ -65,7 +65,13 @@ class AIOHTTPClient(HTTPClient):
         """
         _assert_aiohttp()
         self._config = client_config or AIOHTTPClientConfig()
-        self._session = _session or aiohttp.ClientSession()
+        # Disable transparent response decompression and advertise
+        # 'identity' to request uncompressed responses.
+        # TODO: add a functional test once the test client framework exists
+        self._session = _session or aiohttp.ClientSession(
+            auto_decompress=False,
+            headers={"Accept-Encoding": "identity"},
+        )
 
     async def send(
         self,


### PR DESCRIPTION
### Description

The `AIOHTTPClient` currently creates its session with aiohttp's defaults, which transparently decompress `Content-Encoding` responses before they're buffered via `resp.read()`. This change constructs the session with `auto_decompress=False` and a default `Accept-Encoding: identity` header ([reference](https://docs.aiohttp.org/en/stable/client_reference.html)), so the codec receives the response bytes as sent and servers are asked not to compress.

Matches similar fixes in [smithy-ruby](https://github.com/smithy-lang/smithy-ruby/pull/339) and [smithy-kotlin](https://github.com/smithy-lang/smithy-kotlin/pull/1047).

### Testing
- Ran `make test-py` successfully
- Generated STS client with `AIOHTTPClient` and confirmed round-trip requests are functional
- Added a todo for a functional test once we have a test client framework

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
