### PR TITLE
fix: escape invalid backslash sequences in generated docstrings

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownConverter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownConverter.java
@@ -168,20 +168,9 @@ public final class MarkdownConverter {
         // Remove empty lines at the start and end
         output = output.trim();
 
-        // Remove unnecessary backslash escapes that pandoc adds for markdown.
-        // These characters don't need escaping in Python docstrings. The
-        // negative lookbehind ensures we only strip a single, spurious escape
-        // and never consume one half of a literal "\\" (which is a valid Python
-        // escape and must be preserved, e.g. a charset like "[\\]").
-        output = output.replaceAll("(?<!\\\\)\\\\([\\[\\]'{}()<>`@_*|!~$#^])", "$1");
-
-        // Escape any remaining lone backslash that does not form a valid Python
-        // escape sequence, so the docstring is a valid Python string. A backslash
-        // is left untouched when it begins a recognized Python escape (quote,
-        // letter escapes, octal, hex, Unicode, or a line continuation) and is
-        // doubled otherwise (e.g. a charset like a lone backslash between spaces).
-        // See https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences
-        output = output.replaceAll("(?<!\\\\)\\\\(?![\\\\'\"abfnrtv0-7xNuU\\r\\n])", "\\\\\\\\");
+        // Fix up the backslash escapes pandoc adds for Markdown so the result is
+        // a valid Python string literal (see normalizeBackslashEscapes).
+        output = normalizeBackslashEscapes(output);
 
         // Replace <note> and <important> tags with admonitions for mkdocstrings
         output = replaceAdmonitionTags(output, "note", "Note");
@@ -189,6 +178,45 @@ public final class MarkdownConverter {
 
         // Escape Smithy format specifiers
         return output.replace("$", "$$");
+    }
+
+    // A lone backslash before one of these is dropped: pandoc adds it for Markdown
+    // but it needs no escaping in a Python docstring.
+    private static final String MARKDOWN_ONLY_CHARS = "[](){}<>`@_*|!~$#^'.";
+    // A lone backslash before one of these is kept: together they form a valid
+    // Python escape. (' is intentionally left out; it lives in MARKDOWN_ONLY_CHARS.)
+    private static final String VALID_ESCAPE_CHARS = "\\\"abfnrtv01234567xNuU\r\n";
+    private static final Pattern BACKSLASH_RUN = Pattern.compile("(\\\\+)([^\\\\]|$)", Pattern.DOTALL);
+
+    /**
+     * Fixes pandoc's backslash escaping so the docstring is a valid Python literal.
+     *
+     * <p>Backslashes must come in pairs, but pandoc can leave an odd-length run
+     * (it escapes literal backslashes and Markdown characters separately, and
+     * adjacent escapes pile up). For each run we keep the pairs; a leftover
+     * backslash is then kept if it forms a valid escape, dropped if it is only
+     * there for Markdown, or doubled otherwise.
+     */
+    private static String normalizeBackslashEscapes(String output) {
+        Matcher m = BACKSLASH_RUN.matcher(output);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            int runLength = m.group(1).length();
+            String next = m.group(2);
+            int backslashes = (runLength / 2) * 2;
+            if (runLength % 2 != 0) {
+                char c = next.isEmpty() ? '\0' : next.charAt(0);
+                if (!next.isEmpty() && VALID_ESCAPE_CHARS.indexOf(c) >= 0) {
+                    backslashes += 1;
+                } else if (next.isEmpty() || MARKDOWN_ONLY_CHARS.indexOf(c) < 0) {
+                    backslashes += 2;
+                }
+                // else: Markdown-only char, drop the spurious backslash
+            }
+            m.appendReplacement(sb, Matcher.quoteReplacement("\\".repeat(backslashes) + next));
+        }
+        m.appendTail(sb);
+        return sb.toString();
     }
 
     /**

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownConverter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/MarkdownConverter.java
@@ -168,9 +168,20 @@ public final class MarkdownConverter {
         // Remove empty lines at the start and end
         output = output.trim();
 
-        // Remove unnecessary backslash escapes that pandoc adds for markdown
-        // These characters don't need escaping in Python docstrings
-        output = output.replaceAll("\\\\([\\[\\]'{}()<>`@_*|!~$#^])", "$1");
+        // Remove unnecessary backslash escapes that pandoc adds for markdown.
+        // These characters don't need escaping in Python docstrings. The
+        // negative lookbehind ensures we only strip a single, spurious escape
+        // and never consume one half of a literal "\\" (which is a valid Python
+        // escape and must be preserved, e.g. a charset like "[\\]").
+        output = output.replaceAll("(?<!\\\\)\\\\([\\[\\]'{}()<>`@_*|!~$#^])", "$1");
+
+        // Escape any remaining lone backslash that does not form a valid Python
+        // escape sequence, so the docstring is a valid Python string. A backslash
+        // is left untouched when it begins a recognized Python escape (quote,
+        // letter escapes, octal, hex, Unicode, or a line continuation) and is
+        // doubled otherwise (e.g. a charset like a lone backslash between spaces).
+        // See https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences
+        output = output.replaceAll("(?<!\\\\)\\\\(?![\\\\'\"abfnrtv0-7xNuU\\r\\n])", "\\\\\\\\");
 
         // Replace <note> and <important> tags with admonitions for mkdocstrings
         output = replaceAdmonitionTags(output, "note", "Note");

--- a/codegen/core/src/test/java/software/amazon/smithy/python/codegen/writer/MarkdownConverterTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/python/codegen/writer/MarkdownConverterTest.java
@@ -157,6 +157,26 @@ public class MarkdownConverterTest {
     }
 
     @Test
+    public void testConvertHandlesBackslashBeforeMarkdownChar() {
+        // A backslash followed by a Markdown-significant character (here "*") makes
+        // pandoc emit an odd-length backslash run. The spurious escape must be
+        // dropped so the result is valid Python.
+        String html = "<code>arn:aws:iam::\\*:user/\\*</code>";
+        String result = MarkdownConverter.convert(html, createMockContext(true)).trim();
+        assertEquals("`arn:aws:iam::*:user/*`", result);
+    }
+
+    @Test
+    public void testConvertHandlesBackslashStarNextToQuote() {
+        // The API Gateway model documents the comment marker "\*/". Next to a quote,
+        // pandoc emits an odd-length backslash run; the result must stay a valid
+        // Python literal.
+        String html = "<p>Do not include \"\\*/\" characters</p>";
+        String result = MarkdownConverter.convert(html, createMockContext(true)).trim();
+        assertEquals("Do not include \\\"\\\\*/\\\" characters", result);
+    }
+
+    @Test
     public void testConvertMixedElements() {
         String html = "<h1>Title</h1><p>Paragraph</p><ul><li>Item 1</li><li>Item 2</li></ul>";
         String result = MarkdownConverter.convert(html, createMockContext(true));

--- a/codegen/core/src/test/java/software/amazon/smithy/python/codegen/writer/MarkdownConverterTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/python/codegen/writer/MarkdownConverterTest.java
@@ -129,6 +129,34 @@ public class MarkdownConverterTest {
     }
 
     @Test
+    public void testConvertPreservesLiteralDoubleBackslash() {
+        // A literal "\\" is a valid Python escape (e.g. a password charset like
+        // "[\\]") and must be preserved.
+        String html = "<code>@[\\\\]^</code>";
+        String result = MarkdownConverter.convert(html, createMockContext(true)).trim();
+        assertEquals("`@[\\\\]^`", result);
+    }
+
+    @Test
+    public void testConvertEscapesLoneBackslash() {
+        // A lone backslash that is not part of a recognized Python escape (here a
+        // backslash followed by a space) must be doubled so the docstring is a
+        // valid Python string.
+        String html = "<code>[ \\ ]</code>";
+        String result = MarkdownConverter.convert(html, createMockContext(true)).trim();
+        assertEquals("`[ \\\\ ]`", result);
+    }
+
+    @Test
+    public void testConvertPreservesValidPythonEscapes() {
+        // A backslash that already forms a valid Python escape (e.g. \") must be
+        // left untouched rather than doubled.
+        String html = "<code>!\\\"#</code>";
+        String result = MarkdownConverter.convert(html, createMockContext(true)).trim();
+        assertEquals("`!\\\"#`", result);
+    }
+
+    @Test
     public void testConvertMixedElements() {
         String html = "<h1>Title</h1><p>Paragraph</p><ul><li>Item 1</li><li>Item 2</li></ul>";
         String result = MarkdownConverter.convert(html, createMockContext(true));


### PR DESCRIPTION
### Background

Generated docstrings are Python string literals, so every backslash must either form a valid escape sequence or the literal is malformed. Python 3.12+ emits a `SyntaxWarning` for unrecognized escape sequences, and strict type checkers (pyright) report `reportInvalidStringEscapeSequence` as an error, which fails codegen's post-generation type check.

`MarkdownConverter.postProcessPandocOutput` is responsible for cleaning up the backslash escapes that pandoc adds. After #707 the single strip regex still produced invalid Python, reproducible with the [Secrets Manager model](https://github.com/aws/api-models-aws/blob/main/models/secrets-manager/service/2017-10-17/secrets-manager-2017-10-17.json).

### Problem

The original line in `MarkdownConverter.java`:

```java
output = output.replaceAll("\\\\([\\[\\]'{}()<>`@_*|!~$#^])", "$1");
```

A Python string literal requires backslashes to come in pairs (each pair is one literal backslash). The trouble is that pandoc escapes literal backslashes (`\` → `\\`) and Markdown-significant characters (`*` → `\*`) independently, and when the two sit next to each other the backslashes pile up into runs of varying length. A single strip regex cannot get every run right — it either consumes one half of a valid pair or leaves a lone backslash behind. Both happen with the Secrets Manager model, which documents password character sets that contain a literal `\`:

- [Line 1085 of the model file](https://github.com/aws/api-models-aws/blob/a51a2ed24797ec37a53c21ffd156ed511b8c73e0/models/secrets-manager/service/2017-10-17/secrets-manager-2017-10-17.json#L1085): the documentation contains a literal `\\`, which pandoc preserves. The regex matched the second backslash followed by `]` and stripped it, turning the valid `\\` into a lone `\` — it broke a previously valid escape.
- [Line 1128 of the model file](https://github.com/aws/api-models-aws/blob/a51a2ed24797ec37a53c21ffd156ed511b8c73e0/models/secrets-manager/service/2017-10-17/secrets-manager-2017-10-17.json#L1128): the documentation contains a lone backslash followed by a space, which the regex does not match, so it was left untouched — still an invalid escape.

### Generated code before this fix

`src/aws_sdk_secretsmanager/client.py` (GetRandomPassword docstring):

```python
in passwords: `` !\"#$$%&'()*+,-./:;<=>?@[\]^_`{|}~ ``
```

`src/aws_sdk_secretsmanager/models.py` (ExcludePunctuation docstring):

```python
`` ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~ ``.
```

pyright (run by `PythonFormatter` during codegen) fails the build:

```
src/aws_sdk_secretsmanager/client.py:636:51 - error: Unsupported escape sequence in string literal (reportInvalidStringEscapeSequence)
src/aws_sdk_secretsmanager/models.py:3311:54 - error: Unsupported escape sequence in string literal (reportInvalidStringEscapeSequence)
```

At runtime these also raise `SyntaxWarning: invalid escape sequence '\]'` / `'\ '` on import.

### The fix

Replace the strip regex with `normalizeBackslashEscapes`, which handles each maximal run of backslashes (plus the character that follows it) as a unit instead of matching one backslash at a time. Because backslashes must be paired in a Python literal, the `run / 2` fully paired backslashes are always kept; if the run is odd, the one leftover backslash binds to the next character and is:

- kept if it forms a valid Python escape (`\"`, `\n`, octal, hex, Unicode, line continuation),
- dropped if the next character is one pandoc only escapes for Markdown (e.g. `[`, `*`), or
- doubled otherwise, so a real lone backslash becomes a valid `\\`.

Working on whole runs keeps the result correct no matter how many backslashes pandoc emits, including odd-length runs where a literal backslash sits next to a Markdown character.

### Generated code after this fix

`src/aws_sdk_secretsmanager/client.py`:

```python
in passwords: `` !\"#$$%&'()*+,-./:;<=>?@[\\]^_`{|}~ ``
```

`src/aws_sdk_secretsmanager/models.py`:

```python
`` ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~ ``.
```

Both are now valid Python: `[\\]` renders as `[\]` (a single literal backslash), matching the intended documentation.

### Testing

- Regenerated the Secrets Manager client: no `reportInvalidStringEscapeSequence` errors, and the module imports under `python -W error::SyntaxWarning` with no warning. Also inspected the generated code as above.
- Regenerated DynamoDB, SQS, and API Gateway clients: no errors.
- `:core:test --tests "*MarkdownConverterTest*"` passes, including regression tests for paired backslashes, lone backslashes, valid escapes, and backslashes adjacent to Markdown characters.
- Regenerated existing clients in [aws-sdk-python](https://github.com/awslabs/aws-sdk-python) with no error during code generation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.