### PR TITLE
Validate Transport Support For Bidirectional Streaming

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -653,6 +653,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                     ""\"An asynchronous HTTP client solely for testing purposes.""\"
 
                     TIMEOUT_EXCEPTIONS = ()
+                    SUPPORTS_DUPLEX_STREAMING: bool = True
 
                     def __init__(self, *, client_config: $5T | None = None):
                         self._client_config = client_config
@@ -668,6 +669,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                     ""\"An asynchronous HTTP client solely for testing purposes.""\"
 
                     TIMEOUT_EXCEPTIONS = ()
+                    SUPPORTS_DUPLEX_STREAMING: bool = True
 
                     def __init__(
                         self,

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -145,7 +145,9 @@ public final class ConfigGenerator implements Runnable {
                                 .namespace("smithy_core.aio.interfaces", ".")
                                 .build())
                         .build())
-                .documentation("The transport to use to send requests (e.g. an HTTP client).");
+                .documentation("The transport to use to send requests (e.g. an HTTP client). "
+                        + "Operations with bidirectional event streams require a transport that "
+                        + "sets SUPPORTS_DUPLEX_STREAMING to True, such as AWSCRTHTTPClient.");
 
         if (context.applicationProtocol().isHttpProtocol()) {
             properties.addAll(HTTP_PROPERTIES);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -146,8 +146,10 @@ public final class ConfigGenerator implements Runnable {
                                 .build())
                         .build())
                 .documentation("The transport to use to send requests (e.g. an HTTP client). "
-                        + "Operations with bidirectional event streams require a transport that "
-                        + "sets SUPPORTS_DUPLEX_STREAMING to True, such as AWSCRTHTTPClient.");
+                        + "Operations with bidirectional event streams require a "
+                        + "DuplexClientTransport, such as AWSCRTHTTPClient. Transports are "
+                        + "assumed not to support duplex streaming unless they explicitly set "
+                        + "SUPPORTS_DUPLEX_STREAMING to True.");
 
         if (context.applicationProtocol().isHttpProtocol()) {
             properties.addAll(HTTP_PROPERTIES);

--- a/designs/http-interfaces.md
+++ b/designs/http-interfaces.md
@@ -258,6 +258,14 @@ which takes a request and some configuration and asynchronously return a respons
 Having a minimal interface makes it much easier to implement these interfaces on top of
 a variety http libraries.
 
+Clients that support duplex (bidirectional) event streaming, which in practice
+requires HTTP/2, must declare it by setting the `SUPPORTS_DUPLEX_STREAMING` class
+attribute to `True`. Clients are assumed not to support it otherwise, and duplex
+stream operations invoked with such a client fail fast with an
+`UnsupportedTransportError`. This surfaces the configuration problem before any
+request is sent instead of letting the stream fail later with an opaque connection
+error.
+
 ```python
 @dataclass(kw_only=True)
 class HTTPRequestConfiguration:

--- a/designs/http-interfaces.md
+++ b/designs/http-interfaces.md
@@ -259,12 +259,13 @@ Having a minimal interface makes it much easier to implement these interfaces on
 a variety http libraries.
 
 Clients that support duplex (bidirectional) event streaming, which in practice
-requires HTTP/2, must declare it by setting the `SUPPORTS_DUPLEX_STREAMING` class
-attribute to `True`. Clients are assumed not to support it otherwise, and duplex
-stream operations invoked with such a client fail fast with an
-`UnsupportedTransportError`. This surfaces the configuration problem before any
-request is sent instead of letting the stream fail later with an opaque connection
-error.
+requires HTTP/2, implement the `DuplexClientTransport` protocol by setting the
+`SUPPORTS_DUPLEX_STREAMING` class attribute to `True`. Clients are assumed not to
+support it otherwise, and duplex stream operations invoked with such a client fail
+fast with an `UnsupportedTransportError`. This prevents clients that cannot support
+duplex streaming, such as `AIOHTTPClient`, from attempting these operations. This
+capability declaration does not guarantee that a particular connection negotiates
+HTTP/2.
 
 ```python
 @dataclass(kw_only=True)

--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-318f09ab1c7e425e88c6e8ba970cb2fe.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-318f09ab1c7e425e88c6e8ba970cb2fe.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Added `SUPPORTS_DUPLEX_STREAMING` to `ClientTransport` so transports can declare support for duplex (bidirectional) event streaming. `RequestPipeline.duplex_stream` now fails fast with an `UnsupportedTransportError` when the configured transport does not declare support."
+}

--- a/packages/smithy-core/.changes/next-release/smithy-core-enhancement-318f09ab1c7e425e88c6e8ba970cb2fe.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-enhancement-318f09ab1c7e425e88c6e8ba970cb2fe.json
@@ -1,4 +1,4 @@
 {
   "type": "enhancement",
-  "description": "Added `SUPPORTS_DUPLEX_STREAMING` to `ClientTransport` so transports can declare support for duplex (bidirectional) event streaming. `RequestPipeline.duplex_stream` now fails fast with an `UnsupportedTransportError` when the configured transport does not declare support."
+  "description": "Added `DuplexClientTransport` so transports can declare support for duplex (bidirectional) event streaming. `RequestPipeline.duplex_stream` now fails fast with an `UnsupportedTransportError` when the configured transport does not declare support."
 }

--- a/packages/smithy-core/src/smithy_core/aio/client.py
+++ b/packages/smithy-core/src/smithy_core/aio/client.py
@@ -12,7 +12,12 @@ from .. import URI
 from ..auth import AuthParams
 from ..deserializers import DeserializeableShape, ShapeDeserializer
 from ..endpoints import EndpointResolverParams
-from ..exceptions import ClientTimeoutError, RetryError, SmithyError
+from ..exceptions import (
+    ClientTimeoutError,
+    RetryError,
+    SmithyError,
+    UnsupportedTransportError,
+)
 from ..interceptors import (
     InputContext,
     Interceptor,
@@ -197,6 +202,18 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
         :param output_event_type: The event type to receive in the output stream.
         :param event_deserializer: The method used to deserialize events.
         """
+        # The transport is assumed not to support duplex streaming unless it
+        # explicitly declares otherwise.
+        if not getattr(self.transport, "SUPPORTS_DUPLEX_STREAMING", False):
+            raise UnsupportedTransportError(
+                f"The configured transport ({type(self.transport).__name__}) does "
+                f"not support duplex (bidirectional) event streaming, which is "
+                f"required by the {call.operation.schema.id} operation. Use a "
+                f"transport that does, such as "
+                f"smithy_http.aio.crt.AWSCRTHTTPClient. Custom transports that "
+                f"support duplex streaming must set SUPPORTS_DUPLEX_STREAMING "
+                f"to True."
+            )
         request_future = Future[RequestContext[I, TRequest]]()
         execute_task = asyncio.create_task(self._execute_request(call, request_future))
         request_context = await request_future

--- a/packages/smithy-core/src/smithy_core/aio/client.py
+++ b/packages/smithy-core/src/smithy_core/aio/client.py
@@ -204,15 +204,15 @@ class RequestPipeline[TRequest: Request, TResponse: Response]:
         """
         # The transport is assumed not to support duplex streaming unless it
         # explicitly declares otherwise.
-        if not getattr(self.transport, "SUPPORTS_DUPLEX_STREAMING", False):
+        if getattr(self.transport, "SUPPORTS_DUPLEX_STREAMING", False) is not True:
             raise UnsupportedTransportError(
                 f"The configured transport ({type(self.transport).__name__}) does "
                 f"not support duplex (bidirectional) event streaming, which is "
                 f"required by the {call.operation.schema.id} operation. Use a "
                 f"transport that does, such as "
                 f"smithy_http.aio.crt.AWSCRTHTTPClient. Custom transports that "
-                f"support duplex streaming must set SUPPORTS_DUPLEX_STREAMING "
-                f"to True."
+                f"support duplex streaming can implement DuplexClientTransport "
+                f"by setting SUPPORTS_DUPLEX_STREAMING to True."
             )
         request_future = Future[RequestContext[I, TRequest]]()
         execute_task = asyncio.create_task(self._execute_request(call, request_future))

--- a/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
+++ b/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
@@ -90,6 +90,14 @@ class ClientTransport[I: Request, O: Response](Protocol):
 
     TIMEOUT_EXCEPTIONS: tuple[type[Exception], ...]
 
+    SUPPORTS_DUPLEX_STREAMING: bool = False
+    """Whether this transport can read response data while the request body is still
+    being written (typically requires HTTP/2).
+
+    Transports that support duplex (bidirectional) event streaming must explicitly set
+    this to True. Transports that don't declare it are assumed not to support it.
+    """
+
     async def send(self, request: I) -> O:
         """Send a request over the transport and receive the response."""
         ...

--- a/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
+++ b/packages/smithy-core/src/smithy_core/aio/interfaces/__init__.py
@@ -1,7 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 from collections.abc import AsyncIterable, Callable
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from ...documents import TypeRegistry
 from ...endpoints import EndpointResolverParams
@@ -86,21 +86,27 @@ class EndpointResolver(Protocol):
 
 
 class ClientTransport[I: Request, O: Response](Protocol):
-    """Protocol-agnostic representation of a client transport (e.g. an HTTP client)."""
+    """Protocol-agnostic representation of a client transport (e.g. an HTTP client).
+
+    Transports that support duplex (bidirectional) event streaming can implement
+    :py:class:`DuplexClientTransport`.
+    """
 
     TIMEOUT_EXCEPTIONS: tuple[type[Exception], ...]
-
-    SUPPORTS_DUPLEX_STREAMING: bool = False
-    """Whether this transport can read response data while the request body is still
-    being written (typically requires HTTP/2).
-
-    Transports that support duplex (bidirectional) event streaming must explicitly set
-    this to True. Transports that don't declare it are assumed not to support it.
-    """
 
     async def send(self, request: I) -> O:
         """Send a request over the transport and receive the response."""
         ...
+
+
+class DuplexClientTransport[I: Request, O: Response](ClientTransport[I, O], Protocol):
+    """A client transport that supports duplex (bidirectional) event streaming.
+
+    Duplex transports can read response data while the request body is still being
+    written. HTTP transports typically require HTTP/2 for this capability.
+    """
+
+    SUPPORTS_DUPLEX_STREAMING: Literal[True]
 
 
 class ClientProtocol[I: Request, O: Response](Protocol):

--- a/packages/smithy-core/src/smithy_core/exceptions.py
+++ b/packages/smithy-core/src/smithy_core/exceptions.py
@@ -114,5 +114,10 @@ class UnsupportedStreamError(SmithyError):
     streams are not supported."""
 
 
+class UnsupportedTransportError(SmithyError):
+    """Indicates that an operation requires a transport capability that the configured
+    transport does not declare support for (e.g. duplex event streaming)."""
+
+
 class EndpointResolutionError(SmithyError):
     """Exception type for all exceptions raised by endpoint resolution."""

--- a/packages/smithy-core/src/smithy_core/exceptions.py
+++ b/packages/smithy-core/src/smithy_core/exceptions.py
@@ -124,5 +124,10 @@ class UnsupportedStreamError(SmithyError):
     streams are not supported."""
 
 
+class UnsupportedTransportError(SmithyError):
+    """Indicates that an operation requires a transport capability that the configured
+    transport does not declare support for (e.g. duplex event streaming)."""
+
+
 class EndpointResolutionError(SmithyError):
     """Exception type for all exceptions raised by endpoint resolution."""

--- a/packages/smithy-core/tests/unit/aio/_pipeline_harness.py
+++ b/packages/smithy-core/tests/unit/aio/_pipeline_harness.py
@@ -1,0 +1,207 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import Any, Self, cast
+
+from smithy_core import URI
+from smithy_core.aio.client import ClientCall, RequestPipeline
+from smithy_core.aio.interfaces import ClientProtocol, ClientTransport
+from smithy_core.deserializers import ShapeDeserializer
+from smithy_core.documents import TypeRegistry
+from smithy_core.endpoints import EndpointResolverParams
+from smithy_core.interceptors import InterceptorChain
+from smithy_core.schemas import APIOperation, Schema
+from smithy_core.serializers import ShapeSerializer
+from smithy_core.shapes import ShapeID, ShapeType
+from smithy_core.traits import StreamingTrait
+from smithy_core.types import TypedProperties
+
+_STRING = Schema(id=ShapeID("smithy.api#String"), shape_type=ShapeType.STRING)
+
+_EVENTS = Schema.collection(
+    id=ShapeID("com.example#Events"),
+    shape_type=ShapeType.UNION,
+    members={"message": {"target": _STRING}},
+)
+
+_INPUT_SCHEMA = Schema.collection(
+    id=ShapeID("com.example#StreamingInput"),
+    members={"events": {"target": _EVENTS, "traits": [StreamingTrait()]}},
+)
+
+_OUTPUT_SCHEMA = Schema.collection(
+    id=ShapeID("com.example#StreamingOutput"),
+    members={"events": {"target": _EVENTS, "traits": [StreamingTrait()]}},
+)
+
+
+class StubInput:
+    def serialize(self, serializer: ShapeSerializer) -> None:
+        pass
+
+
+class StubOutput:
+    @classmethod
+    def deserialize(cls, deserializer: ShapeDeserializer) -> Self:
+        return cls()
+
+
+class StubEvent:
+    def serialize(self, serializer: ShapeSerializer) -> None:
+        pass
+
+    @classmethod
+    def deserialize(cls, deserializer: ShapeDeserializer) -> Self:
+        return cls()
+
+
+OPERATION = APIOperation(
+    input=StubInput,
+    output=StubOutput,
+    schema=Schema(
+        id=ShapeID("com.example#StreamingOperation"),
+        shape_type=ShapeType.OPERATION,
+    ),
+    input_schema=_INPUT_SCHEMA,
+    output_schema=_OUTPUT_SCHEMA,
+    error_registry=TypeRegistry({}),
+    effective_auth_schemes=[],
+    error_schemas=[],
+)
+
+
+class StubRequest:
+    def __init__(self) -> None:
+        self.destination = URI(host="example.com")
+        self.body = b""
+
+    async def consume_body_async(self) -> bytes:
+        return b""
+
+    def consume_body(self) -> bytes:
+        return b""
+
+
+class StubResponse:
+    body = b""
+
+    async def consume_body_async(self) -> bytes:
+        return b""
+
+    def consume_body(self) -> bytes:
+        return b""
+
+
+class StubEventPublisher:
+    async def send(self, event: Any) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+class StubEventReceiver:
+    async def receive(self) -> Any:
+        return None
+
+    async def close(self) -> None:
+        pass
+
+
+class StubProtocol:
+    def __init__(self) -> None:
+        self.serialize_request_calls = 0
+        self.set_service_endpoint_calls = 0
+        self.deserialize_response_calls = 0
+        self.create_event_publisher_calls = 0
+        self.create_event_receiver_calls = 0
+
+    @property
+    def id(self) -> ShapeID:
+        return ShapeID("com.example#testProtocol")
+
+    def serialize_request(self, **kwargs: Any) -> StubRequest:
+        self.serialize_request_calls += 1
+        return StubRequest()
+
+    def set_service_endpoint(self, *, request: Any, endpoint: Any) -> Any:
+        self.set_service_endpoint_calls += 1
+        return request
+
+    async def deserialize_response(self, **kwargs: Any) -> StubOutput:
+        self.deserialize_response_calls += 1
+        return StubOutput()
+
+    def create_event_publisher(self, **kwargs: Any) -> StubEventPublisher:
+        self.create_event_publisher_calls += 1
+        return StubEventPublisher()
+
+    def create_event_receiver(self, **kwargs: Any) -> StubEventReceiver:
+        self.create_event_receiver_calls += 1
+        return StubEventReceiver()
+
+
+class StubEndpoint:
+    def __init__(self) -> None:
+        self.uri = URI(host="example.com")
+        self.properties = TypedProperties()
+
+
+class StubEndpointResolver:
+    async def resolve_endpoint(self, params: EndpointResolverParams[Any]) -> Any:
+        return StubEndpoint()
+
+
+class StubAuthResolver:
+    def resolve_auth_scheme(self, *, auth_parameters: Any) -> list[Any]:
+        return []
+
+
+class UndeclaredTransport:
+    """A transport that does not declare whether it supports duplex streaming."""
+
+    TIMEOUT_EXCEPTIONS: tuple[type[Exception], ...] = ()
+
+    def __init__(self) -> None:
+        self.send_calls = 0
+
+    async def send(self, request: Any) -> StubResponse:
+        self.send_calls += 1
+        return StubResponse()
+
+
+class NonDuplexTransport(UndeclaredTransport):
+    SUPPORTS_DUPLEX_STREAMING = False
+
+
+class DuplexTransport(UndeclaredTransport):
+    SUPPORTS_DUPLEX_STREAMING = True
+
+
+@dataclass
+class PipelineHarness:
+    protocol: StubProtocol
+    transport: UndeclaredTransport
+    pipeline: RequestPipeline[Any, Any]
+
+
+def pipeline_harness(transport: UndeclaredTransport) -> PipelineHarness:
+    protocol = StubProtocol()
+    pipeline = RequestPipeline(
+        protocol=cast("ClientProtocol[Any, Any]", protocol),
+        transport=cast("ClientTransport[Any, Any]", transport),
+    )
+    return PipelineHarness(protocol=protocol, transport=transport, pipeline=pipeline)
+
+
+def client_call() -> ClientCall[Any, Any]:
+    return ClientCall(
+        input=StubInput(),
+        operation=OPERATION,
+        context=TypedProperties(),
+        interceptor=InterceptorChain([]),
+        auth_scheme_resolver=StubAuthResolver(),
+        supported_auth_schemes={},
+        endpoint_resolver=StubEndpointResolver(),
+        retry_strategy=None,  # type: ignore[arg-type] # unused for streaming input
+    )

--- a/packages/smithy-core/tests/unit/aio/_pipeline_harness.py
+++ b/packages/smithy-core/tests/unit/aio/_pipeline_harness.py
@@ -5,7 +5,7 @@ from typing import Any, Self, cast
 
 from smithy_core import URI
 from smithy_core.aio.client import ClientCall, RequestPipeline
-from smithy_core.aio.interfaces import ClientProtocol, ClientTransport
+from smithy_core.aio.interfaces import ClientProtocol
 from smithy_core.deserializers import ShapeDeserializer
 from smithy_core.documents import TypeRegistry
 from smithy_core.endpoints import EndpointResolverParams
@@ -189,7 +189,7 @@ def pipeline_harness(transport: UndeclaredTransport) -> PipelineHarness:
     protocol = StubProtocol()
     pipeline = RequestPipeline(
         protocol=cast("ClientProtocol[Any, Any]", protocol),
-        transport=cast("ClientTransport[Any, Any]", transport),
+        transport=transport,
     )
     return PipelineHarness(protocol=protocol, transport=transport, pipeline=pipeline)
 

--- a/packages/smithy-core/tests/unit/aio/test_client.py
+++ b/packages/smithy-core/tests/unit/aio/test_client.py
@@ -1,0 +1,226 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any, Self, cast
+
+import pytest
+from smithy_core import URI
+from smithy_core.aio.client import ClientCall, RequestPipeline
+from smithy_core.aio.eventstream import DuplexEventStream, InputEventStream
+from smithy_core.aio.interfaces import ClientProtocol, ClientTransport
+from smithy_core.deserializers import ShapeDeserializer
+from smithy_core.documents import TypeRegistry
+from smithy_core.endpoints import EndpointResolverParams
+from smithy_core.exceptions import UnsupportedTransportError
+from smithy_core.interceptors import InterceptorChain
+from smithy_core.schemas import APIOperation, Schema
+from smithy_core.serializers import ShapeSerializer
+from smithy_core.shapes import ShapeID, ShapeType
+from smithy_core.traits import StreamingTrait
+from smithy_core.types import TypedProperties
+
+_STRING = Schema(id=ShapeID("smithy.api#String"), shape_type=ShapeType.STRING)
+
+_EVENTS = Schema.collection(
+    id=ShapeID("com.example#Events"),
+    shape_type=ShapeType.UNION,
+    members={"message": {"target": _STRING}},
+)
+
+_INPUT_SCHEMA = Schema.collection(
+    id=ShapeID("com.example#StreamingInput"),
+    members={"events": {"target": _EVENTS, "traits": [StreamingTrait()]}},
+)
+
+_OUTPUT_SCHEMA = Schema.collection(
+    id=ShapeID("com.example#StreamingOutput"),
+    members={"events": {"target": _EVENTS, "traits": [StreamingTrait()]}},
+)
+
+
+class _Input:
+    def serialize(self, serializer: ShapeSerializer) -> None:
+        pass
+
+
+class _Output:
+    @classmethod
+    def deserialize(cls, deserializer: ShapeDeserializer) -> Self:
+        return cls()
+
+
+class _Event:
+    def serialize(self, serializer: ShapeSerializer) -> None:
+        pass
+
+    @classmethod
+    def deserialize(cls, deserializer: ShapeDeserializer) -> Self:
+        return cls()
+
+
+_OPERATION = APIOperation(
+    input=_Input,
+    output=_Output,
+    schema=Schema(
+        id=ShapeID("com.example#StreamingOperation"),
+        shape_type=ShapeType.OPERATION,
+    ),
+    input_schema=_INPUT_SCHEMA,
+    output_schema=_OUTPUT_SCHEMA,
+    error_registry=TypeRegistry({}),
+    effective_auth_schemes=[],
+    error_schemas=[],
+)
+
+
+class _StubRequest:
+    def __init__(self) -> None:
+        self.destination = URI(host="example.com")
+        self.body = b""
+
+    async def consume_body_async(self) -> bytes:
+        return b""
+
+    def consume_body(self) -> bytes:
+        return b""
+
+
+class _StubResponse:
+    body = b""
+
+    async def consume_body_async(self) -> bytes:
+        return b""
+
+    def consume_body(self) -> bytes:
+        return b""
+
+
+class _StubEventPublisher:
+    async def send(self, event: Any) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+class _StubEventReceiver:
+    async def receive(self) -> Any:
+        return None
+
+    async def close(self) -> None:
+        pass
+
+
+class _StubProtocol:
+    @property
+    def id(self) -> ShapeID:
+        return ShapeID("com.example#testProtocol")
+
+    def serialize_request(self, **kwargs: Any) -> _StubRequest:
+        return _StubRequest()
+
+    def set_service_endpoint(self, *, request: Any, endpoint: Any) -> Any:
+        return request
+
+    async def deserialize_response(self, **kwargs: Any) -> _Output:
+        return _Output()
+
+    def create_event_publisher(self, **kwargs: Any) -> _StubEventPublisher:
+        return _StubEventPublisher()
+
+    def create_event_receiver(self, **kwargs: Any) -> _StubEventReceiver:
+        return _StubEventReceiver()
+
+
+class _StubEndpoint:
+    def __init__(self) -> None:
+        self.uri = URI(host="example.com")
+        self.properties = TypedProperties()
+
+
+class _StubEndpointResolver:
+    async def resolve_endpoint(self, params: EndpointResolverParams[Any]) -> Any:
+        return _StubEndpoint()
+
+
+class _StubAuthResolver:
+    def resolve_auth_scheme(self, *, auth_parameters: Any) -> list[Any]:
+        return []
+
+
+class _UndeclaredTransport:
+    """A transport that does not declare whether it supports duplex streaming."""
+
+    TIMEOUT_EXCEPTIONS: tuple[type[Exception], ...] = ()
+
+    async def send(self, request: Any) -> _StubResponse:
+        return _StubResponse()
+
+
+class _NonDuplexTransport(_UndeclaredTransport):
+    SUPPORTS_DUPLEX_STREAMING = False
+
+
+class _DuplexTransport(_UndeclaredTransport):
+    SUPPORTS_DUPLEX_STREAMING = True
+
+
+def _pipeline(transport: object) -> RequestPipeline[Any, Any]:
+    # The stubs are intentionally structural (they don't subclass the
+    # protocols), so cast them to keep the type checker focused on the
+    # runtime behavior under test.
+    return RequestPipeline(
+        protocol=cast("ClientProtocol[Any, Any]", _StubProtocol()),
+        transport=cast("ClientTransport[Any, Any]", transport),
+    )
+
+
+def _client_call() -> ClientCall[Any, Any]:
+    return ClientCall(
+        input=_Input(),
+        operation=_OPERATION,
+        context=TypedProperties(),
+        interceptor=InterceptorChain([]),
+        auth_scheme_resolver=_StubAuthResolver(),
+        supported_auth_schemes={},
+        endpoint_resolver=_StubEndpointResolver(),
+        retry_strategy=None,  # type: ignore[arg-type] # unused for streaming input
+    )
+
+
+async def test_duplex_stream_raises_for_undeclared_transport() -> None:
+    pipeline = _pipeline(_UndeclaredTransport())
+
+    with pytest.raises(UnsupportedTransportError) as exc_info:
+        await pipeline.duplex_stream(_client_call(), _Event, _Event, _Event.deserialize)
+
+    assert "_UndeclaredTransport" in str(exc_info.value)
+    assert "com.example#StreamingOperation" in str(exc_info.value)
+
+
+async def test_duplex_stream_raises_for_non_duplex_transport() -> None:
+    pipeline = _pipeline(_NonDuplexTransport())
+
+    with pytest.raises(UnsupportedTransportError):
+        await pipeline.duplex_stream(_client_call(), _Event, _Event, _Event.deserialize)
+
+
+async def test_duplex_stream_proceeds_for_duplex_transport() -> None:
+    pipeline = _pipeline(_DuplexTransport())
+
+    stream = await pipeline.duplex_stream(
+        _client_call(), _Event, _Event, _Event.deserialize
+    )
+
+    assert isinstance(stream, DuplexEventStream)
+    output, output_stream = await stream.await_output()
+    assert isinstance(output, _Output)
+    assert isinstance(output_stream, _StubEventReceiver)
+
+
+async def test_input_stream_does_not_require_duplex_support() -> None:
+    pipeline = _pipeline(_NonDuplexTransport())
+
+    stream = await pipeline.input_stream(_client_call(), _Event)
+
+    assert isinstance(stream, InputEventStream)
+    assert isinstance(await stream.await_output(), _Output)

--- a/packages/smithy-core/tests/unit/aio/test_client.py
+++ b/packages/smithy-core/tests/unit/aio/test_client.py
@@ -1,226 +1,65 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, Self, cast
 
 import pytest
-from smithy_core import URI
-from smithy_core.aio.client import ClientCall, RequestPipeline
 from smithy_core.aio.eventstream import DuplexEventStream, InputEventStream
-from smithy_core.aio.interfaces import ClientProtocol, ClientTransport
-from smithy_core.deserializers import ShapeDeserializer
-from smithy_core.documents import TypeRegistry
-from smithy_core.endpoints import EndpointResolverParams
 from smithy_core.exceptions import UnsupportedTransportError
-from smithy_core.interceptors import InterceptorChain
-from smithy_core.schemas import APIOperation, Schema
-from smithy_core.serializers import ShapeSerializer
-from smithy_core.shapes import ShapeID, ShapeType
-from smithy_core.traits import StreamingTrait
-from smithy_core.types import TypedProperties
 
-_STRING = Schema(id=ShapeID("smithy.api#String"), shape_type=ShapeType.STRING)
-
-_EVENTS = Schema.collection(
-    id=ShapeID("com.example#Events"),
-    shape_type=ShapeType.UNION,
-    members={"message": {"target": _STRING}},
+from ._pipeline_harness import (
+    DuplexTransport,
+    NonDuplexTransport,
+    StubEvent,
+    StubEventReceiver,
+    StubOutput,
+    UndeclaredTransport,
+    client_call,
+    pipeline_harness,
 )
-
-_INPUT_SCHEMA = Schema.collection(
-    id=ShapeID("com.example#StreamingInput"),
-    members={"events": {"target": _EVENTS, "traits": [StreamingTrait()]}},
-)
-
-_OUTPUT_SCHEMA = Schema.collection(
-    id=ShapeID("com.example#StreamingOutput"),
-    members={"events": {"target": _EVENTS, "traits": [StreamingTrait()]}},
-)
-
-
-class _Input:
-    def serialize(self, serializer: ShapeSerializer) -> None:
-        pass
-
-
-class _Output:
-    @classmethod
-    def deserialize(cls, deserializer: ShapeDeserializer) -> Self:
-        return cls()
-
-
-class _Event:
-    def serialize(self, serializer: ShapeSerializer) -> None:
-        pass
-
-    @classmethod
-    def deserialize(cls, deserializer: ShapeDeserializer) -> Self:
-        return cls()
-
-
-_OPERATION = APIOperation(
-    input=_Input,
-    output=_Output,
-    schema=Schema(
-        id=ShapeID("com.example#StreamingOperation"),
-        shape_type=ShapeType.OPERATION,
-    ),
-    input_schema=_INPUT_SCHEMA,
-    output_schema=_OUTPUT_SCHEMA,
-    error_registry=TypeRegistry({}),
-    effective_auth_schemes=[],
-    error_schemas=[],
-)
-
-
-class _StubRequest:
-    def __init__(self) -> None:
-        self.destination = URI(host="example.com")
-        self.body = b""
-
-    async def consume_body_async(self) -> bytes:
-        return b""
-
-    def consume_body(self) -> bytes:
-        return b""
-
-
-class _StubResponse:
-    body = b""
-
-    async def consume_body_async(self) -> bytes:
-        return b""
-
-    def consume_body(self) -> bytes:
-        return b""
-
-
-class _StubEventPublisher:
-    async def send(self, event: Any) -> None:
-        pass
-
-    async def close(self) -> None:
-        pass
-
-
-class _StubEventReceiver:
-    async def receive(self) -> Any:
-        return None
-
-    async def close(self) -> None:
-        pass
-
-
-class _StubProtocol:
-    @property
-    def id(self) -> ShapeID:
-        return ShapeID("com.example#testProtocol")
-
-    def serialize_request(self, **kwargs: Any) -> _StubRequest:
-        return _StubRequest()
-
-    def set_service_endpoint(self, *, request: Any, endpoint: Any) -> Any:
-        return request
-
-    async def deserialize_response(self, **kwargs: Any) -> _Output:
-        return _Output()
-
-    def create_event_publisher(self, **kwargs: Any) -> _StubEventPublisher:
-        return _StubEventPublisher()
-
-    def create_event_receiver(self, **kwargs: Any) -> _StubEventReceiver:
-        return _StubEventReceiver()
-
-
-class _StubEndpoint:
-    def __init__(self) -> None:
-        self.uri = URI(host="example.com")
-        self.properties = TypedProperties()
-
-
-class _StubEndpointResolver:
-    async def resolve_endpoint(self, params: EndpointResolverParams[Any]) -> Any:
-        return _StubEndpoint()
-
-
-class _StubAuthResolver:
-    def resolve_auth_scheme(self, *, auth_parameters: Any) -> list[Any]:
-        return []
-
-
-class _UndeclaredTransport:
-    """A transport that does not declare whether it supports duplex streaming."""
-
-    TIMEOUT_EXCEPTIONS: tuple[type[Exception], ...] = ()
-
-    async def send(self, request: Any) -> _StubResponse:
-        return _StubResponse()
-
-
-class _NonDuplexTransport(_UndeclaredTransport):
-    SUPPORTS_DUPLEX_STREAMING = False
-
-
-class _DuplexTransport(_UndeclaredTransport):
-    SUPPORTS_DUPLEX_STREAMING = True
-
-
-def _pipeline(transport: object) -> RequestPipeline[Any, Any]:
-    # The stubs are intentionally structural (they don't subclass the
-    # protocols), so cast them to keep the type checker focused on the
-    # runtime behavior under test.
-    return RequestPipeline(
-        protocol=cast("ClientProtocol[Any, Any]", _StubProtocol()),
-        transport=cast("ClientTransport[Any, Any]", transport),
-    )
-
-
-def _client_call() -> ClientCall[Any, Any]:
-    return ClientCall(
-        input=_Input(),
-        operation=_OPERATION,
-        context=TypedProperties(),
-        interceptor=InterceptorChain([]),
-        auth_scheme_resolver=_StubAuthResolver(),
-        supported_auth_schemes={},
-        endpoint_resolver=_StubEndpointResolver(),
-        retry_strategy=None,  # type: ignore[arg-type] # unused for streaming input
-    )
 
 
 async def test_duplex_stream_raises_for_undeclared_transport() -> None:
-    pipeline = _pipeline(_UndeclaredTransport())
+    harness = pipeline_harness(UndeclaredTransport())
 
     with pytest.raises(UnsupportedTransportError) as exc_info:
-        await pipeline.duplex_stream(_client_call(), _Event, _Event, _Event.deserialize)
+        await harness.pipeline.duplex_stream(
+            client_call(), StubEvent, StubEvent, StubEvent.deserialize
+        )
 
-    assert "_UndeclaredTransport" in str(exc_info.value)
+    assert "UndeclaredTransport" in str(exc_info.value)
     assert "com.example#StreamingOperation" in str(exc_info.value)
+    assert harness.protocol.serialize_request_calls == 0
+    assert harness.transport.send_calls == 0
 
 
 async def test_duplex_stream_raises_for_non_duplex_transport() -> None:
-    pipeline = _pipeline(_NonDuplexTransport())
+    harness = pipeline_harness(NonDuplexTransport())
 
     with pytest.raises(UnsupportedTransportError):
-        await pipeline.duplex_stream(_client_call(), _Event, _Event, _Event.deserialize)
+        await harness.pipeline.duplex_stream(
+            client_call(), StubEvent, StubEvent, StubEvent.deserialize
+        )
+
+    assert harness.protocol.serialize_request_calls == 0
+    assert harness.transport.send_calls == 0
 
 
 async def test_duplex_stream_proceeds_for_duplex_transport() -> None:
-    pipeline = _pipeline(_DuplexTransport())
+    harness = pipeline_harness(DuplexTransport())
 
-    stream = await pipeline.duplex_stream(
-        _client_call(), _Event, _Event, _Event.deserialize
+    stream = await harness.pipeline.duplex_stream(
+        client_call(), StubEvent, StubEvent, StubEvent.deserialize
     )
 
     assert isinstance(stream, DuplexEventStream)
     output, output_stream = await stream.await_output()
-    assert isinstance(output, _Output)
-    assert isinstance(output_stream, _StubEventReceiver)
+    assert isinstance(output, StubOutput)
+    assert isinstance(output_stream, StubEventReceiver)
 
 
 async def test_input_stream_does_not_require_duplex_support() -> None:
-    pipeline = _pipeline(_NonDuplexTransport())
+    harness = pipeline_harness(NonDuplexTransport())
 
-    stream = await pipeline.input_stream(_client_call(), _Event)
+    stream = await harness.pipeline.input_stream(client_call(), StubEvent)
 
     assert isinstance(stream, InputEventStream)
-    assert isinstance(await stream.await_output(), _Output)
+    assert isinstance(await stream.await_output(), StubOutput)

--- a/packages/smithy-http/.changes/next-release/smithy-http-enhancement-91c7d1ab9ee64c0fbfc3dcb60f52c284.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-enhancement-91c7d1ab9ee64c0fbfc3dcb60f52c284.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Declared duplex (bidirectional) streaming support on `AWSCRTHTTPClient` via `SUPPORTS_DUPLEX_STREAMING`. `AIOHTTPClient` explicitly does not support it."
+}

--- a/packages/smithy-http/.changes/next-release/smithy-http-enhancement-91c7d1ab9ee64c0fbfc3dcb60f52c284.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-enhancement-91c7d1ab9ee64c0fbfc3dcb60f52c284.json
@@ -1,4 +1,4 @@
 {
   "type": "enhancement",
-  "description": "Declared duplex (bidirectional) streaming support on `AWSCRTHTTPClient` via `SUPPORTS_DUPLEX_STREAMING`. `AIOHTTPClient` explicitly does not support it."
+  "description": "Declared `AWSCRTHTTPClient` as duplex (bidirectional) streaming capable via `SUPPORTS_DUPLEX_STREAMING`. `AIOHTTPClient` explicitly does not support duplex streaming."
 }

--- a/packages/smithy-http/src/smithy_http/aio/aiohttp.py
+++ b/packages/smithy-http/src/smithy_http/aio/aiohttp.py
@@ -53,6 +53,10 @@ class AIOHTTPClient(HTTPClient):
 
     TIMEOUT_EXCEPTIONS = (TimeoutError,)
 
+    # aiohttp has no HTTP/2 support and this client fully buffers the response
+    # before returning, so it can never interleave request and response data.
+    SUPPORTS_DUPLEX_STREAMING = False
+
     def __init__(
         self,
         *,

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -143,6 +143,10 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     TIMEOUT_EXCEPTIONS = (_CRTTimeoutError,)
 
+    # True duplex streaming additionally requires the connection to negotiate
+    # HTTP/2 via ALPN; over HTTP/1.1 the CRT falls back to a buffered body_stream.
+    SUPPORTS_DUPLEX_STREAMING = True
+
     def __init__(
         self,
         eventloop: _AWSCRTEventLoop | None = None,

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -143,8 +143,8 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     TIMEOUT_EXCEPTIONS = (_CRTTimeoutError,)
 
-    # True duplex streaming additionally requires the connection to negotiate
-    # HTTP/2 via ALPN; over HTTP/1.1 the CRT falls back to a buffered body_stream.
+    # CRT can stream request and response data concurrently when the connection
+    # negotiates HTTP/2.
     SUPPORTS_DUPLEX_STREAMING = True
 
     def __init__(

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -142,6 +142,10 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     TIMEOUT_EXCEPTIONS = (_CRTTimeoutError,)
 
+    # True duplex streaming additionally requires the connection to negotiate
+    # HTTP/2 via ALPN; over HTTP/1.1 the CRT falls back to a buffered body_stream.
+    SUPPORTS_DUPLEX_STREAMING = True
+
     def __init__(
         self,
         eventloop: _AWSCRTEventLoop | None = None,

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -142,8 +142,8 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     TIMEOUT_EXCEPTIONS = (_CRTTimeoutError,)
 
-    # True duplex streaming additionally requires the connection to negotiate
-    # HTTP/2 via ALPN; over HTTP/1.1 the CRT falls back to a buffered body_stream.
+    # CRT can stream request and response data concurrently when the connection
+    # negotiates HTTP/2.
     SUPPORTS_DUPLEX_STREAMING = True
 
     def __init__(

--- a/packages/smithy-http/src/smithy_http/testing/mockhttp.py
+++ b/packages/smithy-http/src/smithy_http/testing/mockhttp.py
@@ -22,6 +22,11 @@ class MockHTTPClient(HTTPClient):
 
     TIMEOUT_EXCEPTIONS = (TimeoutError,)
 
+    # Declared so duplex (bidirectional) stream operations can be unit tested
+    # against this client. Queued responses are returned without consuming the
+    # request body, which is compatible with duplex streaming.
+    SUPPORTS_DUPLEX_STREAMING = True
+
     def __init__(
         self,
         *,

--- a/packages/smithy-http/tests/unit/aio/test_aiohttp.py
+++ b/packages/smithy-http/tests/unit/aio/test_aiohttp.py
@@ -1,0 +1,7 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from smithy_http.aio.aiohttp import AIOHTTPClient
+
+
+def test_does_not_support_duplex_streaming() -> None:
+    assert AIOHTTPClient.SUPPORTS_DUPLEX_STREAMING is False

--- a/packages/smithy-http/tests/unit/aio/test_aiohttp.py
+++ b/packages/smithy-http/tests/unit/aio/test_aiohttp.py
@@ -92,3 +92,7 @@ async def test_prepare_body_does_not_consume_nonseekable_body() -> None:
     assert started is False
     assert prepared is not None
     assert await prepared.read() == b"request body"
+
+
+def test_does_not_support_duplex_streaming() -> None:
+    assert AIOHTTPClient.SUPPORTS_DUPLEX_STREAMING is False

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -27,6 +27,10 @@ def test_deepcopy_client() -> None:
     deepcopy(client)
 
 
+def test_supports_duplex_streaming() -> None:
+    assert AWSCRTHTTPClient.SUPPORTS_DUPLEX_STREAMING is True
+
+
 def test_client_marshal_request() -> None:
     """Test that HTTPRequest is correctly marshaled to CRT HttpRequest."""
     client = AWSCRTHTTPClient()

--- a/packages/smithy-http/tests/unit/testing/test_mockhttp.py
+++ b/packages/smithy-http/tests/unit/testing/test_mockhttp.py
@@ -5,6 +5,12 @@ import pytest
 from smithy_http.testing import MockHTTPClient, MockHTTPClientError, create_test_request
 
 
+def test_supports_duplex_streaming():
+    # Declared True so generated duplex stream operations can be unit tested
+    # against this client.
+    assert MockHTTPClient.SUPPORTS_DUPLEX_STREAMING is True
+
+
 async def test_default_response():
     # Test error when no responses are queued
     mock_client = MockHTTPClient()

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ awscrt = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.14.0,<4.0" },
+    { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.11.12,<4.0" },
     { name = "awscrt", marker = "extra == 'awscrt'", specifier = "~=0.32.0" },
     { name = "smithy-core", editable = "packages/smithy-core" },
     { name = "yarl", marker = "extra == 'aiohttp'" },


### PR DESCRIPTION
## Overview

### Problem

Only the AWS CRT HTTP client can perform true bidirectional (duplex) streaming in the Python ecosystem, since interleaving request and response data in practice requires HTTP/2. Code generation already defaults services with event streams to `AWSCRTHTTPClient`, but nothing stops a user from overriding `config.transport` with `AIOHTTPClient` or a custom transport that can't do this. When they then invoke a bidirectional operation, the request is sent and the stream appears to hang until it eventually dies with an error such as:  `smithy_core.exceptions.SmithyError: Server disconnected`

Nothing in that error points at the actual problem (the configured transport), so this is painful to debug.

### Solution

This PR makes duplex support an explicit, opt-in transport capability. A new `SUPPORTS_DUPLEX_STREAMING` class attribute on `ClientTransport` defaults to `False`, and `RequestPipeline.duplex_stream` now fails fast with an actionable `UnsupportedTransportError` before any request work happens. `AWSCRTHTTPClient` declares support, `AIOHTTPClient` explicitly does not (it buffers the full response before returning and aiohttp has no HTTP/2 support).

## Example

Invoking a bidirectional operation with a non-duplex transport, with this PR:

```python
config = Config(transport=AIOHTTPClient())
stream = await client.streaming_operation(input=..., config=config)
```

**Without this PR:** the request is sent, the stream stalls, and eventually fails mid-stream with `SmithyError: Server disconnected`.

**With this PR:** the call fails immediately, before anything is sent:

```
smithy_core.exceptions.UnsupportedTransportError: The configured transport (AIOHTTPClient) does not support duplex (bidirectional) event streaming, which is required by the com.example#StreamingOperation operation. Use a transport that does, such as smithy_http.aio.crt.AWSCRTHTTPClient. Custom transports that support duplex streaming must set SUPPORTS_DUPLEX_STREAMING to True.
```

**Why opt-in rather than opt-out?** A survey of the Python HTTP client landscape shows most clients cannot interleave request and response data, so absence of a declaration is treated as "not supported". The pipeline reads the attribute with `getattr(transport, "SUPPORTS_DUPLEX_STREAMING", False)`, so existing custom transports that predate the attribute keep working for everything except duplex operations, which were already broken for them.

**Why fail at call time instead of client construction?** A non-duplex transport is perfectly valid for every other operation on the same client. The capability is only required when a duplex operation is actually invoked, so that is where validation happens.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
