### PR TITLE
fix: synchronize aiohttp constraint in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ awscrt = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.14.0,<4.0" },
+    { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.11.12,<4.0" },
     { name = "awscrt", marker = "extra == 'awscrt'", specifier = "~=0.32.0" },
     { name = "smithy-core", editable = "packages/smithy-core" },
     { name = "yarl", marker = "extra == 'aiohttp'" },


### PR DESCRIPTION
## Overview

This PR updates `uv.lock` to match the `aiohttp` constraint declared by `smithy-http`.

## Background

Dependabot PR #710 upgraded the resolved `aiohttp` version to 3.14.0, but also changed the lockfile metadata constraint from `>=3.11.12,<4.0` to `>=3.14.0,<4.0`. The source constraint in `packages/smithy-http/pyproject.toml` was not changed.

As a result, running `make install` causes `uv sync` to detect the stale metadata and modify `uv.lock`.

This has already been reported to dependabot in https://github.com/dependabot/dependabot-core/issues/14937

## Testing

- Ran `uv lock --check` successfully.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
