### PR TITLE
fix: don't emit duplicate Content-Type when header is bound

### DIFF
--- a/packages/smithy-http/.changes/next-release/smithy-http-bugfix-3e31bed2e726497c997ce8c0fb45cf90.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-bugfix-3e31bed2e726497c997ce8c0fb45cf90.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Fixed duplicate Content-Type headers when a member is bound to Content-Type."
+}

--- a/packages/smithy-http/src/smithy_http/serializers.py
+++ b/packages/smithy-http/src/smithy_http/serializers.py
@@ -170,7 +170,9 @@ class HTTPRequestSerializer(SpecificShapeSerializer):
             payload = AsyncBytesReader(sync_payload)
 
         headers = binding_serializer.header_serializer.headers
-        if content_type is not None:
+        if content_type is not None and not any(
+            name.lower() == "content-type" for name, _ in headers
+        ):
             headers.append(("content-type", content_type))
 
         if content_length is not None:
@@ -358,7 +360,9 @@ class HTTPResponseSerializer(SpecificShapeSerializer):
             payload = AsyncBytesReader(sync_payload)
 
         headers = binding_serializer.header_serializer.headers
-        if content_type is not None:
+        if content_type is not None and not any(
+            name.lower() == "content-type" for name, _ in headers
+        ):
             headers.append(("content-type", content_type))
 
         if content_length is not None:

--- a/packages/smithy-http/tests/unit/test_serializers.py
+++ b/packages/smithy-http/tests/unit/test_serializers.py
@@ -645,6 +645,53 @@ class HTTPBlobPayload:
 
 
 @dataclass
+class HTTPBlobPayloadWithContentType:
+    payload: bytes = b""
+    content_type: str | None = None
+
+    ID: ClassVar[ShapeID] = ShapeID("com.smithy#HTTPBlobPayloadWithContentType")
+    SCHEMA: ClassVar[Schema] = Schema.collection(
+        id=ID,
+        members={
+            "payload": {"target": BLOB, "traits": [HTTPPayloadTrait()]},
+            "contentType": {
+                "target": STRING,
+                "traits": [HTTPHeaderTrait("Content-Type")],
+            },
+        },
+    )
+
+    def serialize(self, serializer: ShapeSerializer) -> None:
+        with serializer.begin_struct(self.SCHEMA) as s:
+            self.serialize_members(s)
+
+    def serialize_members(self, serializer: ShapeSerializer) -> None:
+        serializer.write_blob(self.SCHEMA.members["payload"], self.payload)
+        if self.content_type is not None:
+            serializer.write_string(
+                self.SCHEMA.members["contentType"], self.content_type
+            )
+
+    @classmethod
+    def deserialize(cls, deserializer: ShapeDeserializer) -> Self:
+        kwargs: dict[str, Any] = {}
+
+        def _consumer(schema: Schema, de: ShapeDeserializer) -> None:
+            match schema.expect_member_index():
+                case 0:
+                    kwargs["payload"] = de.read_blob(cls.SCHEMA.members["payload"])
+                case 1:
+                    kwargs["content_type"] = de.read_string(
+                        cls.SCHEMA.members["contentType"]
+                    )
+                case _:
+                    raise Exception(f"Unexpected schema: {schema}")
+
+        deserializer.read_struct(schema=cls.SCHEMA, consumer=_consumer)
+        return cls(**kwargs)
+
+
+@dataclass
 class HTTPStreamingPayload:
     payload: StreamingBlob
 
@@ -1756,6 +1803,20 @@ def payload_cases() -> list[HTTPMessageTestCase]:
                 fields=tuples_to_fields(
                     [
                         ("content-type", "application/octet-stream"),
+                        ("content-length", "4"),
+                    ]
+                ),
+                body=AsyncBytesReader(b"\xde\xad\xbe\xef"),
+            ),
+        ),
+        HTTPMessageTestCase(
+            HTTPBlobPayloadWithContentType(
+                payload=b"\xde\xad\xbe\xef", content_type="application/json"
+            ),
+            HTTPMessage(
+                fields=tuples_to_fields(
+                    [
+                        ("Content-Type", "application/json"),
                         ("content-length", "4"),
                     ]
                 ),


### PR DESCRIPTION
## Issue

Bedrock Runtime's [InvokeModel](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html) and [InvokeModelWithResponseStream](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModelWithResponseStream.html) bind their `contentType` input to the `Content-Type` header. Calling either operation with `content_type` set always fails against the live service:

```
CallError: Unknown error for operation com.amazonaws.bedrockruntime#InvokeModel - status: 403 - id: com.amazonaws.bedrockruntime#InvalidSignatureException
```
## Root cause

For blob payloads, the serializer computes a default `Content-Type` ([serializers.py#L108-L118](https://github.com/smithy-lang/smithy-python/blob/5c25af99/packages/smithy-http/src/smithy_http/serializers.py#L108-L118)). It then appends the default without checking the existing headers ([serializers.py#L172-L174](https://github.com/smithy-lang/smithy-python/blob/5c25af99/packages/smithy-http/src/smithy_http/serializers.py#L172-L174)):

```python
headers = binding_serializer.header_serializer.headers
if content_type is not None:
    headers.append(("content-type", content_type))
```

At this point the `httpHeader` binding has already written the user's value into the same list. The request goes out with two values:

```
Content-Type: application/json, application/octet-stream
```

The duplicate header breaks the SigV4 signature check, so the service rejects the request. `HTTPResponseSerializer` has the same pattern at [serializers.py#L360-L362](https://github.com/smithy-lang/smithy-python/blob/5c25af99/packages/smithy-http/src/smithy_http/serializers.py#L360-L362).

## Fix

Apply the payload default only when no `Content-Type` header is already bound, at both sites:

```python
if content_type is not None and not any(
    name.lower() == "content-type" for name, _ in headers
):
    headers.append(("content-type", content_type))
```

Header bindings now take precedence over the protocol default. When the input does not set the bound member, the header binding writes nothing and the default applies as before. 

## Testing

Ran the script below against the live Bedrock Runtime service:
```python
import asyncio
import json

from aws_sdk_bedrock_runtime.client import AsyncBedrockRuntimeClient
from aws_sdk_bedrock_runtime.config import Config
from aws_sdk_bedrock_runtime.models import (
    InvokeModelInput,
    InvokeModelWithResponseStreamInput,
    ResponseStreamChunk,
)
from smithy_aws_core.identity import EnvironmentCredentialsResolver

MODEL_ID = "global.amazon.nova-2-lite-v1:0"
BODY = json.dumps(
    {
        "messages": [{"role": "user", "content": [{"text": "Name one moon of Saturn."}]}],
        "inferenceConfig": {"maxTokens": 40},
    }
).encode("utf-8")


async def main() -> None:
    client = AsyncBedrockRuntimeClient(
        config=Config(
            region="us-east-1",
            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
        )
    )
    try:
        r = await client.invoke_model(
            InvokeModelInput(
                model_id=MODEL_ID,
                content_type="application/json",
                accept="application/json",
                body=BODY,
            )
        )
        text = json.loads(r.body.decode())["output"]["message"]["content"][0]["text"]
        print(f"invoke_model: OK -> {text[:50]!r}")
    except Exception as e:
        print(f"invoke_model: FAIL -> {type(e).__name__}: {str(e)[:200]}")

    try:
        r = await client.invoke_model_with_response_stream(
            InvokeModelWithResponseStreamInput(
                model_id=MODEL_ID,
                content_type="application/json",
                accept="application/json",
                body=BODY,
            )
        )
        parts = []
        async with r as stream:
            async for event in stream.output_stream:
                if isinstance(event, ResponseStreamChunk) and event.value.bytes_:
                    chunk = json.loads(event.value.bytes_.decode())
                    delta = chunk.get("contentBlockDelta", {}).get("delta", {})
                    if isinstance(delta.get("text"), str):
                        parts.append(delta["text"])
        print(f"invoke_model_with_response_stream: OK -> {''.join(parts)[:50]!r}")
    except Exception as e:
        print(
            f"invoke_model_with_response_stream: FAIL -> {type(e).__name__}: {str(e)[:200]}"
        )


asyncio.run(main())
```

Before this change:

```
invoke_model: FAIL -> CallError: ... status: 403 - id: com.amazonaws.bedrockruntime#InvalidSignatureException
invoke_model_with_response_stream: FAIL -> CallError: ... status: 403 - id: com.amazonaws.bedrockruntime#InvalidSignatureException
```

After this change:

```
invoke_model: OK -> 'One well-known moon of Saturn is **Titan**. ...'
invoke_model_with_response_stream: OK -> 'One well-known moon of Saturn is **Titan**. ...'
```

Also added a regression test to `packages/smithy-http/tests/unit/test_serializers.py`. The case fails without the fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
