### PR TITLE
fix: annotate @default:null members as nullable

### DIFF
--- a/codegen/core/src/it/resources/META-INF/smithy/main.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/main.smithy
@@ -335,6 +335,8 @@ structure Defaults {
     @required
     requiredDefaultBool: Boolean = true
 
+    defaultNullBoolean: Boolean = null
+
     @required
     requiredStr: String
 
@@ -354,6 +356,8 @@ structure Defaults {
 
     @required
     requiredDefaultInt: Integer = 42
+
+    defaultNullLong: Long = null
 
     @required
     requiredFloat: Float

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -207,6 +207,14 @@ public final class StructureGenerator implements Runnable {
             if (member.hasTrait(DefaultTrait.class)) {
 
                 defaultValue = getDefaultValue(writer, member);
+                // A `@default: null` member is nullable and resolves to None, so
+                // it needs `| None` like a member with no default. Documents are
+                // excluded: a null document default is a non-None Document(None),
+                // built via default_factory below.
+                if (!target.isDocumentShape()
+                        && member.expectTrait(DefaultTrait.class).toNode().isNullNode()) {
+                    writer.putContext("nullable", true);
+                }
                 if (target.isDocumentShape() || defaultValue.startsWith("list[") || defaultValue.startsWith("dict[")) {
                     writer.addStdlibImport("dataclasses", "field");
                     defaultKey = "default_factory";


### PR DESCRIPTION
### Problem

The Secrets Manager and Cognito Identity models have structure members with `smithy.api#default": null`. For example, in `secrets-manager.json`:

- `DeleteSecretRequest$RecoveryWindowInDays` (target `long`), `@default: null` at [line 614](https://github.com/aws/api-models-aws/blob/a51a2ed24797ec37a53c21ffd156ed511b8c73e0/models/secrets-manager/service/2017-10-17/secrets-manager-2017-10-17.json#L614).
- `DeleteSecretRequest$ForceDeleteWithoutRecovery` (target `boolean`), `@default: null` at [line 621](https://github.com/aws/api-models-aws/blob/a51a2ed24797ec37a53c21ffd156ed511b8c73e0/models/secrets-manager/service/2017-10-17/secrets-manager-2017-10-17.json#L621).

`StructureGenerator.writeProperties` only added the `| None` annotation for members with no `@default` trait, so these members resolved their default to `None` but kept the bare target annotation:

```python
recovery_window_in_days: int = None
force_delete_without_recovery: bool = None
```

`None` is not assignable to `int` / `bool`, so pyright (run by `PythonFormatter` during codegen) fails the build:

```
src/aws_sdk_secretsmanager/models.py - error: Type "None" is not assignable to declared type "int" (reportAssignmentType)
src/aws_sdk_secretsmanager/models.py - error: Type "None" is not assignable to declared type "bool" (reportAssignmentType)
```

### The fix

In the optional-members loop of `StructureGenerator.writeProperties`, mark the field nullable when the resolved default is a null node, so it is annotated `| None`:

```java
if (!target.isDocumentShape()
        && member.expectTrait(DefaultTrait.class).toNode().isNullNode()) {
    writer.putContext("nullable", true);
}
```

This produces:

```python
recovery_window_in_days: int | None = None
force_delete_without_recovery: bool | None = None
```

Document shapes are excluded. A document with a null default is a non-`None` `Document` holding a null value, generated via `default_factory` as `field(default_factory=lambda: Document(None))`. Annotating it `| None` would be wrong.

### Testing

- Regenerated Secrets Manager and Cognito Identity: both build cleanly, and pyright reports 0 errors on the generated source.
- Regenerated DynamoDB, SQS and all existing clients in [aws-sdk-python repo](https://github.com/awslabs/aws-sdk-python) (no `@default: null` members): generated source is unchanged.
- `:core:build` (unit tests and the weather `:core:integ` integration test, whose model includes a `Document = null` member) passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
