### PR TITLE
fix: generate enum fields as str/int so raw values pass type checkers

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -15,5 +15,5 @@
 
 allprojects {
     group = "software.amazon.smithy.python"
-    version = "0.3.1"
+    version = "0.3.2"
 }

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -15,5 +15,5 @@
 
 allprojects {
     group = "software.amazon.smithy.python"
-    version = "0.5.0"
+    version = "0.5.1"
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -766,10 +766,6 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 writer.writeInline(CodegenUtils.getDatetimeConstructor(writer, parsed));
             } else if (inputShape.isFloatShape() || inputShape.isDoubleShape()) {
                 writer.writeInline("float($L)", node.getValue());
-            } else if (inputShape.isIntEnumShape()) {
-                var enumSymbol =
-                        context.symbolProvider().toSymbol(inputShape);
-                writer.writeInline("$T($L)", enumSymbol, node.getValue());
             } else {
                 writer.writeInline("$L", node.getValue());
             }
@@ -801,10 +797,6 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 };
 
                 writer.writeInline("float($S)", value);
-            } else if (inputShape.isEnumShape()) {
-                var enumSymbol =
-                        context.symbolProvider().toSymbol(inputShape);
-                writer.writeInline("$T($S)", enumSymbol, node.getValue());
             } else {
                 writer.writeInline("$S", node.getValue());
             }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/HttpProtocolTestGenerator.java
@@ -785,10 +785,6 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 writer.writeInline(CodegenUtils.getDatetimeConstructor(writer, parsed));
             } else if (inputShape.isFloatShape() || inputShape.isDoubleShape()) {
                 writer.writeInline("float($L)", node.getValue());
-            } else if (inputShape.isIntEnumShape()) {
-                var enumSymbol =
-                        context.symbolProvider().toSymbol(inputShape);
-                writer.writeInline("$T($L)", enumSymbol, node.getValue());
             } else {
                 writer.writeInline("$L", node.getValue());
             }
@@ -820,10 +816,6 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 };
 
                 writer.writeInline("float($S)", value);
-            } else if (inputShape.isEnumShape()) {
-                var enumSymbol =
-                        context.symbolProvider().toSymbol(inputShape);
-                writer.writeInline("$T($S)", enumSymbol, node.getValue());
             } else {
                 writer.writeInline("$S", node.getValue());
             }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
@@ -351,8 +351,16 @@ public final class PythonSymbolProvider implements SymbolProvider, ShapeVisitor<
     }
 
     private Symbol genericEnum(Shape shape) {
-        Symbol symbol = createGeneratedSymbolBuilder(shape, getDefaultShapeName(shape), SHAPES_FILE).build();
-        return escaper.escapeSymbol(shape, symbol);
+        var enumSymbol = createGeneratedSymbolBuilder(shape, getDefaultShapeName(shape), SHAPES_FILE).build();
+
+        // We add this enum symbol as a property on a generic string/int symbol
+        // rather than returning the enum symbol directly because we only
+        // generate the enum constants for convenience. We actually want
+        // to pass around plain types rather than what is effectively
+        // a namespace class.
+        return createSymbolBuilder(shape, shape.isEnumShape() ? "str" : "int")
+                .putProperty(SymbolProperties.ENUM_SYMBOL, escaper.escapeSymbol(shape, enumSymbol))
+                .build();
     }
 
     @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
@@ -355,8 +355,16 @@ public final class PythonSymbolProvider implements SymbolProvider, ShapeVisitor<
     }
 
     private Symbol genericEnum(Shape shape) {
-        Symbol symbol = createGeneratedSymbolBuilder(shape, getDefaultShapeName(shape), SHAPES_FILE).build();
-        return escaper.escapeSymbol(shape, symbol);
+        var enumSymbol = createGeneratedSymbolBuilder(shape, getDefaultShapeName(shape), SHAPES_FILE).build();
+
+        // We add this enum symbol as a property on a generic string/int symbol
+        // rather than returning the enum symbol directly because we only
+        // generate the enum constants for convenience. We actually want
+        // to pass around plain types rather than what is effectively
+        // a namespace class.
+        return createSymbolBuilder(shape, shape.isEnumShape() ? "str" : "int")
+                .putProperty(SymbolProperties.ENUM_SYMBOL, escaper.escapeSymbol(shape, enumSymbol))
+                .build();
     }
 
     @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
@@ -36,6 +36,13 @@ public final class SymbolProperties {
     public static final Property<Boolean> STDLIB = Property.named("stdlib");
 
     /**
+     * Contains a symbol representing the class containing known enum values for the symbol.
+     *
+     * <p>In type signatures, the base int or str is used instead for forwards compatibility.
+     */
+    public static final Property<Symbol> ENUM_SYMBOL = Property.named("enumSymbol");
+
+    /**
      * Contains a symbol representing the unknown variant of a union.
      */
     public static final Property<Symbol> UNION_UNKNOWN = Property.named("unknown");

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/EnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/EnumGenerator.java
@@ -11,6 +11,7 @@ import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.RuntimeTypes;
 import software.amazon.smithy.python.codegen.SmithyPythonDependency;
+import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -36,7 +37,7 @@ public final class EnumGenerator implements Runnable {
 
     @Override
     public void run() {
-        var enumSymbol = context.symbolProvider().toSymbol(shape);
+        var enumSymbol = context.symbolProvider().toSymbol(shape).expectProperty(SymbolProperties.ENUM_SYMBOL);
         context.writerDelegator().useShapeWriter(shape, writer -> {
             writer.addStdlibImport("enum", "StrEnum");
             writer.addDependency(SmithyPythonDependency.SMITHY_CORE);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/IntEnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/IntEnumGenerator.java
@@ -12,6 +12,7 @@ import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.PythonSettings;
 import software.amazon.smithy.python.codegen.RuntimeTypes;
 import software.amazon.smithy.python.codegen.SmithyPythonDependency;
+import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -36,7 +37,7 @@ public final class IntEnumGenerator implements Runnable {
 
     @Override
     public void run() {
-        var enumSymbol = directive.symbol();
+        var enumSymbol = directive.symbol().expectProperty(SymbolProperties.ENUM_SYMBOL);
         directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
             writer.addStdlibImport("enum", "IntEnum");
             writer.addDependency(SmithyPythonDependency.SMITHY_CORE);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberDeserializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberDeserializerGenerator.java
@@ -136,7 +136,9 @@ public class MemberDeserializerGenerator extends ShapeVisitor.DataShapeVisitor<V
     @Override
     public Void intEnumShape(IntEnumShape shape) {
         pushMemberState();
-        var enumSymbol = context.symbolProvider().toSymbol(shape);
+        var enumSymbol = context.symbolProvider()
+                .toSymbol(shape)
+                .expectProperty(SymbolProperties.ENUM_SYMBOL);
         writer.write("$T(${deserializer:L}.read_integer(${C|}))",
                 enumSymbol,
                 writer.consumer(w -> writeSchema()));
@@ -188,7 +190,9 @@ public class MemberDeserializerGenerator extends ShapeVisitor.DataShapeVisitor<V
     @Override
     public Void enumShape(EnumShape shape) {
         pushMemberState();
-        var enumSymbol = context.symbolProvider().toSymbol(shape);
+        var enumSymbol = context.symbolProvider()
+                .toSymbol(shape)
+                .expectProperty(SymbolProperties.ENUM_SYMBOL);
         writer.write("$T(${deserializer:L}.read_string(${C|}))",
                 enumSymbol,
                 writer.consumer(w -> writeSchema()));

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/MemberErrorCorrectionGenerator.java
@@ -146,13 +146,17 @@ public final class MemberErrorCorrectionGenerator extends ShapeVisitor.DataShape
 
     @Override
     public Consumer<PythonWriter> enumShape(EnumShape shape) {
-        var enumSymbol = context.symbolProvider().toSymbol(shape);
+        var enumSymbol = context.symbolProvider()
+                .toSymbol(shape)
+                .expectProperty(SymbolProperties.ENUM_SYMBOL);
         return writer -> writer.writeInline("$T._corrected(\"\")", enumSymbol);
     }
 
     @Override
     public Consumer<PythonWriter> intEnumShape(IntEnumShape shape) {
-        var enumSymbol = context.symbolProvider().toSymbol(shape);
+        var enumSymbol = context.symbolProvider()
+                .toSymbol(shape)
+                .expectProperty(SymbolProperties.ENUM_SYMBOL);
         // -1 is used (rather than 0) as the placeholder because it is least likely to
         // collide with a real member value.
         return writer -> writer.writeInline("$T._corrected(-1)", enumSymbol);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -295,12 +295,14 @@ public final class StructureGenerator implements Runnable {
             return String.format("b'%s'", defaultNode.expectStringNode().getValue());
         } else if (target.isEnumShape()) {
             // Wrap rather than emit a bare string so the value matches the field type.
-            var enumSymbol = symbolProvider.toSymbol(target);
+            var enumSymbol = symbolProvider.toSymbol(target)
+                    .expectProperty(SymbolProperties.ENUM_SYMBOL);
             return String.format("%s(\"%s\")",
                     writer.format("$T", enumSymbol),
                     defaultNode.expectStringNode().getValue());
         } else if (target.isIntEnumShape()) {
-            var enumSymbol = symbolProvider.toSymbol(target);
+            var enumSymbol = symbolProvider.toSymbol(target)
+                    .expectProperty(SymbolProperties.ENUM_SYMBOL);
             return String.format("%s(%s)",
                     writer.format("$T", enumSymbol),
                     defaultNode.expectNumberNode().getValue());

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -300,12 +300,14 @@ public final class StructureGenerator implements Runnable {
             return String.format("b'%s'", defaultNode.expectStringNode().getValue());
         } else if (target.isEnumShape()) {
             // Wrap rather than emit a bare string so the value matches the field type.
-            var enumSymbol = symbolProvider.toSymbol(target);
+            var enumSymbol = symbolProvider.toSymbol(target)
+                    .expectProperty(SymbolProperties.ENUM_SYMBOL);
             return String.format("%s(\"%s\")",
                     writer.format("$T", enumSymbol),
                     defaultNode.expectStringNode().getValue());
         } else if (target.isIntEnumShape()) {
-            var enumSymbol = symbolProvider.toSymbol(target);
+            var enumSymbol = symbolProvider.toSymbol(target)
+                    .expectProperty(SymbolProperties.ENUM_SYMBOL);
             return String.format("%s(%s)",
                     writer.format("$T", enumSymbol),
                     defaultNode.expectNumberNode().getValue());

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/PythonDelegator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/writer/PythonDelegator.java
@@ -5,9 +5,13 @@
 package software.amazon.smithy.python.codegen.writer;
 
 import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.WriterDelegator;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.python.codegen.PythonSettings;
+import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -23,7 +27,30 @@ public final class PythonDelegator extends WriterDelegator<PythonWriter> {
     ) {
         super(
                 fileManifest,
-                symbolProvider,
+                new EnumSymbolProviderWrapper(symbolProvider),
                 new PythonWriter.PythonWriterFactory(settings));
+    }
+
+    private static final class EnumSymbolProviderWrapper implements SymbolProvider {
+
+        private final SymbolProvider wrapped;
+
+        EnumSymbolProviderWrapper(SymbolProvider wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public Symbol toSymbol(Shape shape) {
+            Symbol symbol = wrapped.toSymbol(shape);
+            if (shape.isEnumShape() || shape.isIntEnumShape()) {
+                symbol = symbol.expectProperty(SymbolProperties.ENUM_SYMBOL);
+            }
+            return symbol;
+        }
+
+        @Override
+        public String toMemberName(MemberShape shape) {
+            return wrapped.toMemberName(shape);
+        }
     }
 }


### PR DESCRIPTION
*Description of changes:*

When we generate a Python dataclass for a Smithy structure, each member that targets an enum shape gets a type annotation. Before #702, these fields were annotated as `str | None` (or `int | None` for intEnums), so users could pass either a raw string like `"RETRIEVAL_MODE"` or the enum constant `ChatMode.RETRIEVAL_MODE`: both worked and both passed type checkers.

#702 changed `genericEnum` in `PythonSymbolProvider` to return the enum class symbol directly, so those fields became `ChatMode | None`. This is more precise, but it means passing a raw string (https://github.com/awslabs/aws-sdk-python/pull/54 for example) now fails static type checkers (e.g., `ty`) with errors like:

```
error[invalid-argument-type]: Argument is incorrect
  --> tests/integration/test_bidirectional_streaming.py:36:38
   |
36 |             value=ConfigurationEvent(chat_mode="RETRIEVAL_MODE")
   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected `ChatMode | None`, found `Literal["RETRIEVAL_MODE"]`
   |
```

This PR restores the original `str`/`int` field typing while preserving all #702 functionality (error correction, unknown-value handling). 

*Testing:*

Regenerated the `qbusiness` and `connecthealth` clients locally. Verfied their integration tests (https://github.com/awslabs/aws-sdk-python/pull/54 and https://github.com/awslabs/aws-sdk-python/pull/62) still passed, which means the #702 functionality is preserved. Type checker `ty` also passed with no issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.