### PR TITLE
Add support for config resolver

### DIFF
--- a/packages/smithy-aws-core/src/smithy_aws_core/config/aws_config.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/aws_config.py
@@ -1,0 +1,176 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Self
+
+from smithy_aws_core.config.context import FileSystem, SharedConfigContext
+from smithy_aws_core.config.exceptions import ConfigError
+from smithy_aws_core.config.resolvers import resolve_region, resolve_retry_config
+from smithy_aws_core.config.types import UNSET, ConfigSource, FieldSpec, Resolved
+from smithy_aws_core.config.validators import (
+    validate_region,
+    validate_retry_strategy_options,
+)
+from smithy_core.retries import RetryStrategyOptions
+
+
+@dataclass(kw_only=True)
+class AsyncAwsConfig:
+    """Base configuration class for all AWS services.
+
+    Fields are resolved asynchronously from multiple sources (env vars,
+    config files, defaults) through the resolve() classmethod.
+
+    Do not instantiate directly — use:
+        config = await AsyncAwsConfig.resolve()
+    """
+
+    region: str | None = None
+    retry_strategy_options: RetryStrategyOptions | None = None
+
+    _ctx: SharedConfigContext | None = field(default=None, repr=False, compare=False)
+    _sources: dict[str, ConfigSource] = field(  # type: ignore[assignment]
+        default_factory=dict,
+        repr=False,
+        compare=False,
+    )
+
+    _FIELDS: ClassVar[dict[str, FieldSpec]] = {
+        "region": FieldSpec(
+            default=None,
+            resolver=resolve_region,
+            validator=validate_region,
+        ),
+        "retry_strategy_options": FieldSpec(
+            default_factory=RetryStrategyOptions,
+            resolver=resolve_retry_config,
+            validator=validate_retry_strategy_options,
+        ),
+    }
+
+    def __post_init__(self) -> None:
+        """Block direct construction. Use resolve() instead."""
+        raise ConfigError(
+            f"{type(self).__name__} cannot be constructed directly. "
+            f"Use `await {type(self).__name__}.resolve(...)` instead."
+        )
+
+    @classmethod
+    async def resolve(
+        cls,
+        *,
+        profile: str | None = None,
+        env: Mapping[str, str] | None = None,
+        fs: FileSystem | None = None,
+        config_file_path: str | None = None,
+        credentials_file_path: str | None = None,
+        **overrides: Any,
+    ) -> Self:
+        """Resolve a config object from environment, config files, and defaults.
+
+        This is the only supported way to create a config instance.
+
+        :param profile: Override the active profile name.
+        :param env: Override the environment variable mapping.
+        :param fs: Override the filesystem abstraction.
+        :param config_file_path: Override path for config file.
+        :param credentials_file_path: Override path for credentials file.
+        :param overrides: Explicit field values that skip resolution.
+        :returns: A fully-resolved config instance.
+        """
+        ctx = SharedConfigContext(
+            profile_name=profile,
+            env=env,
+            fs=fs,
+            config_file_path=config_file_path,
+            credentials_file_path=credentials_file_path,
+        )
+
+        # Create the instance bypassing __post_init__ check
+        instance = cls._create_instance()
+        instance._ctx = ctx
+
+        # Resolve each field
+        await instance._resolve_fields(overrides)
+
+        return instance
+
+    def source_of(self, field_name: str) -> ConfigSource | None:
+        """Get the source that provided a field's value.
+
+        :param field_name: The config field name.
+        :returns: The ConfigSource, or None if not tracked.
+        """
+        return self._sources.get(field_name)
+
+    def resolution_context(self) -> SharedConfigContext | None:
+        """Get the resolution context used to create this config.
+
+        :returns: The SharedConfigContext, or None if not available.
+        """
+        return self._ctx
+
+    @classmethod
+    def _create_instance(cls) -> Self:
+        """Create an instance that bypasses construction blocking."""
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "_sources", {})
+        object.__setattr__(instance, "_ctx", None)
+        for field_name in cls._FIELDS:
+            object.__setattr__(instance, field_name, UNSET)
+        return instance
+
+    async def _resolve_fields(self, overrides: dict[str, Any]) -> None:
+        """Run the resolution pipeline for all fields."""
+        unknown = set(overrides) - set(self._FIELDS)
+        if unknown:
+            raise ConfigError(
+                f"Unknown config field(s): {sorted(unknown)}. "
+                f"Valid fields are: {sorted(self._FIELDS)}"
+            )
+
+        for field_name, spec in self._FIELDS.items():
+            # check for overrides first
+            if field_name in overrides:
+                value = overrides[field_name]
+                setattr(self, field_name, value)
+                self._sources[field_name] = ConfigSource.OVERRIDE
+            # check in resolver
+            elif spec.resolver is not None:
+                result: Resolved[Any] = await spec.resolver(self._ctx)
+                if result.value is not UNSET:
+                    setattr(self, field_name, result.value)
+                    self._sources[field_name] = result.source
+                else:
+                    # If resolver returned UNSET, fall back to default
+                    self._apply_default(field_name, spec)
+
+            else:
+                # No resolver, use default directly
+                self._apply_default(field_name, spec)
+
+            # Run validator for all sources
+            if spec.validator is not None:
+                spec.validator(getattr(self, field_name))
+
+    def _apply_default(self, field_name: str, spec: FieldSpec) -> None:
+        """Apply the default value for a field."""
+        if spec.default_factory is not None:
+            value = spec.default_factory()
+        else:
+            value = spec.default
+        setattr(self, field_name, value)
+        self._sources[field_name] = ConfigSource.DEFAULT
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Track provenance when fields are set with plugins after construction"""
+        super().__setattr__(name, value)
+        # Mark as override only if the field is in _FIELDS and was already resolved
+        if (
+            name in self.__class__._FIELDS
+            and hasattr(self, "_sources")
+            and name in self._sources
+        ):
+            self._sources[name] = ConfigSource.OVERRIDE

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/context.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/context.py
@@ -1,0 +1,139 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import logging
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from smithy_aws_core.config import load_config
+from smithy_aws_core.config.merged_config import MergedConfig
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class FileSystem(Protocol):
+    """Protocol for filesystem operations.
+
+    Abstraction over file I/O so tests can provide mock implementations
+    without touching the real filesystem.
+    """
+
+    async def read_file(self, path: str) -> str | None:
+        """Read a file's content as UTF-8.
+
+        :param path: Resolved file path.
+        :returns: File content, or None if the file is inaccessible.
+        """
+        ...
+
+
+class DefaultFileSystem:
+    """Default filesystem implementation using real disk I/O."""
+
+    async def read_file(self, path: str) -> str | None:
+        """Read a file asynchronously from disk.
+
+        Missing files and permission errors return None with a warning.
+        Encoding errors (invalid UTF-8) are raised to the caller.
+
+        :param path: Resolved file path.
+        :returns: File content, or None if the file is inaccessible.
+        """
+        try:
+            content: str = await asyncio.to_thread(
+                Path(path).read_text, encoding="utf-8"
+            )
+            return content
+        except FileNotFoundError:
+            return None
+        except (PermissionError, OSError) as e:
+            logger.warning("Unable to read config file '%s': %s", path, e)
+            return None
+
+
+class SharedConfigContext:
+    """Resolution context shared across resolvers during config construction.
+
+    Holds environment state and cached file data that resolvers use to
+    look up values. Created once per resolve() call.
+    """
+
+    def __init__(
+        self,
+        *,
+        profile_name: str | None = None,
+        env: Mapping[str, str] | None = None,
+        fs: FileSystem | None = None,
+        http_client: Any | None = None,
+        config_file_path: str | Path | None = None,
+        credentials_file_path: str | Path | None = None,
+    ) -> None:
+        """Initialize the resolution context.
+
+        :param profile_name: The active profile to use. Defaults to
+            AWS_PROFILE env var, then "default".
+        :param env: Environment variable mapping. Defaults to os.environ.
+        :param fs: Filesystem abstraction for reading config files.
+            Defaults to real disk I/O.
+        :param http_client: HTTP client for network-based resolvers
+            (e.g., IMDS).
+        :param config_file_path: Override path for config file.
+        :param credentials_file_path: Override path for credentials file.
+        """
+        self._env: Mapping[str, str] = env if env is not None else os.environ
+        self._fs: FileSystem = fs if fs is not None else DefaultFileSystem()
+        self._http_client: Any | None = http_client
+        self._profile_name: str = self._resolve_profile_name(profile_name)
+        self._config_file_path: Path | None = (
+            Path(config_file_path) if config_file_path is not None else None
+        )
+        self._credentials_file_path: Path | None = (
+            Path(credentials_file_path) if credentials_file_path is not None else None
+        )
+        self._cached_config_file: MergedConfig | None = None
+
+    @property
+    def env(self) -> Mapping[str, str]:
+        """The environment variable mapping."""
+        return self._env
+
+    @property
+    def profile_name(self) -> str:
+        """The active profile name."""
+        return self._profile_name
+
+    @property
+    def fs(self) -> FileSystem:
+        """The filesystem abstraction."""
+        return self._fs
+
+    @property
+    def http_client(self) -> Any | None:
+        """HTTP client for network-based resolvers."""
+        return self._http_client
+
+    async def parsed_profiles(self) -> MergedConfig:
+        """Get the parsed and merged config/credentials file data.
+
+        The result is cached after the first call so files are only
+        read from disk once per context.
+        """
+        if self._cached_config_file is None:
+            self._cached_config_file = await load_config(
+                config_file_path=self._config_file_path,
+                credentials_file_path=self._credentials_file_path,
+            )
+        return self._cached_config_file
+
+    def _resolve_profile_name(self, explicit_profile: str | None) -> str:
+        """Determine the active profile name.
+
+        Priority: explicit argument > AWS_PROFILE env var > "default"
+        """
+        if explicit_profile is not None:
+            return explicit_profile
+        return self._env.get("AWS_PROFILE", "default")

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/resolvers.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/resolvers.py
@@ -1,0 +1,135 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Sequence
+from typing import Any
+
+from smithy_aws_core.config.context import SharedConfigContext
+from smithy_aws_core.config.exceptions import ConfigError
+from smithy_aws_core.config.types import UNSET, ConfigSource, Resolved
+from smithy_core.retries import RetryStrategyOptions
+
+
+async def _resolve_str(
+    ctx: SharedConfigContext,
+    *,
+    env_vars: Sequence[str] = (),
+    profile_keys: Sequence[str] = (),
+) -> Resolved[str | None]:
+    """Resolve a string value by checking providers in priority order.
+
+    Priority: env vars (first match) > config file (profile keys, first match) > unresolved.
+
+    :param ctx: The shared resolution context.
+    :param env_vars: Environment variable names to check, in order.
+    :param profile_keys: Config file profile keys to check, in order.
+    :returns: Resolved value with source, or Resolved(value=UNSET) if not found.
+    """
+    # Check environment variables first
+    for var_name in env_vars:
+        value: str | None = ctx.env.get(var_name)
+        if value:
+            return Resolved(value=value, source=ConfigSource.ENV)
+
+    # Check config file profile keys
+    if profile_keys:
+        config_file = await ctx.parsed_profiles()
+        for key in profile_keys:
+            value = config_file.get(ctx.profile_name, key)
+            if value:
+                return Resolved(value=value, source=ConfigSource.PROFILE)
+
+    return Resolved(value=UNSET, source=ConfigSource.DEFAULT)  # type: ignore[arg-type]
+
+
+async def _resolve_int(
+    ctx: SharedConfigContext,
+    *,
+    env_vars: Sequence[str] = (),
+    profile_keys: Sequence[str] = (),
+) -> Resolved[int | None]:
+    """Resolve an integer value by checking providers in priority order.
+
+    :param ctx: The shared resolution context.
+    :param env_vars: Environment variable names to check, in order.
+    :param profile_keys: Config file profile keys to check, in order.
+    :returns: Resolved int value with source, or Resolved(value=UNSET) if not found.
+    """
+    result = await _resolve_str(ctx, env_vars=env_vars, profile_keys=profile_keys)
+    if result.value is UNSET:
+        return Resolved(value=UNSET, source=ConfigSource.DEFAULT)  # type: ignore[arg-type]
+    if result.value is None:
+        return Resolved(value=None, source=result.source)
+    try:
+        return Resolved(value=int(result.value), source=result.source)
+    except (ValueError, TypeError):
+        raise ConfigError(
+            f"Invalid integer value {result.value!r} for config key. "
+            "Expected a valid integer."
+        )
+
+
+def _strongest_source(*sources: ConfigSource) -> ConfigSource:
+    """Return the highest-priority source among multiple resolved values.
+
+    Priority: ENV > PROFILE > DEFAULT
+    """
+    priority = {ConfigSource.ENV: 3, ConfigSource.PROFILE: 2, ConfigSource.DEFAULT: 1}
+    return max(sources, key=lambda s: priority.get(s, 0))
+
+
+async def resolve_region(ctx: SharedConfigContext) -> Resolved[str | None]:
+    """Resolve the AWS region from environment or config file.
+
+    :param ctx: The shared resolution context.
+    :returns: Resolved region value with source.
+    """
+    return await _resolve_str(
+        ctx,
+        env_vars=("AWS_REGION", "AWS_DEFAULT_REGION"),
+        profile_keys=("region",),
+    )
+
+
+async def resolve_retry_config(
+    ctx: SharedConfigContext,
+) -> Resolved[RetryStrategyOptions]:
+    """Resolve retry configuration from environment and config file.
+
+    Combines retry_mode and max_attempts into a single RetryStrategyOptions.
+    Each sub-value is resolved independently with its own priority chain.
+
+    :param ctx: The shared resolution context.
+    :returns: Resolved RetryStrategyOptions with the strongest source.
+    """
+    mode_result = await _resolve_str(
+        ctx,
+        env_vars=("AWS_RETRY_MODE",),
+        profile_keys=("retry_mode",),
+    )
+    attempts_result = await _resolve_int(
+        ctx,
+        env_vars=("AWS_MAX_ATTEMPTS",),
+        profile_keys=("max_attempts",),
+    )
+
+    # Build kwargs for values that were resolved
+    kwargs: dict[str, Any] = {}
+    sources_found: list[ConfigSource] = []
+
+    if mode_result.value is not UNSET and mode_result.value is not None:
+        kwargs["retry_mode"] = mode_result.value
+        sources_found.append(mode_result.source)
+
+    if attempts_result.value is not UNSET and attempts_result.value is not None:
+        kwargs["max_attempts"] = attempts_result.value
+        sources_found.append(attempts_result.source)
+
+    source = (
+        _strongest_source(*sources_found) if sources_found else ConfigSource.DEFAULT
+    )
+
+    return Resolved(
+        value=RetryStrategyOptions(**kwargs),
+        source=source,
+    )

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/types.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/types.py
@@ -1,0 +1,70 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class _UnsetType:
+    def __repr__(self) -> str:
+        return "UNSET"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET = _UnsetType()
+
+
+class ConfigSource(str, Enum):
+    """Where a resolved config value came from."""
+
+    ENV = "env"
+    PROFILE = "profile"
+    DEFAULT = "default"
+    OVERRIDE = "override"
+
+
+@dataclass(frozen=True, kw_only=True)
+class Resolved[T]:
+    """A resolved config value paired with its provenance source."""
+
+    value: T
+    source: ConfigSource
+
+
+@dataclass(frozen=True, kw_only=True)
+class FieldSpec:
+    """Specification for a single config field.
+
+    Carries everything the resolution pipeline needs to resolve,
+    validate, and default a field.
+
+    """
+
+    default: Any = UNSET
+    """Value used if no resolver runs or all providers return unresolved."""
+
+    default_factory: Callable[[], Any] | None = None
+    """Factory for mutable defaults (lists, dicts) that need a fresh instance per config."""
+
+    resolver: Callable[..., Awaitable[Resolved[Any]]] | None = None
+    """Async function that resolves the field from env/profile/etc."""
+
+    validator: Callable[[Any], None] | None = None
+    """Function that validates the resolved value. Raises on invalid input."""
+
+    def __post_init__(self) -> None:
+        has_default = self.default is not UNSET
+        has_factory = self.default_factory is not None
+        if has_default and has_factory:
+            raise ValueError(
+                "FieldSpec: cannot set both 'default' and 'default_factory'"
+            )
+        if not has_default and not has_factory:
+            raise ValueError(
+                "FieldSpec: exactly one of 'default' or 'default_factory' must be set"
+            )

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/validators.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+from smithy_aws_core.config.exceptions import ConfigError
+from smithy_core.retries import RetryStrategyOptions
+
+_REGION_PATTERN = re.compile(r"^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{1,63}(?<!-)$")
+
+
+def validate_region(value: object) -> None:
+    """Validate that region is a non-empty string matching AWS region format.
+
+    Region is required and must be explicitly set via env var, config file,
+    or override.
+
+    :param value: The resolved region value.
+    :raises ConfigError: If the value is None or doesn't match the pattern.
+    """
+    if value is None:
+        raise ConfigError(
+            "Invalid value for 'region': None. Region is required and must be set."
+        )
+    if not isinstance(value, str) or not _REGION_PATTERN.match(value):
+        raise ConfigError(
+            f"Invalid value for 'region': {value!r}. "
+            "Must be a valid AWS region identifier."
+        )
+
+
+def validate_retry_strategy_options(value: object) -> None:
+    """Validate that retry_strategy_options is a RetryStrategyOptions instance.
+
+    :param value: The resolved retry strategy options value.
+    :raises ConfigError: If the value is not a RetryStrategyOptions instance.
+    """
+    if not isinstance(value, RetryStrategyOptions):
+        raise ConfigError(
+            f"Invalid value for 'retry_strategy_options': {value!r}. "
+            f"Must be RetryStrategyOptions, got {type(value).__name__}."
+        )

--- a/packages/smithy-aws-core/tests/unit/config/test_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_resolver.py
@@ -1,0 +1,285 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the config resolution pipeline.
+
+Tests AsyncAwsConfig.resolve(), resolver functions, SharedConfigContext,
+provenance tracking, and precedence behavior.
+"""
+
+from pathlib import Path
+
+import pytest
+from smithy_aws_core.config.aws_config import AsyncAwsConfig
+from smithy_aws_core.config.context import SharedConfigContext
+from smithy_aws_core.config.exceptions import ConfigError
+from smithy_aws_core.config.resolvers import (
+    resolve_region,
+    resolve_retry_config,
+)
+from smithy_aws_core.config.types import ConfigSource
+
+
+class TestResolveRegion:
+    @pytest.mark.asyncio
+    async def test_resolves_from_aws_region(self):
+        ctx = SharedConfigContext(env={"AWS_REGION": "us-west-2"})
+        result = await resolve_region(ctx)
+        assert result.value == "us-west-2"
+        assert result.source == ConfigSource.ENV
+
+    @pytest.mark.asyncio
+    async def test_resolves_from_aws_default_region(self):
+        ctx = SharedConfigContext(env={"AWS_DEFAULT_REGION": "eu-central-1"})
+        result = await resolve_region(ctx)
+        assert result.value == "eu-central-1"
+        assert result.source == ConfigSource.ENV
+
+    @pytest.mark.asyncio
+    async def test_aws_region_takes_precedence_over_default_region(self):
+        ctx = SharedConfigContext(
+            env={"AWS_REGION": "us-west-2", "AWS_DEFAULT_REGION": "eu-west-1"},
+        )
+        result = await resolve_region(ctx)
+        assert result.value == "us-west-2"
+
+    @pytest.mark.asyncio
+    async def test_resolves_from_profile_when_no_env(self, tmp_path: Path):
+        config_file = tmp_path / "config"
+        config_file.write_text("[profile default]\nregion = ap-southeast-1\n")
+
+        ctx = SharedConfigContext(
+            env={},
+            config_file_path=str(config_file),
+            credentials_file_path=str(tmp_path / "none"),
+        )
+        result = await resolve_region(ctx)
+        assert result.value == "ap-southeast-1"
+        assert result.source == ConfigSource.PROFILE
+
+    @pytest.mark.asyncio
+    async def test_env_takes_precedence_over_profile(self, tmp_path: Path):
+        config_file = tmp_path / "config"
+        config_file.write_text("[profile default]\nregion = eu-west-1\n")
+        ctx = SharedConfigContext(
+            env={"AWS_REGION": "us-west-2"},
+            config_file_path=str(config_file),
+            credentials_file_path=str(tmp_path / "nonexistent"),
+        )
+        result = await resolve_region(ctx)
+        assert result.value == "us-west-2"
+        assert result.source == ConfigSource.ENV
+
+    @pytest.mark.asyncio
+    async def test_empty_string_env_var_treated_as_absent(self, tmp_path: Path):
+        config_file = tmp_path / "config"
+        config_file.write_text("[profile default]\nregion = eu-west-1\n")
+        ctx = SharedConfigContext(
+            env={"AWS_REGION": ""},
+            config_file_path=str(config_file),
+            credentials_file_path=str(tmp_path / "nonexistent"),
+        )
+        result = await resolve_region(ctx)
+        assert result.value == "eu-west-1"
+        assert result.source == ConfigSource.PROFILE
+
+
+class TestResolveRetryConfig:
+    @pytest.mark.asyncio
+    async def test_resolves_both_from_env(self):
+        ctx = SharedConfigContext(
+            env={"AWS_RETRY_MODE": "standard", "AWS_MAX_ATTEMPTS": "10"},
+        )
+        result = await resolve_retry_config(ctx)
+        assert result.value.retry_mode == "standard"
+        assert result.value.max_attempts == 10
+        assert result.source == ConfigSource.ENV
+
+    @pytest.mark.asyncio
+    async def test_uses_defaults_when_nothing_found(self):
+        ctx = SharedConfigContext(env={})
+        result = await resolve_retry_config(ctx)
+        assert result.value.retry_mode == "standard"
+        assert result.value.max_attempts is None
+        assert result.source == ConfigSource.DEFAULT
+
+    @pytest.mark.asyncio
+    async def test_partial_resolution_uses_defaults_for_missing(self):
+        ctx = SharedConfigContext(env={"AWS_RETRY_MODE": "standard"})
+        result = await resolve_retry_config(ctx)
+        assert result.value.retry_mode == "standard"
+        assert result.value.max_attempts is None  # RetryStrategyOptions default
+        assert result.source == ConfigSource.ENV  # strongest source
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_cast_to_int(self):
+        ctx = SharedConfigContext(
+            env={"AWS_RETRY_MODE": "standard", "AWS_MAX_ATTEMPTS": "5"}
+        )
+        result = await resolve_retry_config(ctx)
+        assert result.value.max_attempts == 5
+        assert isinstance(result.value.max_attempts, int)
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_unset_when_not_found(self):
+        ctx = SharedConfigContext(env={})
+        result = await resolve_retry_config(ctx)
+        assert result.value.max_attempts is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_attempts_raises_config_error(self):
+        ctx = SharedConfigContext(env={"AWS_MAX_ATTEMPTS": "abc"})
+        with pytest.raises(ConfigError, match="Invalid integer value"):
+            await resolve_retry_config(ctx)
+
+
+class TestAsyncAwsConfigResolve:
+    @pytest.mark.asyncio
+    async def test_resolves_region_from_env(self):
+        config = await AsyncAwsConfig.resolve(env={"AWS_REGION": "us-west-2"})
+        assert config.region == "us-west-2"
+
+    @pytest.mark.asyncio
+    async def test_resolves_retry_from_env(self):
+        config = await AsyncAwsConfig.resolve(
+            env={"AWS_RETRY_MODE": "standard", "AWS_MAX_ATTEMPTS": "5"},
+        )
+        assert config.retry_strategy_options is not None
+        assert config.retry_strategy_options.retry_mode == "standard"
+        assert config.retry_strategy_options.max_attempts == 5
+
+    @pytest.mark.asyncio
+    async def test_explicit_override_takes_precedence(self):
+        config = await AsyncAwsConfig.resolve(
+            env={"AWS_REGION": "us-west-2"},
+            region="eu-west-1",
+        )
+        assert config.region == "eu-west-1"
+
+    @pytest.mark.asyncio
+    async def test_default_region_raises_error(self, tmp_path: Path):
+        with pytest.raises(ConfigError, match="Region is required"):
+            await AsyncAwsConfig.resolve(
+                env={},
+                config_file_path=str(tmp_path / "no_config"),
+                credentials_file_path=str(tmp_path / "no_creds"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_default_retry_strategy(self, tmp_path: Path):
+        config = await AsyncAwsConfig.resolve(
+            env={"AWS_REGION": "us-east-1"},
+            config_file_path=str(tmp_path / "no_config"),
+            credentials_file_path=str(tmp_path / "no_creds"),
+        )
+        assert config.retry_strategy_options is not None
+        assert config.retry_strategy_options.retry_mode == "standard"
+        assert config.retry_strategy_options.max_attempts is None
+
+    @pytest.mark.asyncio
+    async def test_resolves_region_from_non_default_profile(self, tmp_path: Path):
+        config_file = tmp_path / "config"
+        config_file.write_text(
+            "[profile default]\nregion = us-east-1\n"
+            "[profile work]\nregion = eu-west-1\n"
+        )
+
+        config = await AsyncAwsConfig.resolve(
+            profile="work",
+            env={},
+            config_file_path=str(config_file),
+            credentials_file_path=str(tmp_path / "none"),
+        )
+        assert config.region == "eu-west-1"
+        assert config.source_of("region") == ConfigSource.PROFILE
+
+    @pytest.mark.asyncio
+    async def test_invalid_override_triggers_validator(self):
+        with pytest.raises(ConfigError, match="Must be a valid AWS region"):
+            await AsyncAwsConfig.resolve(
+                env={},
+                region="bad-value!",
+            )
+
+
+class TestProvenanceTracking:
+    @pytest.mark.asyncio
+    async def test_source_of_env_resolved_field(self):
+        config = await AsyncAwsConfig.resolve(env={"AWS_REGION": "us-west-2"})
+        assert config.source_of("region") == ConfigSource.ENV
+
+    @pytest.mark.asyncio
+    async def test_source_of_profile_resolved_field(self, tmp_path: Path):
+        config_file = tmp_path / "config"
+        config_file.write_text("[profile default]\nregion = eu-west-1\n")
+
+        config = await AsyncAwsConfig.resolve(
+            env={},
+            config_file_path=str(config_file),
+            credentials_file_path=str(tmp_path / "none"),
+        )
+        assert config.source_of("region") == ConfigSource.PROFILE
+
+    @pytest.mark.asyncio
+    async def test_source_of_default_field(self, tmp_path: Path):
+        config = await AsyncAwsConfig.resolve(
+            env={"AWS_REGION": "us-east-1"},
+            config_file_path=str(tmp_path / "no_config"),
+            credentials_file_path=str(tmp_path / "no_creds"),
+        )
+        assert config.source_of("retry_strategy_options") == ConfigSource.DEFAULT
+
+    @pytest.mark.asyncio
+    async def test_source_of_override_field(self):
+        config = await AsyncAwsConfig.resolve(env={}, region="us-east-1")
+        assert config.source_of("region") == ConfigSource.OVERRIDE
+
+    @pytest.mark.asyncio
+    async def test_post_resolution_assignment_marks_source_as_override(self):
+        config = await AsyncAwsConfig.resolve(env={"AWS_REGION": "us-west-2"})
+        assert config.source_of("region") == ConfigSource.ENV
+        config.region = "eu-west-1"
+        assert config.source_of("region") == ConfigSource.OVERRIDE
+        assert config.region == "eu-west-1"
+
+
+class TestConstructionBlocking:
+    def test_direct_instantiation_raises_error(self):
+        with pytest.raises(ConfigError, match="cannot be constructed directly"):
+            AsyncAwsConfig()
+
+    @pytest.mark.asyncio
+    async def test_unknown_override_field_raises_error(self):
+        with pytest.raises(ConfigError, match="Unknown config field"):
+            await AsyncAwsConfig.resolve(
+                env={"AWS_REGION": "us-east-1"},
+                reigon="us-west-2",
+            )
+
+
+class TestSharedConfigContext:
+    def test_default_profile_is_default(self):
+        ctx = SharedConfigContext(env={})
+        assert ctx.profile_name == "default"
+
+    def test_profile_from_aws_profile_env(self):
+        ctx = SharedConfigContext(env={"AWS_PROFILE": "work"})
+        assert ctx.profile_name == "work"
+
+    def test_explicit_profile_overrides_env(self):
+        ctx = SharedConfigContext(profile_name="custom", env={"AWS_PROFILE": "work"})
+        assert ctx.profile_name == "custom"
+
+    @pytest.mark.asyncio
+    async def test_parsed_profiles_caches_result(self, tmp_path: Path):
+        config_file = tmp_path / "config"
+        config_file.write_text("[profile default]\nregion = us-east-1\n")
+
+        ctx = SharedConfigContext(
+            env={},
+            config_file_path=str(config_file),
+            credentials_file_path=str(tmp_path / "none"),
+        )
+
+        result1 = await ctx.parsed_profiles()
+        result2 = await ctx.parsed_profiles()
+        assert result1 is result2

--- a/packages/smithy-aws-core/tests/unit/config/test_validators.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_validators.py
@@ -1,0 +1,93 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for config field validators."""
+
+import pytest
+from smithy_aws_core.config.exceptions import ConfigError
+from smithy_aws_core.config.types import FieldSpec
+from smithy_aws_core.config.validators import (
+    validate_region,
+    validate_retry_strategy_options,
+)
+from smithy_core.retries import RetryStrategyOptions
+
+
+class TestValidateRegion:
+    @pytest.mark.parametrize(
+        "region",
+        [
+            "us-east-1",
+            "ap-southeast-2",
+            "eu-west-1",
+            "us",
+            "us-gov-west-1",
+        ],
+    )
+    def test_valid_regions(self, region: str):
+        validate_region(region)
+
+    def test_none_raises(self):
+        with pytest.raises(ConfigError, match="Region is required"):
+            validate_region(None)
+
+    @pytest.mark.parametrize(
+        "region,reason",
+        [
+            ("", "empty string"),
+            ("-us-east-1", "starts with dash"),
+            ("us-east-1-", "ends with dash"),
+            ("12345", "all numbers"),
+            ("us-east-1!", "special characters"),
+            ("us east 1", "spaces"),
+        ],
+        ids=lambda x: x if isinstance(x, str) else "",
+    )
+    def test_invalid_regions(self, region: str, reason: str):
+        with pytest.raises(ConfigError, match="Must be a valid AWS region"):
+            validate_region(region)
+
+    def test_non_string_raises(self):
+        with pytest.raises(ConfigError, match="Must be a valid AWS region"):
+            validate_region(123)
+
+
+class TestValidateRetryStrategyOptions:
+    def test_valid_default_options(self):
+        validate_retry_strategy_options(RetryStrategyOptions())
+
+    def test_valid_options_with_values(self):
+        validate_retry_strategy_options(
+            RetryStrategyOptions(retry_mode="standard", max_attempts=5)
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "standard",
+            {"retry_mode": "standard"},
+            3,
+        ],
+        ids=["none", "string", "dict", "int"],
+    )
+    def test_invalid_types_raise(self, value: object):
+        with pytest.raises(ConfigError, match="Must be RetryStrategyOptions"):
+            validate_retry_strategy_options(value)
+
+
+class TestFieldSpec:
+    """Tests for FieldSpec validation constraints."""
+
+    def test_default_only_is_valid(self):
+        FieldSpec(default=None)
+
+    def test_default_factory_only_is_valid(self):
+        FieldSpec(default_factory=list)
+
+    def test_both_default_and_factory_raises(self):
+        with pytest.raises(ValueError, match="cannot set both"):
+            FieldSpec(default=None, default_factory=list)
+
+    def test_neither_default_nor_factory_raises(self):
+        with pytest.raises(ValueError, match="exactly one of"):
+            FieldSpec()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change implements the async config resolution pipeline with `AsyncAwsConfig` using a `resolve()` classmethod as the only construction path. It adds `SharedConfigContext` for holding env vars and memoized config file data, `FieldSpec` for per-field resolution metadata, and provenance tracking via `ConfigSource`. Resolvers for region and `retry_strategy_options` are included along with validators for both fields.

*Testing:*
- Added unit and end-to-end tests covering env var resolution, profile resolution, explicit overrides, defaults, provenance tracking, validator enforcement, and construction blocking, and verified that they all pass.
- All existing tests pass 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
