### PR TITLE
Address async retry refactor review follow-ups

### DIFF
--- a/designs/retries.md
+++ b/designs/retries.md
@@ -146,14 +146,14 @@ example:
 try:
     retry_token = await retry_strategy.acquire_initial_retry_token()
 except RetryError:
-    transport_response = transport_client.send(serialized_request)
-    return self._deserialize(transport_response)
+    transport_response = await transport_client.send(serialized_request)
+    return await self._deserialize(transport_response)
 
 while True:
     await asyncio.sleep(retry_token.retry_delay)
     try:
-        transport_response = transport_client.send(serialized_request)
-        response = self._deserialize(transport_response)
+        transport_response = await transport_client.send(serialized_request)
+        response = await self._deserialize(transport_response)
     except Exception as e:
         response = e
 

--- a/packages/smithy-core/.changes/next-release/smithy-core-breaking-e1d59c61d8344b88832fc481dbc16531.json
+++ b/packages/smithy-core/.changes/next-release/smithy-core-breaking-e1d59c61d8344b88832fc481dbc16531.json
@@ -1,4 +1,4 @@
 {
   "type": "breaking",
-  "description": "Refactored retry strategies to be async, allowing them to wait internally or use async synchronization primitives if necessary."
+  "description": "Refactored retry strategies to be async, allowing them to wait internally or use async synchronization primitives if necessary. The `RetryStrategy` protocol moved from `smithy_core.interfaces.retries` to `smithy_core.aio.interfaces.retries`, and `SimpleRetryStrategy`, `StandardRetryStrategy`, and `RetryStrategyResolver` moved from `smithy_core.retries` to `smithy_core.aio.retries`."
 }

--- a/packages/smithy-core/src/smithy_core/aio/retries.py
+++ b/packages/smithy-core/src/smithy_core/aio/retries.py
@@ -1,7 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 from functools import lru_cache
-from typing import Any, Literal
+from typing import Any
 
 from ..exceptions import RetryError
 from ..interfaces import retries as retries_interface
@@ -9,13 +9,12 @@ from ..retries import (
     ExponentialBackoffJitterType,
     ExponentialRetryBackoffStrategy,
     RetryStrategyOptions,
+    RetryStrategyType,
     SimpleRetryToken,
     StandardRetryQuota,
     StandardRetryToken,
 )
 from .interfaces.retries import RetryStrategy
-
-RetryStrategyType = Literal["simple", "standard"]
 
 
 class RetryStrategyResolver:

--- a/packages/smithy-core/src/smithy_core/interfaces/retries.py
+++ b/packages/smithy-core/src/smithy_core/interfaces/retries.py
@@ -46,7 +46,7 @@ class RetryBackoffStrategy(Protocol):
 
 @dataclass(kw_only=True)
 class RetryToken(Protocol):
-    """Token issued by a :py:class:`RetryStrategy` for the next attempt."""
+    """Token issued by a :py:class:`smithy_core.aio.interfaces.retries.RetryStrategy` for the next attempt."""
 
     retry_count: int
     """Retry count is the total number of attempts minus the initial attempt."""


### PR DESCRIPTION
## Overview 

Minor follow-ups from the async `RetryStrategy` refactor (#671), addressing review feedback we deferred to a separate PR.

## Changes

- Await the async transport `send` and `deserialize` calls in the `designs/retries.md` example.
- Import `RetryStrategyType` from `..retries` in `aio/retries.py` instead of redefining the `Literal` alias.
- Fix the dangling `RetryStrategy` cross-reference in the `RetryToken` docstring, since the protocol moved to `smithy_core.aio.interfaces.retries`.
- Expand the changelog entry to note the module relocations, and add a trailing newline.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
