### PR TITLE
fix(smithy-aws-core): omit Result wrapper for empty awsQuery output

### DIFF
--- a/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-bugfix-05435b3fb9a54b86b4ebb4d61b0d13ae.json
+++ b/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-bugfix-05435b3fb9a54b86b4ebb4d61b0d13ae.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Fixed awsQuery response deserialization for operations with no output members."
+}

--- a/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/aio/protocols.py
@@ -364,10 +364,14 @@ class AwsQueryClientProtocol(HttpClientProtocol):
     def _response_wrapper_elements(
         self,
         operation: APIOperation[SerializeableShape, DeserializeableShape],
-    ) -> tuple[str, str]:
+    ) -> tuple[str, ...]:
+        name = operation.schema.id.name
+        # Operations with no output members will omit the <OpResult> element.
+        if not operation.output_schema.members:
+            return (f"{name}Response",)
         return (
-            f"{operation.schema.id.name}Response",
-            f"{operation.schema.id.name}Result",
+            f"{name}Response",
+            f"{name}Result",
         )
 
     def _error_wrapper_elements(self) -> tuple[str, ...]:

--- a/packages/smithy-aws-core/tests/unit/aio/test_protocols.py
+++ b/packages/smithy-aws-core/tests/unit/aio/test_protocols.py
@@ -131,9 +131,6 @@ _INVALID_ACTION_ERROR_SCHEMA = Schema.collection(
     ],
     members={"message": {"target": STRING}},
 )
-_EMPTY_OUTPUT_SCHEMA = Schema.collection(
-    id=ShapeID("com.test#EmptyOutput"),
-)
 
 
 @dataclass
@@ -163,16 +160,6 @@ class _ModeledQueryError(ModeledError):
         return cls(**kwargs)
 
 
-class _EmptyOutput:
-    @classmethod
-    def deserialize(cls, deserializer: ShapeDeserializer) -> "_EmptyOutput":
-        def _consumer(schema: Schema, de: ShapeDeserializer) -> None:
-            pass
-
-        deserializer.read_struct(_EMPTY_OUTPUT_SCHEMA, consumer=_consumer)
-        return cls()
-
-
 def _operation_schema(name: str) -> Schema:
     return Schema(
         id=ShapeID(f"com.test#{name}"),
@@ -184,14 +171,10 @@ def _mock_operation(
     schema: Schema,
     *,
     error_schemas: list[Schema] | None = None,
-    output: Any = None,
-    output_schema: Schema | None = None,
 ) -> APIOperation[Any, Any]:
     operation = Mock(spec=APIOperation)
     operation.schema = schema
     operation.error_schemas = error_schemas or []
-    operation.output = output
-    operation.output_schema = output_schema
     return cast("APIOperation[Any, Any]", operation)
 
 
@@ -289,28 +272,3 @@ async def test_aws_query_returns_generic_error_for_unknown_code() -> None:
         "Unknown error for operation com.test#FailingOperation"
         " - status: 500, code: UnknownThing"
     )
-
-
-async def test_aws_query_deserializes_empty_output_without_result_wrapper() -> None:
-    protocol = AwsQueryClientProtocol(_SERVICE_SCHEMA, "2020-01-08")
-    result = await protocol.deserialize_response(
-        operation=_mock_operation(
-            _operation_schema("EmptyOperation"),
-            output=_EmptyOutput,
-            output_schema=_EMPTY_OUTPUT_SCHEMA,
-        ),
-        request=cast(HTTPRequest, Mock()),
-        response=HTTPResponse(
-            status=200,
-            fields=tuples_to_fields([]),
-            body=(
-                b"<EmptyOperationResponse>"
-                b"<ResponseMetadata><RequestId>abc-123</RequestId></ResponseMetadata>"
-                b"</EmptyOperationResponse>"
-            ),
-        ),
-        error_registry=TypeRegistry({}),
-        context=TypedProperties(),
-    )
-
-    assert isinstance(result, _EmptyOutput)

--- a/packages/smithy-aws-core/tests/unit/aio/test_protocols.py
+++ b/packages/smithy-aws-core/tests/unit/aio/test_protocols.py
@@ -131,6 +131,9 @@ _INVALID_ACTION_ERROR_SCHEMA = Schema.collection(
     ],
     members={"message": {"target": STRING}},
 )
+_EMPTY_OUTPUT_SCHEMA = Schema.collection(
+    id=ShapeID("com.test#EmptyOutput"),
+)
 
 
 @dataclass
@@ -160,6 +163,16 @@ class _ModeledQueryError(ModeledError):
         return cls(**kwargs)
 
 
+class _EmptyOutput:
+    @classmethod
+    def deserialize(cls, deserializer: ShapeDeserializer) -> "_EmptyOutput":
+        def _consumer(schema: Schema, de: ShapeDeserializer) -> None:
+            pass
+
+        deserializer.read_struct(_EMPTY_OUTPUT_SCHEMA, consumer=_consumer)
+        return cls()
+
+
 def _operation_schema(name: str) -> Schema:
     return Schema(
         id=ShapeID(f"com.test#{name}"),
@@ -171,10 +184,14 @@ def _mock_operation(
     schema: Schema,
     *,
     error_schemas: list[Schema] | None = None,
+    output: Any = None,
+    output_schema: Schema | None = None,
 ) -> APIOperation[Any, Any]:
     operation = Mock(spec=APIOperation)
     operation.schema = schema
     operation.error_schemas = error_schemas or []
+    operation.output = output
+    operation.output_schema = output_schema
     return cast("APIOperation[Any, Any]", operation)
 
 
@@ -272,3 +289,28 @@ async def test_aws_query_returns_generic_error_for_unknown_code() -> None:
         "Unknown error for operation com.test#FailingOperation"
         " - status: 500, code: UnknownThing"
     )
+
+
+async def test_aws_query_deserializes_empty_output_without_result_wrapper() -> None:
+    protocol = AwsQueryClientProtocol(_SERVICE_SCHEMA, "2020-01-08")
+    result = await protocol.deserialize_response(
+        operation=_mock_operation(
+            _operation_schema("EmptyOperation"),
+            output=_EmptyOutput,
+            output_schema=_EMPTY_OUTPUT_SCHEMA,
+        ),
+        request=cast(HTTPRequest, Mock()),
+        response=HTTPResponse(
+            status=200,
+            fields=tuples_to_fields([]),
+            body=(
+                b"<EmptyOperationResponse>"
+                b"<ResponseMetadata><RequestId>abc-123</RequestId></ResponseMetadata>"
+                b"</EmptyOperationResponse>"
+            ),
+        ),
+        error_registry=TypeRegistry({}),
+        context=TypedProperties(),
+    )
+
+    assert isinstance(result, _EmptyOutput)


### PR DESCRIPTION
**Problem:**

The awsQuery protocol returns XML responses wrapped in two layers: an outer `<{OperationName}Response>` element, and inside it an `<{OperationName}Result>` element and a `<ResponseMetadata>` element. For example, Amazon SNS `CreateTopic` returns:

```xml
<CreateTopicResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
  <CreateTopicResult>
    <TopicArn>arn:aws:sns:us-east-1:111122223333:my-topic</TopicArn>
  </CreateTopicResult>
  <ResponseMetadata>
    <RequestId>...</RequestId>
  </ResponseMetadata>
</CreateTopicResponse>
```

To deserialize this, `AwsQueryClientProtocol._response_wrapper_elements` tells the XML deserializer to descend through both wrapper elements before reading members. The current implementation always returns both:

```python
def _response_wrapper_elements(
    self,
    operation: APIOperation[SerializeableShape, DeserializeableShape],
) -> tuple[str, str]:
    return (
        f"{operation.schema.id.name}Response",
        f"{operation.schema.id.name}Result",
    )
```

The problem is that some operations' output shapes do not have members, so they do not get a `<{OperationName}Result>` element from the service. The response body contains only `<ResponseMetadata>` inside the outer wrapper. Requiring `<{OperationName}Result>` then fails.

This was found while testing Amazon SNS `SetTopicAttributes` and `DeleteTopic` operations. For example:

```xml
<SetTopicAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
  <ResponseMetadata>
    <RequestId>...</RequestId>
  </ResponseMetadata>
</SetTopicAttributesResponse>
```

The call failed with:

```
XMLParseError: Error parsing XML: Expected element 'SetTopicAttributesResult', got 'ResponseMetadata'
```

**Description of changes:**

In `_response_wrapper_elements`, only include the `<{OperationName}Result>` wrapper when the operation's output shape has members. Operations with empty output are unwrapped using just the outer `<{OperationName}Response>`. The return type is changed from `tuple[str, str]` to `tuple[str, ...]` since it now returns either one or two wrapper names.

**Testing:**

- Added a unit test in `tests/unit/aio/test_protocols.py` that deserializes an empty-output awsQuery response, and asserts it returns the output shape instead of raising.
- Generated Amazon SNS client locally, and verified its operation worked well: CreateTopic / GetTopicAttributes / SetTopicAttributes / ListTopics / DeleteTopic / Subscribe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
