### PR TITLE
Add async client transport cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ from echo.models import EchoMessageInput
 
 
 async def main() -> None:
-    client = EchoService(Config(endpoint_uri="https://example.com/"))
-    response = await client.echo_message(EchoMessageInput(message="spam"))
-    print(response.message)
+    async with EchoService(Config(endpoint_uri="https://example.com/")) as client:
+        response = await client.echo_message(EchoMessageInput(message="spam"))
+        print(response.message)
 
 
 if __name__ == "__main__":

--- a/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
@@ -48,6 +48,6 @@ public class PythonCodegenTest {
         assertFalse(client.contains("retry_mode="));
         assertFalse(client.contains("max_attempts="));
         assertTrue(client.contains("async def close(self) -> None:"));
-        assertTrue(client.contains("{id(self._config.transport): self._config.transport}"));
+        assertTrue(client.contains("if self._closed:"));
     }
 }

--- a/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.python.codegen.test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -46,5 +47,7 @@ public class PythonCodegenTest {
         var client = Files.readString(tempDir.resolve("src/weather/client.py"));
         assertFalse(client.contains("retry_mode="));
         assertFalse(client.contains("max_attempts="));
+        assertTrue(client.contains("async def close(self) -> None:"));
+        assertTrue(client.contains("{id(self._config.transport): self._config.transport}"));
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -143,10 +143,12 @@ final class ClientGenerator implements Runnable {
                         \"\"\"Close this client and any resources held by its transport.\"\"\"
                         if self._closed:
                             return
-                        self._closed = True
-                        await self._ensure_setup()
-                        assert self._config is not None
-                        await $1T(self._config.transport)
+                        async with self._derive_lock:
+                            if self._closed:
+                                return
+                            self._closed = True
+                            if self._setup_done and self._config is not None:
+                                await $1T(self._config.transport)
 
                     async def __aenter__(self) -> Self:
                         if self._closed:

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -134,6 +134,29 @@ final class ClientGenerator implements Runnable {
                         w.popState();
                     }));
 
+            writer.addStdlibImport("typing", "Any");
+            writer.write("""
+
+                    async def close(self) -> None:
+                        \"\"\"Close any resources held by this client's transport.\"\"\"
+                        await self._ensure_setup()
+                        assert self._config is not None
+                        await $1T(self._config.transport)
+
+                    async def __aenter__(self) -> "$2L":
+                        return self
+
+                    async def __aexit__(
+                        self,
+                        exc_type: Any,
+                        exc_value: Any,
+                        traceback: Any,
+                    ) -> None:
+                        await self.close()
+                    """,
+                    RuntimeTypes.ASYNC_CLOSE,
+                    serviceSymbol.getName());
+
             var topDownIndex = TopDownIndex.of(model);
             var eventStreamIndex = EventStreamIndex.of(model);
             for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
@@ -289,7 +312,10 @@ final class ClientGenerator implements Runnable {
                         assert self._config is not None
                         if operation_plugins:
                             # Keep operation-plugin mutations scoped to this call.
-                            config = deepcopy(self._config)
+                            config = deepcopy(
+                                self._config,
+                                {id(self._config.transport): self._config.transport},
+                            )
                             for plugin in operation_plugins:
                                 plugin(config)
                         else:

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -94,6 +94,7 @@ final class ClientGenerator implements Runnable {
                         self._plugins = plugins
                         self._derive_lock = asyncio.Lock()
                         self._setup_done = False
+                        self._closed = False
                         self._retry_strategy_resolver = $4T()
                         self._client_plugins: list[$2T] = [
                             ${5C|}
@@ -135,15 +136,21 @@ final class ClientGenerator implements Runnable {
                     }));
 
             writer.addStdlibImport("typing", "Any");
+            writer.addStdlibImport("typing", "Self");
             writer.write("""
 
                     async def close(self) -> None:
-                        \"\"\"Close any resources held by this client's transport.\"\"\"
+                        \"\"\"Close this client and any resources held by its transport.\"\"\"
+                        if self._closed:
+                            return
+                        self._closed = True
                         await self._ensure_setup()
                         assert self._config is not None
                         await $1T(self._config.transport)
 
-                    async def __aenter__(self) -> "$2L":
+                    async def __aenter__(self) -> Self:
+                        if self._closed:
+                            raise RuntimeError("Cannot enter a client that has been closed.")
                         return self
 
                     async def __aexit__(
@@ -154,8 +161,7 @@ final class ClientGenerator implements Runnable {
                     ) -> None:
                         await self.close()
                     """,
-                    RuntimeTypes.ASYNC_CLOSE,
-                    serviceSymbol.getName());
+                    RuntimeTypes.ASYNC_CLOSE);
 
             var topDownIndex = TopDownIndex.of(model);
             var eventStreamIndex = EventStreamIndex.of(model);
@@ -303,6 +309,11 @@ final class ClientGenerator implements Runnable {
 
         writer.write(
                 """
+                        if self._closed:
+                            raise RuntimeError(
+                                "Cannot invoke an operation on a client that has been closed."
+                            )
+
                         operation_plugins: list[Plugin] = [
                             $1C
                         ]
@@ -312,10 +323,7 @@ final class ClientGenerator implements Runnable {
                         assert self._config is not None
                         if operation_plugins:
                             # Keep operation-plugin mutations scoped to this call.
-                            config = deepcopy(
-                                self._config,
-                                {id(self._config.transport): self._config.transport},
-                            )
+                            config = deepcopy(self._config)
                             for plugin in operation_plugins:
                                 plugin(config)
                         else:

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/PythonSymbolProvider.java
@@ -66,6 +66,7 @@ public final class PythonSymbolProvider implements SymbolProvider, ShapeVisitor<
     private static final Logger LOGGER = Logger.getLogger(PythonSymbolProvider.class.getName());
     private static final String SHAPES_FILE = "models";
     private static final String SCHEMAS_FILE = "_private/schemas";
+    private static final Set<String> CLIENT_RESERVED_METHOD_NAMES = Set.of("close");
 
     private final Model model;
     private final ReservedWordSymbolProvider.Escaper escaper;
@@ -297,6 +298,9 @@ public final class PythonSymbolProvider implements SymbolProvider, ShapeVisitor<
         // Operation names are escaped like members because ultimately they're
         // properties on an object too.
         var methodName = escaper.escapeMemberName(CaseUtils.toSnakeCase(shape.getId().getName(service)));
+        if (CLIENT_RESERVED_METHOD_NAMES.contains(methodName)) {
+            methodName = escapeWord(methodName);
+        }
         var methodSymbol = createGeneratedSymbolBuilder(shape, methodName, "client", false)
                 .putProperty(SymbolProperties.IMPORTABLE, false)
                 .build();

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/RuntimeTypes.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/RuntimeTypes.java
@@ -117,6 +117,7 @@ public final class RuntimeTypes {
 
     // smithy_core.aio.utils
     public static final Symbol ASYNC_LIST = createSymbol("aio.utils", "async_list", SmithyPythonDependency.SMITHY_CORE);
+    public static final Symbol ASYNC_CLOSE = createSymbol("aio.utils", "close", SmithyPythonDependency.SMITHY_CORE);
 
     // smithy_http
     public static final Symbol TUPLES_TO_FIELDS =

--- a/codegen/core/src/test/java/software/amazon/smithy/python/codegen/PythonSymbolProviderTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/python/codegen/PythonSymbolProviderTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.UnionShape;
 
@@ -82,6 +83,29 @@ public class PythonSymbolProviderTest {
 
         assertEquals("MyUnion_Unknown",
                 provider.toSymbol(union).expectProperty(SymbolProperties.UNION_UNKNOWN).getName());
+    }
+
+    @Test
+    public void testOperationNameCollidingWithClientMethodIsEscaped() {
+        Model model = loadModel("""
+                $version: "2"
+                namespace smithy.example
+
+                service TestService {
+                    version: "2024-01-01"
+                    operations: [Close]
+                }
+
+                operation Close {}
+                """);
+        PythonSymbolProvider provider = createProvider(model);
+        var operation = model.expectShape(ShapeId.from(NS + "#Close"), OperationShape.class);
+
+        assertEquals(
+                "close_",
+                provider.toSymbol(operation)
+                        .expectProperty(SymbolProperties.OPERATION_METHOD)
+                        .getName());
     }
 
     private static Model loadModel(String smithyIdl) {

--- a/packages/smithy-http/.changes/next-release/smithy-http-bugfix-9b22c3201ef34610abb155ba32d0b097.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-bugfix-9b22c3201ef34610abb155ba32d0b097.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Preserved HTTP clients across operation configuration copies to avoid duplicating sessions and discarding connection pools."
+}

--- a/packages/smithy-http/.changes/next-release/smithy-http-bugfix-9b22c3201ef34610abb155ba32d0b097.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-bugfix-9b22c3201ef34610abb155ba32d0b097.json
@@ -1,4 +1,0 @@
-{
-  "type": "bugfix",
-  "description": "Preserved HTTP clients across operation configuration copies to avoid duplicating sessions and discarding connection pools."
-}

--- a/packages/smithy-http/.changes/next-release/smithy-http-feature-4fe36219987843b19f163600ae3a25a2.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-feature-4fe36219987843b19f163600ae3a25a2.json
@@ -1,0 +1,4 @@
+{
+  "type": "feature",
+  "description": "Added deterministic connection-pool cleanup and async context manager support to HTTP clients."
+}

--- a/packages/smithy-http/src/smithy_http/aio/aiohttp.py
+++ b/packages/smithy-http/src/smithy_http/aio/aiohttp.py
@@ -1,5 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
+from copy import copy, deepcopy
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Self
 from urllib.parse import parse_qs
@@ -26,6 +27,7 @@ from smithy_core.exceptions import MissingDependencyError
 from smithy_core.interfaces import URI
 
 from .. import Field, Fields
+from ..exceptions import SmithyHTTPError
 from ..interfaces import (
     HTTPClientConfiguration,
     HTTPRequestConfiguration,
@@ -68,6 +70,7 @@ class AIOHTTPClient(HTTPClient):
         """
         _assert_aiohttp()
         self._config = client_config or AIOHTTPClientConfig()
+        self._closed = False
         # Disable transparent response decompression and advertise
         # 'identity' to request uncompressed responses.
         # TODO: add a functional test once the test client framework exists
@@ -87,6 +90,11 @@ class AIOHTTPClient(HTTPClient):
         :param request: The request including destination URI, fields, payload.
         :param request_config: Configuration specific to this request.
         """
+        if self._closed:
+            raise SmithyHTTPError(
+                "Cannot send a request after the HTTP client has been closed."
+            )
+
         request_config = request_config or HTTPRequestConfiguration()
 
         headers_list = list(
@@ -117,9 +125,14 @@ class AIOHTTPClient(HTTPClient):
 
     async def close(self) -> None:
         """Close the underlying aiohttp session and its connection pool."""
+        if self._closed:
+            return
+        self._closed = True
         await self._session.close()
 
     async def __aenter__(self) -> Self:
+        if self._closed:
+            raise SmithyHTTPError("Cannot enter an HTTP client that has been closed.")
         return self
 
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
@@ -173,4 +186,7 @@ class AIOHTTPClient(HTTPClient):
         )
 
     def __deepcopy__(self, memo: Any) -> "AIOHTTPClient":
-        return self
+        return AIOHTTPClient(
+            client_config=deepcopy(self._config),
+            _session=copy(self._session),
+        )

--- a/packages/smithy-http/src/smithy_http/aio/aiohttp.py
+++ b/packages/smithy-http/src/smithy_http/aio/aiohttp.py
@@ -1,8 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from copy import copy, deepcopy
 from itertools import chain
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 from urllib.parse import parse_qs
 
 import yarl
@@ -116,6 +115,16 @@ class AIOHTTPClient(HTTPClient):
         ) as resp:
             return await self._marshal_response(resp)
 
+    async def close(self) -> None:
+        """Close the underlying aiohttp session and its connection pool."""
+        await self._session.close()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        await self.close()
+
     async def _prepare_body(self, body: StreamingBlob) -> AsyncBytesReader | None:
         """Convert a body for aiohttp, omitting seekable bodies with no data."""
         if not isinstance(body, AsyncBytesReader):
@@ -164,7 +173,4 @@ class AIOHTTPClient(HTTPClient):
         )
 
     def __deepcopy__(self, memo: Any) -> "AIOHTTPClient":
-        return AIOHTTPClient(
-            client_config=deepcopy(self._config),
-            _session=copy(self._session),
-        )
+        return self

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -3,6 +3,7 @@
 #  pyright: reportMissingTypeStubs=false,reportUnknownMemberType=false
 from asyncio import gather
 from collections.abc import AsyncGenerator, AsyncIterable
+from copy import deepcopy
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
 from io import BytesIO
@@ -164,6 +165,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         self._tls_ctx = crt_io.ClientTlsContext(crt_io.TlsContextOptions())
         self._socket_options = crt_io.SocketOptions()
         self._connections: ConnectionPoolDict = {}
+        self._closed = False
 
     async def send(
         self,
@@ -176,6 +178,11 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         :param request: The request including destination URI, fields, payload.
         :param request_config: Configuration specific to this request.
         """
+        if self._closed:
+            raise SmithyHTTPError(
+                "Cannot send a request after the HTTP client has been closed."
+            )
+
         try:
             crt_request = self._marshal_request(request)
             connection = await self._get_connection(request.destination)
@@ -201,11 +208,16 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     async def close(self) -> None:
         """Close all pooled HTTP connections."""
+        if self._closed:
+            return
+        self._closed = True
         connections = tuple(self._connections.values())
         self._connections.clear()
         await gather(*(connection.close() for connection in connections))
 
     async def __aenter__(self) -> Self:
+        if self._closed:
+            raise SmithyHTTPError("Cannot enter an HTTP client that has been closed.")
         return self
 
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
@@ -380,4 +392,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
                     yield chunk
 
     def __deepcopy__(self, memo: Any) -> "AWSCRTHTTPClient":
-        return self
+        return AWSCRTHTTPClient(
+            eventloop=self._eventloop,
+            client_config=deepcopy(self._config),
+        )

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -213,7 +213,10 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         self._closed = True
         connections = tuple(self._connections.values())
         self._connections.clear()
-        await gather(*(connection.close() for connection in connections))
+        await gather(
+            *(connection.close() for connection in connections),
+            return_exceptions=True,
+        )
 
     async def __aenter__(self) -> Self:
         if self._closed:

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -1,12 +1,12 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 #  pyright: reportMissingTypeStubs=false,reportUnknownMemberType=false
+from asyncio import gather
 from collections.abc import AsyncGenerator, AsyncIterable
-from copy import deepcopy
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
 from io import BytesIO
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 from awscrt.exceptions import AwsCrtError
 
@@ -199,6 +199,18 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
                 raise _CRTTimeoutError(f"CRT {e.name}: {e.message}") from e
             raise
 
+    async def close(self) -> None:
+        """Close all pooled HTTP connections."""
+        connections = tuple(self._connections.values())
+        self._connections.clear()
+        await gather(*(connection.close() for connection in connections))
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        await self.close()
+
     async def _await_response(
         self, stream: "AIOHttpClientStreamUnified"
     ) -> AWSCRTHTTPResponse:
@@ -368,7 +380,4 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
                     yield chunk
 
     def __deepcopy__(self, memo: Any) -> "AWSCRTHTTPClient":
-        return AWSCRTHTTPClient(
-            eventloop=self._eventloop,
-            client_config=deepcopy(self._config),
-        )
+        return self

--- a/packages/smithy-http/tests/unit/aio/test_aiohttp.py
+++ b/packages/smithy-http/tests/unit/aio/test_aiohttp.py
@@ -2,6 +2,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  pyright: reportPrivateUsage=false
 from collections.abc import AsyncIterator
+from copy import deepcopy
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -17,9 +18,34 @@ def _create_client() -> tuple[AIOHTTPClient, MagicMock]:
     response.read = AsyncMock(return_value=b"")
 
     session = MagicMock()
+    session.close = AsyncMock()
     session.request.return_value.__aenter__ = AsyncMock(return_value=response)
     session.request.return_value.__aexit__ = AsyncMock(return_value=None)
     return AIOHTTPClient(_session=cast(Any, session)), session
+
+
+def test_deepcopy_returns_same_client() -> None:
+    client, _ = _create_client()
+
+    assert deepcopy(client) is client
+
+
+async def test_close_closes_session() -> None:
+    client, session = _create_client()
+
+    await client.close()
+    await client.close()
+
+    assert session.close.await_count == 2
+
+
+async def test_context_manager_closes_session() -> None:
+    client, session = _create_client()
+
+    async with client as entered:
+        assert entered is client
+
+    session.close.assert_awaited_once()
 
 
 async def test_send_omits_empty_async_reader_body() -> None:

--- a/packages/smithy-http/tests/unit/aio/test_aiohttp.py
+++ b/packages/smithy-http/tests/unit/aio/test_aiohttp.py
@@ -2,15 +2,16 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  pyright: reportPrivateUsage=false
 from collections.abc import AsyncIterator
-from copy import deepcopy
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from smithy_core import URI
 from smithy_core.aio.types import AsyncBytesReader
 from smithy_http import Field, Fields
 from smithy_http.aio import HTTPRequest
 from smithy_http.aio.aiohttp import AIOHTTPClient
+from smithy_http.exceptions import SmithyHTTPError
 
 
 def _create_client() -> tuple[AIOHTTPClient, MagicMock]:
@@ -24,19 +25,21 @@ def _create_client() -> tuple[AIOHTTPClient, MagicMock]:
     return AIOHTTPClient(_session=cast(Any, session)), session
 
 
-def test_deepcopy_returns_same_client() -> None:
-    client, _ = _create_client()
-
-    assert deepcopy(client) is client
-
-
 async def test_close_closes_session() -> None:
     client, session = _create_client()
 
     await client.close()
     await client.close()
 
-    assert session.close.await_count == 2
+    session.close.assert_awaited_once()
+
+
+async def test_send_after_close_raises() -> None:
+    client, _ = _create_client()
+    await client.close()
+
+    with pytest.raises(SmithyHTTPError, match="has been closed"):
+        await client.send(MagicMock())
 
 
 async def test_context_manager_closes_session() -> None:
@@ -46,6 +49,10 @@ async def test_context_manager_closes_session() -> None:
         assert entered is client
 
     session.close.assert_awaited_once()
+
+    with pytest.raises(SmithyHTTPError, match="has been closed"):
+        async with client:
+            pass
 
 
 async def test_send_omits_empty_async_reader_body() -> None:

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -22,9 +22,25 @@ from smithy_http.exceptions import SmithyHTTPError
 
 
 def test_deepcopy_client() -> None:
-    """Test that AWSCRTHTTPClient can be deep copied."""
+    """Test that config copies share the stateful HTTP client."""
     client = AWSCRTHTTPClient()
-    deepcopy(client)
+    assert deepcopy(client) is client
+
+
+async def test_close_closes_and_clears_pooled_connections() -> None:
+    client = AWSCRTHTTPClient()
+    connections = [AsyncMock(), AsyncMock()]
+    client._connections = {
+        ("https", "one.example.com", None): connections[0],
+        ("https", "two.example.com", None): connections[1],
+    }
+
+    await client.close()
+    await client.close()
+
+    assert client._connections == {}
+    for connection in connections:
+        connection.close.assert_awaited_once()
 
 
 def test_supports_duplex_streaming() -> None:

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -22,9 +22,9 @@ from smithy_http.exceptions import SmithyHTTPError
 
 
 def test_deepcopy_client() -> None:
-    """Test that config copies share the stateful HTTP client."""
+    """Test that AWSCRTHTTPClient can be deep copied."""
     client = AWSCRTHTTPClient()
-    assert deepcopy(client) is client
+    deepcopy(client)
 
 
 async def test_close_closes_and_clears_pooled_connections() -> None:
@@ -45,6 +45,25 @@ async def test_close_closes_and_clears_pooled_connections() -> None:
 
 def test_supports_duplex_streaming() -> None:
     assert AWSCRTHTTPClient.SUPPORTS_DUPLEX_STREAMING is True
+
+
+async def test_send_after_close_raises() -> None:
+    client = AWSCRTHTTPClient()
+    await client.close()
+
+    with pytest.raises(SmithyHTTPError, match="has been closed"):
+        await client.send(Mock())
+
+
+async def test_context_manager_cannot_be_reentered() -> None:
+    client = AWSCRTHTTPClient()
+
+    async with client as entered:
+        assert entered is client
+
+    with pytest.raises(SmithyHTTPError, match="has been closed"):
+        async with client:
+            pass
 
 
 def test_client_marshal_request() -> None:


### PR DESCRIPTION
## Overview

This PR adds deterministic resource cleanup to generated clients and HTTP transports. Generated clients can now close transport resources explicitly or through async context managers, while closing an unused client does not trigger lazy config resolution or credential I/O.

## Current State

Generated clients do not expose a lifecycle API for their transport. aiohttp sessions and CRT pooled connections can remain open unless callers reach into the configured transport and close it themselves, which can produce `Unclosed client session` and `Unclosed connector` warnings during shutdown.

## New Pattern

Generated clients and HTTP transports now support idempotent `close()` methods and async context managers. A generated client closes its configured transport after setup, rejects operations and context-manager re-entry after closure, and avoids initializing config or transport resources solely to close an unused client.

`AIOHTTPClient.close()` closes its `ClientSession`. `AWSCRTHTTPClient.close()` attempts to close every pooled connection and clears the pool even when an individual connection close fails. Both transports reject sends after closure.

If a service models an operation named `Close`, the operation is generated as `close_()` so it does not collide with the lifecycle `close()` method.

```python
async with AsyncExampleClient(config) as client:
    response = await client.some_operation(input)
```

Clients can also be closed manually:

```python
client = AsyncExampleClient(config)
try:
    response = await client.some_operation(input)
finally:
    await client.close()
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

