### PR TITLE
fix: update env provider to skip terminal resolver registration if asume role creds are configured

### DIFF
--- a/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-bugfix-0391d2827ce9402b8a77fd4ba5df090f.json
+++ b/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-bugfix-0391d2827ce9402b8a77fd4ba5df090f.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Updated the Environment credentials provider to skip registering a terminal resolver when a configured profile assumes a role using `credential_source = Environment`."
+}

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/providers/environment.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/providers/environment.py
@@ -4,6 +4,7 @@ import os
 
 from smithy_core.interfaces.identity import Identity
 
+from ....config import load_config
 from ...components import AWSCredentialsIdentity
 from ...environment import EnvironmentCredentialsResolver
 from ..ordering import Standard, StandardProvider
@@ -11,6 +12,8 @@ from ..provider import ChainSetup
 
 _ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
 _SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"  # noqa: S105
+_ROLE_ARN = "role_arn"
+_CREDENTIAL_SOURCE = "credential_source"
 
 
 class EnvironmentCredentialsProvider:
@@ -37,5 +40,16 @@ class EnvironmentCredentialsProvider:
 
         if not os.getenv(_ACCESS_KEY_ID) or not os.getenv(_SECRET_ACCESS_KEY):
             return
+
+        # Skip environment provider if a profile is explicitly provided and
+        # that profile configures assume role credentials with 'Environment' as the
+        # credential source
+        profile_name = setup.profile_name
+        if profile_name:
+            config = setup.config_file or await load_config()
+            role_arn = config.get(profile_name, _ROLE_ARN)
+            credential_source = config.get(profile_name, _CREDENTIAL_SOURCE)
+            if role_arn is not None and credential_source == "Environment":
+                return
 
         setup.add_terminal_resolver(EnvironmentCredentialsResolver())

--- a/packages/smithy-aws-core/tests/unit/identity/chain/providers/test_environment.py
+++ b/packages/smithy-aws-core/tests/unit/identity/chain/providers/test_environment.py
@@ -1,8 +1,9 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 
 import pytest
+from smithy_aws_core.config.merged_config import MergedConfig
 from smithy_aws_core.identity.chain.provider import ChainSetup
 from smithy_aws_core.identity.chain.providers.environment import (
     EnvironmentCredentialsProvider,
@@ -63,4 +64,83 @@ async def test_registers_terminal_resolver(
     assert setup.terminal
     assert len(setup.resolvers) == 1
     assert setup.resolvers[0].provider_name == "Environment"
+    assert isinstance(setup.resolvers[0].resolver, EnvironmentCredentialsResolver)
+
+
+async def test_skips_when_profile_uses_environment_credential_source(
+    setup_provider: Callable[..., Awaitable[ChainSetup]],
+    merged_config: Callable[..., MergedConfig],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    config = merged_config(
+        {
+            "assume": {
+                "role_arn": "arn:aws:iam::123456789012:role/example",
+                "credential_source": "Environment",
+            }
+        }
+    )
+
+    setup = await setup_provider(
+        EnvironmentCredentialsProvider(),
+        config_file=config,
+        profile_name="assume",
+    )
+
+    assert setup.resolvers == ()
+    assert not setup.terminal
+
+
+@pytest.mark.parametrize(
+    "profile_properties",
+    [
+        {
+            "role_arn": "arn:aws:iam::123456789012:role/example",
+            "credential_source": "Ec2InstanceMetadata",
+        },
+        {"credential_source": "Environment"},
+        {"role_arn": "arn:aws:iam::123456789012:role/example"},
+    ],
+)
+async def test_registers_resolver_when_not_assuming_role_from_environment(
+    profile_properties: Mapping[str, str],
+    setup_provider: Callable[..., Awaitable[ChainSetup]],
+    merged_config: Callable[..., MergedConfig],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    config = merged_config({"assume": profile_properties})
+
+    setup = await setup_provider(
+        EnvironmentCredentialsProvider(),
+        config_file=config,
+        profile_name="assume",
+    )
+
+    assert setup.terminal
+    assert len(setup.resolvers) == 1
+    assert isinstance(setup.resolvers[0].resolver, EnvironmentCredentialsResolver)
+
+
+async def test_registers_resolver_when_profile_missing_from_config(
+    setup_provider: Callable[..., Awaitable[ChainSetup]],
+    merged_config: Callable[..., MergedConfig],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    setup = await setup_provider(
+        EnvironmentCredentialsProvider(),
+        config_file=merged_config({}),
+        profile_name="does-not-exist",
+    )
+
+    assert setup.terminal
+    assert len(setup.resolvers) == 1
     assert isinstance(setup.resolvers[0].resolver, EnvironmentCredentialsResolver)


### PR DESCRIPTION
### Description

The `EnvironmentCredentialsProvider` previously registered a terminal resolver whenever `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` were present in the environment. This short-circuited the credential chain even when the active profile was configured to *assume a role* using those environment credentials as the source, meaning the source credentials were handed back directly instead of being used to make the AssumeRole call.

This change makes the provider skip registering a terminal `EnvironmentCredentialsResolver` when a profile is explicitly configure in `IdentityChain.create()` and that profile declares both `role_arn` and `credential_source = Environment`, deferring to assume-role resolution.

Example profile that triggers the skip (`~/.aws/config`):

```
[profile assume]
role_arn = arn:aws:iam::123456789012:role/example
credential_source = Environment
```

With this profile, the environment credentials are treated as the *source* for the AssumeRole call rather than the credentials to return.

### Testing

- Added unit tests in `test_environment.py`:
- Ran `make test-py`- 1881 passed, 9 skipped.
- Ran `make check-py` - ruff, format, and pyright all clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.