### PR TITLE
smithy-http: disable redirects in aiohttp client

### DIFF
--- a/packages/smithy-http/.changes/next-release/smithy-http-enhancement-aa179eb92d72443d8a7664d7a1a07a38.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-enhancement-aa179eb92d72443d8a7664d7a1a07a38.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Disabled automatic redirects in `AIOHTTPClient` so that redirect responses are returned to the caller instead of being followed transparently."
+}

--- a/packages/smithy-http/src/smithy_http/aio/aiohttp.py
+++ b/packages/smithy-http/src/smithy_http/aio/aiohttp.py
@@ -108,6 +108,7 @@ class AIOHTTPClient(HTTPClient):
             params=parse_qs(request.destination.query),  # type: ignore
             headers=headers_list,
             data=body,
+            allow_redirects=False,
         ) as resp:
             return await self._marshal_response(resp)
 

--- a/packages/smithy-http/tests/unit/aio/test_aiohttp.py
+++ b/packages/smithy-http/tests/unit/aio/test_aiohttp.py
@@ -51,6 +51,20 @@ async def test_send_preserves_explicitly_framed_empty_body() -> None:
     assert session.request.call_args.kwargs["data"] is body
 
 
+async def test_send_disables_redirects() -> None:
+    client, session = _create_client()
+    request = HTTPRequest(
+        method="GET",
+        destination=URI(scheme="https", host="example.com", path="/"),
+        body=AsyncBytesReader(b""),
+        fields=Fields(),
+    )
+
+    await client.send(request)
+
+    assert session.request.call_args.kwargs["allow_redirects"] is False
+
+
 async def test_prepare_body_preserves_nonempty_reader_position() -> None:
     client, _ = _create_client()
     body = AsyncBytesReader(b"request body")


### PR DESCRIPTION
### Description
This PR disables automatic HTTP redirect following in the aiohttp client by passing `allow_redirects=False` to `self._session.request(...)`. This ensures that 3xx responses are returned to the caller instead of being followed by the transport.

This aligns the aiohttp transport with SDK convention of not following redirects by default (e.g. [botocore](https://github.com/boto/botocore/blob/develop/botocore/httpsession.py#L477-L487) via `Retry(False)`, and [smithy-kotlin](https://github.com/smithy-lang/smithy-kotlin/blob/main/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt#L117-L119) via OkHttp `followRedirects(false)`). The CRT transport is not updated because the CRT client already does not follow redirects (no behavior or option exists).

### Testing
`make check-py` and `make test-py` pass (1793 passed, 9 skipped).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
