### PR TITLE
fix: handle explicit null member defaults for enums and intEnums

### DIFF
--- a/codegen/core/src/it/resources/META-INF/smithy/main.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/main.smithy
@@ -381,6 +381,8 @@ structure Defaults {
     @required
     requiredDefaultBlob: Blob = "c3BhbQ=="
 
+    defaultNullBlob: Blob = null
+
     // timestamp
     @required
     requiredTimestamp: Timestamp
@@ -399,6 +401,8 @@ structure Defaults {
 
     @required
     requiredDefaultTimestamp: Timestamp = 4.2
+
+    defaultNullTimestamp: Timestamp = null
 
     @required
     requiredList: StringList
@@ -419,6 +423,14 @@ structure Defaults {
 
     @required
     requiredDefaultMap: StringMap = {}
+
+    defaultEnum: StringYesNo = "YES"
+
+    defaultNullEnum: StringYesNo = null
+
+    defaultIntEnum: IntYesNo = 1
+
+    defaultNullIntEnum: IntYesNo = null
 
     @required
     requiredDocument: Document

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -288,11 +288,8 @@ public final class StructureGenerator implements Runnable {
         // see: https://smithy.io/2.0/spec/type-refinement-traits.html#smithy-api-default-trait
         var defaultNode = member.expectTrait(DefaultTrait.class).toNode();
         var target = model.expectShape(member.getTarget());
-        // A member may override its target's default with an explicit null to mark
-        // itself nullable, in which case it resolves to None. This guard covers every
-        // non-document type in one place so each branch below can assume a typed value.
-        // Documents are excluded: a null document default is a non-None Document(None),
-        // built by the document branch below.
+        // A null default marks the member nullable and resolves to None. Documents are
+        // excluded since their null default is a non-None Document(None) (see the branch below).
         if (!target.isDocumentShape() && defaultNode.isNullNode()) {
             return "None";
         }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -288,6 +288,14 @@ public final class StructureGenerator implements Runnable {
         // see: https://smithy.io/2.0/spec/type-refinement-traits.html#smithy-api-default-trait
         var defaultNode = member.expectTrait(DefaultTrait.class).toNode();
         var target = model.expectShape(member.getTarget());
+        // A member may override its target's default with an explicit null to mark
+        // itself nullable, in which case it resolves to None. This guard covers every
+        // non-document type in one place so each branch below can assume a typed value.
+        // Documents are excluded: a null document default is a non-None Document(None),
+        // built by the document branch below.
+        if (!target.isDocumentShape() && defaultNode.isNullNode()) {
+            return "None";
+        }
         if (target.isTimestampShape()) {
             ZonedDateTime value = CodegenUtils.parseTimestampNode(model, member, defaultNode);
             return CodegenUtils.getDatetimeConstructor(writer, value);
@@ -318,8 +326,8 @@ public final class StructureGenerator implements Runnable {
             });
         }
 
+        // A null default is handled by the guard above, so it can't reach here.
         return switch (defaultNode.getType()) {
-            case NULL -> "None";
             case BOOLEAN -> defaultNode.expectBooleanNode().getValue() ? "True" : "False";
             // These will be given to a default_factory in field. They're inherently empty, so no need to
             // worry about any potential values.


### PR DESCRIPTION
## Summary

Fixes a Python codegen crash when a structure member overrides an enum or intEnum default with an explicit `@default(null)`.

## Problem

A member can set `@default(null)` to mark itself nullable even when its target enum declares a non-null default. This is valid Smithy that appears in real AWS models (e.g. `bedrock-agentcore-control`'s `UpdatePolicyRequest$enforcementMode`). In existing codegen, `StructureGenerator.getDefaultValue` sent these into the enum/intEnum branches, which read the default as a string/number without a null check and threw:

```
ExpectationNotMetException: Expected string, but found null.
```

## Solution

Guard for a null default at the top of `getDefaultValue` so every non-document type resolves to `None` before the typed branches run (documents are excluded, their null default is a non-None `Document(None)`).

Added `defaultNull{Enum,IntEnum,Blob,Timestamp}` members to the integration model to cover this path.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
