### PR TITLE
Mock PermissionError in config file permission test

### DIFF
--- a/packages/smithy-aws-core/tests/unit/config/test_config_file_io.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_config_file_io.py
@@ -3,6 +3,7 @@
 
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from smithy_aws_core.config import load_config
@@ -26,12 +27,13 @@ class TestFileIssues:
     async def test_permission_denied_returns_empty(self, tmp_path: Path):
         restricted_file = tmp_path / "restricted_config"
         restricted_file.write_text("[profile default]\nregion = us-east-1\n")
-        restricted_file.chmod(0o000)
-        try:
+        # Patch read_text to raise PermissionError rather than relying on
+        # chmod(0o000), which is bypassed when tests run as root (e.g. in CI).
+        with patch.object(
+            Path, "read_text", side_effect=PermissionError("Permission denied")
+        ):
             result = await parse_config_file(str(restricted_file))
-            assert result == {}
-        finally:
-            restricted_file.chmod(0o644)
+        assert result == {}
 
 
 class TestEncodingErrors:


### PR DESCRIPTION
## Summary
Fix `test_permission_denied_returns_empty` failing in release infra by mocking the `PermissionError` instead of relying on filesystem permission bits.

## Issue
The test used `chmod(0o000)` to make a config file unreadable, expecting `parse_config_file` to catch a `PermissionError` and return `{}`. This passed locally but failed in release infra because CI runs tests as root, which bypasses Unix permission bits. The read succeeded, the file was parsed, and the result was `{'profile default': {'region': 'us-east-1'}}` instead of `{}`.

## Solution
Replace the `chmod` with `patch.object(Path, "read_text", side_effect=PermissionError(...))`. This deterministically exercises the `except (PermissionError, OSError)` branch regardless of the running user, and matches the mocking approach already used in `test_config_file_location.py`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
