### PR TITLE
Add `Async` prefix to generated AWS client names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,27 @@
 
 ## Unreleased
 
+## v0.4.0
+
 ### Breaking Changes
 
-* Removed the `http_client` config option in favor of the generic `transport`.
+* Renamed generated AWS service clients to include `Async` (e.g.
+  `BedrockRuntimeClient` is now `AsyncBedrockRuntimeClient`) to match the
+  Python community convention for async clients. The old name is still
+  available as a deprecated alias that emits a `DeprecationWarning`, and will
+  be removed in an upcoming release. The unprefixed name will later be
+  reintroduced for synchronous clients.
 
-### Features
+<!--
+TODO: Backfill pre-0.4.0 codegen releases into this file. Prior changes were
+accumulated under "Unreleased" and never cut over per release, so the following
+already shipped (in-tree as of the 0.3.0 codegen release) and need to be placed
+under their correct version section:
 
-* Removed code-generated protocol implementations in favor of hand-written
-  implementations based on schemas.
-* Moved documentation for structure members into doc strings after the member's
-  dataclass field declaration.
+* (Breaking) Removed the `http_client` config option in favor of the generic
+  `transport`.
+* (Feature) Removed code-generated protocol implementations in favor of
+  hand-written implementations based on schemas.
+* (Feature) Moved documentation for structure members into doc strings after
+  the member's dataclass field declaration.
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@
 
 * Renamed generated AWS service clients to include `Async` (e.g.
   `BedrockRuntimeClient` is now `AsyncBedrockRuntimeClient`) to match the
-  Python community convention for async clients. The old name is still
-  available as a deprecated alias that emits a `DeprecationWarning`, and will
-  be removed in an upcoming release. The unprefixed name will later be
-  reintroduced for synchronous clients.
+  Python community convention for async clients. For clients that were already
+  published under the unprefixed name, the old name remains available as a
+  deprecated alias that emits a `DeprecationWarning` and will be removed in an
+  upcoming release. The unprefixed name will later be reintroduced for
+  synchronous clients.
 
 <!--
 TODO: Backfill pre-0.4.0 codegen releases into this file. Prior changes were

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
@@ -11,6 +11,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.python.codegen.PythonSettings;
+import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.python.codegen.integrations.PythonIntegration;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -33,8 +34,13 @@ public final class AwsServiceIdIntegration implements PythonIntegration {
             Symbol symbol = this.delegate.toSymbol(shape);
             if (shape.isServiceShape() && shape.hasTrait(ServiceTrait.class)) {
                 var serviceTrait = shape.expectTrait(ServiceTrait.class);
-                var serviceName = StringUtils.capitalize(serviceTrait.getSdkId() + "Client").replace(" ", "");
-                symbol = symbol.toBuilder().name(serviceName).build();
+                var baseClientName = StringUtils.capitalize(serviceTrait.getSdkId() + "Client").replace(" ", "");
+                var serviceName = "Async" + baseClientName;
+                var deprecatedName = baseClientName;
+                symbol = symbol.toBuilder()
+                        .name(serviceName)
+                        .putProperty(SymbolProperties.DEPRECATED_ALIAS, deprecatedName)
+                        .build();
             }
             return symbol;
         }

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.python.aws.codegen;
 
+import java.util.Set;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -16,6 +17,25 @@ import software.amazon.smithy.python.codegen.integrations.PythonIntegration;
 import software.amazon.smithy.utils.StringUtils;
 
 public final class AwsServiceIdIntegration implements PythonIntegration {
+
+    /**
+     * SDK IDs of the AWS clients that were published under the unprefixed
+     * {@code <SdkId>Client} name before the {@code Async} prefix was adopted.
+     *
+     * <p>Only these clients generate a deprecated alias for the old name so that
+     * existing imports keep working. New clients are generated with the
+     * {@code Async}-prefixed name from the start and need no alias. This set can
+     * be removed once the aliases are dropped.
+     */
+    private static final Set<String> LEGACY_ALIAS_SDK_IDS = Set.of(
+            "Bedrock Runtime",
+            "ConnectHealth",
+            "Lex Runtime V2",
+            "Polly",
+            "QBusiness",
+            "SageMaker Runtime HTTP2",
+            "Transcribe Streaming");
+
     @Override
     public SymbolProvider decorateSymbolProvider(Model model, PythonSettings settings, SymbolProvider symbolProvider) {
         return new ServiceIdSymbolProvider(symbolProvider);
@@ -35,12 +55,13 @@ public final class AwsServiceIdIntegration implements PythonIntegration {
             if (shape.isServiceShape() && shape.hasTrait(ServiceTrait.class)) {
                 var serviceTrait = shape.expectTrait(ServiceTrait.class);
                 var baseClientName = StringUtils.capitalize(serviceTrait.getSdkId() + "Client").replace(" ", "");
-                var serviceName = "Async" + baseClientName;
-                var deprecatedName = baseClientName;
-                symbol = symbol.toBuilder()
-                        .name(serviceName)
-                        .putProperty(SymbolProperties.DEPRECATED_ALIAS, deprecatedName)
-                        .build();
+                var symbolBuilder = symbol.toBuilder().name("Async" + baseClientName);
+                // Only clients that already shipped under the unprefixed name get a
+                // backwards-compatible alias; new clients start life Async-prefixed.
+                if (LEGACY_ALIAS_SDK_IDS.contains(serviceTrait.getSdkId())) {
+                    symbolBuilder.putProperty(SymbolProperties.DEPRECATED_ALIAS, baseClientName);
+                }
+                symbol = symbolBuilder.build();
             }
             return symbol;
         }

--- a/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegrationTest.java
@@ -5,8 +5,10 @@
 package software.amazon.smithy.python.aws.codegen;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.python.codegen.PythonSettings;
@@ -18,7 +20,22 @@ public class AwsServiceIdIntegrationTest {
     private static final String NS = "smithy.example";
 
     @Test
-    public void testServiceSymbolUsesAsyncClientNameWithDeprecatedAlias() {
+    public void testLegacyClientGetsAsyncNameWithDeprecatedAlias() {
+        var symbol = toServiceSymbol("Bedrock Runtime");
+
+        assertEquals("AsyncBedrockRuntimeClient", symbol.getName());
+        assertEquals("BedrockRuntimeClient", symbol.expectProperty(SymbolProperties.DEPRECATED_ALIAS));
+    }
+
+    @Test
+    public void testNewClientGetsAsyncNameWithoutDeprecatedAlias() {
+        var symbol = toServiceSymbol("Weather");
+
+        assertEquals("AsyncWeatherClient", symbol.getName());
+        assertFalse(symbol.getProperty(SymbolProperties.DEPRECATED_ALIAS).isPresent());
+    }
+
+    private static Symbol toServiceSymbol(String sdkId) {
         Model model = Model.assembler()
                 .discoverModels(AwsServiceIdIntegrationTest.class.getClassLoader())
                 .addUnparsedModel("test.smithy", """
@@ -27,11 +44,11 @@ public class AwsServiceIdIntegrationTest {
 
                         use aws.api#service
 
-                        @service(sdkId: "Bedrock Runtime")
+                        @service(sdkId: "%s")
                         service TestService {
                             version: "2024-01-01"
                         }
-                        """)
+                        """.formatted(sdkId))
                 .assemble()
                 .unwrap();
         PythonSettings settings = PythonSettings.builder()
@@ -41,10 +58,6 @@ public class AwsServiceIdIntegrationTest {
                 .build();
         var integration = new AwsServiceIdIntegration();
         var provider = integration.decorateSymbolProvider(model, settings, new PythonSymbolProvider(model, settings));
-
-        var symbol = provider.toSymbol(model.expectShape(ShapeId.from(NS + "#TestService")));
-
-        assertEquals("AsyncBedrockRuntimeClient", symbol.getName());
-        assertEquals("BedrockRuntimeClient", symbol.expectProperty(SymbolProperties.DEPRECATED_ALIAS));
+        return provider.toSymbol(model.expectShape(ShapeId.from(NS + "#TestService")));
     }
 }

--- a/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegrationTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.python.aws.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.python.codegen.PythonSettings;
+import software.amazon.smithy.python.codegen.PythonSymbolProvider;
+import software.amazon.smithy.python.codegen.SymbolProperties;
+
+public class AwsServiceIdIntegrationTest {
+
+    private static final String NS = "smithy.example";
+
+    @Test
+    public void testServiceSymbolUsesAsyncClientNameWithDeprecatedAlias() {
+        Model model = Model.assembler()
+                .discoverModels(AwsServiceIdIntegrationTest.class.getClassLoader())
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+
+                        use aws.api#service
+
+                        @service(sdkId: "Bedrock Runtime")
+                        service TestService {
+                            version: "2024-01-01"
+                        }
+                        """)
+                .assemble()
+                .unwrap();
+        PythonSettings settings = PythonSettings.builder()
+                .service(ShapeId.from(NS + "#TestService"))
+                .moduleName("test_client")
+                .moduleVersion("0.0.1")
+                .build();
+        var integration = new AwsServiceIdIntegration();
+        var provider = integration.decorateSymbolProvider(model, settings, new PythonSymbolProvider(model, settings));
+
+        var symbol = provider.toSymbol(model.expectShape(ShapeId.from(NS + "#TestService")));
+
+        assertEquals("AsyncBedrockRuntimeClient", symbol.getName());
+        assertEquals("BedrockRuntimeClient", symbol.expectProperty(SymbolProperties.DEPRECATED_ALIAS));
+    }
+}

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -15,5 +15,5 @@
 
 allprojects {
     group = "software.amazon.smithy.python"
-    version = "0.3.1"
+    version = "0.4.0"
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -105,6 +105,30 @@ final class ClientGenerator implements Runnable {
                 }
             }
         });
+
+        serviceSymbol.getProperty(SymbolProperties.DEPRECATED_ALIAS).ifPresent(alias -> {
+            writer.addStdlibImport("typing", "TYPE_CHECKING");
+            writer.addStdlibImport("typing", "Any");
+            writer.addStdlibImport("warnings");
+            writer.write("""
+
+                    if TYPE_CHECKING:
+                        # Deprecated alias for backwards compatibility, to be removed.
+                        $1L = $2L
+
+
+                    def __getattr__(name: str) -> Any:
+                        if name == $1S:
+                            warnings.warn(
+                                "$1L is deprecated, use $2L instead. "
+                                "This alias will be removed in a future version.",
+                                DeprecationWarning,
+                                stacklevel=2,
+                            )
+                            return $2L
+                        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+                    """, alias, serviceSymbol.getName());
+        });
     }
 
     private void writeDefaultPlugins(PythonWriter writer, Collection<SymbolReference> plugins) {

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
@@ -77,5 +77,11 @@ public final class SymbolProperties {
      */
     public static final Property<Boolean> IMPORTABLE = Property.named("nonImportable");
 
+    /**
+     * Contains a deprecated name for the symbol that is generated as an alias
+     * for backwards compatibility. This is only used for services.
+     */
+    public static final Property<String> DEPRECATED_ALIAS = Property.named("deprecatedAlias");
+
     private SymbolProperties() {}
 }


### PR DESCRIPTION
## Summary

Generated AWS clients are async, but they're named `<SdkId>Client` (e.g. `BedrockRuntimeClient`). This PR renames them to `Async<SdkId>Client` (e.g. `AsyncBedrockRuntimeClient`) to match the convention and to free up the unprefixed name for the sync clients we plan to add later.

The rename is a breaking change for the clients already published under the old name. To keep existing code working, those clients also emit the old name as a deprecated alias that resolves to the async client and raises a `DeprecationWarning`. The alias is temporary and will be removed in a minor bump sometime in the future.

## Scope

The Async rename applies to all generated AWS clients. The backwards-compat alias is only generated for the clients already published under the unprefixed name in [awslabs/aws-sdk-python](https://github.com/awslabs/aws-sdk-python/tree/main/clients):

Bedrock Runtime, ConnectHealth, Lex Runtime V2, Polly, QBusiness, SageMaker Runtime HTTP2, Transcribe Streaming

New clients released after this change is merged are created with the Async-prefixed and no alias.

## Before

Client Class:
```python
class BedrockRuntimeClient
    ...
```

Usage (no warning):
```
>>> from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient
>>> BedrockRuntimeClient()
<aws_sdk_bedrock_runtime.client.AsyncBedrockRuntimeClient object at 0x102ce64e0>
```

## After

The old name stays importable at runtime (with a DeprecationWarning) and resolves for type checkers via the TYPE_CHECKING alias.

Client Class:
```python
class AsyncBedrockRuntimeClient
    ...

if TYPE_CHECKING:
    # Deprecated alias for backwards compatibility, to be removed.
    BedrockRuntimeClient = AsyncBedrockRuntimeClient

def __getattr__(name: str) -> Any:
    if name == "BedrockRuntimeClient":
        warnings.warn(
            "BedrockRuntimeClient is deprecated, use AsyncBedrockRuntimeClient instead. "
            "This alias will be removed in a future version.",
            DeprecationWarning,
            stacklevel=2,
        )
        return AsyncBedrockRuntimeClient
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
```

Usage:
```
>>> from aws_sdk_bedrock_runtime.client import AsyncBedrockRuntimeClient
>>> AsyncBedrockRuntimeClient()
<aws_sdk_bedrock_runtime.client.AsyncBedrockRuntimeClient object at 0x102ce7530>
>>> from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient
<stdin>:1: DeprecationWarning: BedrockRuntimeClient is deprecated, use AsyncBedrockRuntimeClient instead. This alias will be removed in a future version.
>>> BedrockRuntimeClient()
<aws_sdk_bedrock_runtime.client.AsyncBedrockRuntimeClient object at 0x102ce64e0>
```

A newly added service (not in the allowlist) generates just the class, no alias:

```
class AsyncWeatherClient:
    ...
```

## Backwards compatibility

Existing customer code using `BedrockRuntimeClient` will continue to work since we're aliasing it to `AsyncBedrockRuntimeClient`. This will be removed in a future version of the SDK in a minor bump before GA.



## Testing

Regenerated all 7 aws-sdk-python clients. I verified all clients have the renamed class and only the existing clients get the aliasing logic.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
