### PR TITLE
fix: quote recursive union member annotations

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -15,5 +15,5 @@
 
 allprojects {
     group = "software.amazon.smithy.python"
-    version = "0.3.0"
+    version = "0.3.1"
 }

--- a/codegen/core/src/it/resources/META-INF/smithy/main.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/main.smithy
@@ -305,6 +305,8 @@ operation ListCities {
         sparseItems: SparseCitySummaries
 
         mutual: MutuallyRecursiveA
+
+        recursiveUnion: RecursiveUnion
     }
 }
 
@@ -565,6 +567,21 @@ structure MutuallyRecursiveA {
 
 structure MutuallyRecursiveB {
     mutual: MutuallyRecursiveA
+}
+
+union RecursiveUnion {
+    nested: RecursiveUnionMap
+    items: RecursiveUnionList
+    leaf: String
+}
+
+map RecursiveUnionMap {
+    key: String
+    value: RecursiveUnion
+}
+
+list RecursiveUnionList {
+    member: RecursiveUnion
 }
 
 // CitySummaries is a list of CitySummary structures.

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
@@ -62,12 +62,14 @@ public final class UnionGenerator implements Runnable {
 
             var target = model.expectShape(member.getTarget());
             var targetSymbol = symbolProvider.toSymbol(target);
+            writer.pushState();
+            writer.putContext("quote", recursiveShapes.contains(target) ? "'" : "");
             writer.write("""
                     @dataclass
                     class $1L:
                         ${2C|}
 
-                        value: $3T
+                        value: ${quote:L}$3T${quote:L}
 
                         def serialize(self, serializer: ShapeSerializer):
                             serializer.write_struct($4T, self)
@@ -92,6 +94,7 @@ public final class UnionGenerator implements Runnable {
                             new MemberDeserializerGenerator(context, w, member, "deserializer")))
 
             );
+            writer.popState();
         }
 
         // Note that the unknown variant doesn't implement __eq__. This is because


### PR DESCRIPTION
**Description of changes:**

Generating a client from a model that contains a **recursive union** currently fails the code generation process. For example, DynamoDB's [`AttributeValue`](https://github.com/aws/api-models-aws/blob/87480db7ee4bec827c971dbf0294446591d1b229/models/dynamodb/service/2012-08-10/dynamodb-2012-08-10.json#L175) is a union where the `M` variant targets a map of `AttributeValue` and the `L` variant targets a list of `AttributeValue`. These generate Python members typed `dict[str, AttributeValue]` and `list[AttributeValue]`, i.e. they reference the union itself. `smithy build --aut` fails during `ruff check --fix` with:

```
models.py:15921:22: F821 Undefined name `AttributeValue`
models.py:15941:17: F821 Undefined name `AttributeValue`
```

The reason is that the `AttributeValue` union alias is emitted *after* its member dataclasses, so a member annotation like `value: dict[str, AttributeValue]` is a forward reference to a name that isn't defined yet.

[`StructureGenerator`](https://github.com/smithy-lang/smithy-python/blob/2472785bbb35ca6a462522791a1e21a0c8ba2acd/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java#L169-L189) already handles this: when a member targets a recursive shape, it wraps the type annotation in quotes to make it a forward reference. `UnionGenerator` is passed the same set of recursive shapes but never uses it, so union members miss this treatment. This change applies the same logic in `UnionGenerator`. Only members whose target is a recursive shape are affected; all other unions generate exactly as before.

**Testing:**

Validated against the DynamoDB model which failed the code generation before. Locally, on top of the [clean-json-rpc-v1 branch](https://github.com/smithy-lang/smithy-python/tree/clean-json-rpc-v1) (which adds AWS JSON protocol support), I applied this change together with [#707](https://github.com/smithy-lang/smithy-python/pull/707) (strip `\^` escape in docstrings). With both changes in place, the DynamoDB client generates successfully: `smithy build --aut` passes ruff and pyright cleanly, and there are no `F821` errors.

Inspecting the generated `AttributeValue` union members confirms the recursive annotations are now quoted:

```python
# Before
value: dict[str, AttributeValue]
value: list[AttributeValue]

# After
value: "dict[str, AttributeValue]"
value: "list[AttributeValue]"
```

(The code emits single quotes, matching `StructureGenerator`; `ruff format` then normalizes them to double quotes, which is what appears in the generated output.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
