### PR TITLE
fix(smithy-http): auto-close aiohttp session to avoid unclosed warnings

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/aiohttp.py
+++ b/packages/smithy-http/src/smithy_http/aio/aiohttp.py
@@ -1,6 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from copy import copy, deepcopy
+import weakref
+from copy import deepcopy
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs
@@ -65,13 +66,20 @@ class AIOHTTPClient(HTTPClient):
         """
         _assert_aiohttp()
         self._config = client_config or AIOHTTPClientConfig()
-        # Disable transparent response decompression and advertise
-        # 'identity' to request uncompressed responses.
-        # TODO: add a functional test once the test client framework exists
-        self._session = _session or aiohttp.ClientSession(
-            auto_decompress=False,
-            headers={"Accept-Encoding": "identity"},
-        )
+        if _session is not None:
+            self._session = _session
+        else:
+            # Disable transparent response decompression and advertise
+            # 'identity' to request uncompressed responses.
+            # TODO: add a functional test once the test client framework exists
+            self._session = aiohttp.ClientSession(
+                auto_decompress=False,
+                headers={"Accept-Encoding": "identity"},
+            )
+            # Close the connector on GC/interpreter exit so aiohttp doesn't
+            # emit "Unclosed client session"/"Unclosed connector" warnings
+            # when the client is never closed explicitly.
+            self._finalizer = weakref.finalize(self, self._close_session, self._session)
 
     async def send(
         self,
@@ -143,5 +151,17 @@ class AIOHTTPClient(HTTPClient):
     def __deepcopy__(self, memo: Any) -> "AIOHTTPClient":
         return AIOHTTPClient(
             client_config=deepcopy(self._config),
-            _session=copy(self._session),
+            _session=self._session,
         )
+
+    @staticmethod
+    def _close_session(session: "aiohttp.ClientSession") -> None:
+        """Synchronously close a session's connector.
+
+        Runs from the :py:class:`weakref.finalize` hook, where there may be no
+        running event loop, so we close the connector directly instead of
+        awaiting ``session.close()``.
+        """
+        connector = session.connector
+        if connector is not None and not connector.closed:
+            connector._close()  # type: ignore[attr-defined]


### PR DESCRIPTION
*Problem:*

The `AIOHTTPClient` never closes its `aiohttp.ClientSession`. Because the generated client deep-copies its config (and thus the transport) on every operation call, each call produced a throwaway session copy. On garbage collection these emit `Unclosed client session` / `Unclosed connector` warnings that print to stderr.

*Description of changes:*

- Share the single `ClientSession` across `__deepcopy__` instead of copying it, so that all per-call copies of the transport point to the same session.
- Register a `weakref.finalize` hook that closes the underlying connector when the client is garbage collected (or at interpreter exit). The connector is closed synchronously because no event loop may be running at finalization. Closing it also marks the session as closed, so both warnings are suppressed.

*Testing:*

Verified with the generated DynamoDB client running the example below (create table → put item → get item → delete table):

```python
"""Getting started with DynamoDB using the AWS SDK for Python."""

import asyncio
import uuid

from smithy_http.aio.crt import AWSCRTHTTPClient
from aws_sdk_dynamodb.client import DynamoDBClient
from aws_sdk_dynamodb.models import (
    AttributeDefinition,
    AttributeValueN,
    AttributeValueS,
    CreateTableInput,
    DeleteTableInput,
    DescribeTableInput,
    GetItemInput,
    KeySchemaElement,
    ProvisionedThroughput,
    PutItemInput,
)
from aws_sdk_dynamodb.config import Config
from smithy_aws_core.identity import EnvironmentCredentialsResolver


TABLE_NAME = f"sdk-python-getting-started-{uuid.uuid4().hex[:12]}"
REGION = "us-east-1"


async def main() -> None:
    # 1. Create the DynamoDB client
    client = DynamoDBClient(
        config=Config(
            endpoint_uri=f"https://dynamodb.{REGION}.amazonaws.com",
            region=REGION,
            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
        )
    )

    # 2. Create a table
    print(f"Creating table '{TABLE_NAME}'...")
    await client.create_table(
        input=CreateTableInput(
            table_name=TABLE_NAME,
            attribute_definitions=[
                AttributeDefinition(attribute_name="pk", attribute_type="S"),
            ],
            key_schema=[
                KeySchemaElement(attribute_name="pk", key_type="HASH"),
            ],
            provisioned_throughput=ProvisionedThroughput(
                read_capacity_units=5,
                write_capacity_units=5,
            ),
        )
    )

    # 3. Wait for the table to become active
    print("Waiting for table to be active...")
    while True:
        response = await client.describe_table(
            input=DescribeTableInput(table_name=TABLE_NAME)
        )
        if response.table and response.table.table_status == "ACTIVE":
            break
        await asyncio.sleep(2)
    print("Table is active.")

    try:
        # 4. Put an item
        print("Writing an item...")
        await client.put_item(
            input=PutItemInput(
                table_name=TABLE_NAME,
                item={
                    "pk": AttributeValueS(value="user-001"),
                    "name": AttributeValueS(value="Alice"),
                    "age": AttributeValueN(value="30"),
                },
            )
        )

        # 5. Get the item back
        print("Reading the item back...")
        get_response = await client.get_item(
            input=GetItemInput(
                table_name=TABLE_NAME,
                key={"pk": AttributeValueS(value="user-001")},
                consistent_read=True,
            )
        )

        item = get_response.item
        if item:
            print(f"  pk:   {item['pk'].value}")
            print(f"  name: {item['name'].value}")
            print(f"  age:  {item['age'].value}")
        else:
            print("  Item not found!")

    finally:
        # 6. Delete the table
        print(f"Deleting table '{TABLE_NAME}'...")
        await client.delete_table(
            input=DeleteTableInput(table_name=TABLE_NAME)
        )
        print("Done.")


if __name__ == "__main__":
    asyncio.run(main())

```

Before:
```
(python-client-codegen) yuxnchen@80a9973bd433 python-client-codegen % python getting_started_dynamodb.py
Creating table 'sdk-python-getting-started-4df481afe7fc'...
/Users/yuxnchen/sdk/newServiceProject/smithy-python/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py:794: AWSSDKWarning: Payload signing is enabled. This may result in decreased performance for large request bodies.
  warnings.warn(
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10b3bb440>
Waiting for table to be active...
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10b3bbef0>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10b3bbbf0>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10b3bbfb0>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10b3cb320>
Table is active.
Writing an item...
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10b3cb3b0>
Reading the item back...
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10b3cb110>
  pk:   user-001
  name: Alice
  age:  30
Deleting table 'sdk-python-getting-started-4df481afe7fc'...
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10b3cb950>
Done.
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10b3bb170>
Unclosed connector
connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x10b3a7cb0>, 697165.2273415)])']
connector: <aiohttp.connector.TCPConnector object at 0x10b3bb1a0>
```

After:
```
(python-client-codegen) yuxnchen@80a9973bd433 python-client-codegen % python getting_started_dynamodb.py      
Creating table 'sdk-python-getting-started-1c4334bbba49'...
/Users/yuxnchen/sdk/newServiceProject/smithy-python/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py:794: AWSSDKWarning: Payload signing is enabled. This may result in decreased performance for large request bodies.
  warnings.warn(
Waiting for table to be active...
Table is active.
Writing an item...
Reading the item back...
  pk:   user-001
  name: Alice
  age:  30
Deleting table 'sdk-python-getting-started-1c4334bbba49'...
Done.
```

Also ran the full `smithy-http` test suite: 334 passed, 3 skipped.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
