### PR TITLE
Prevent Java builds from silently reformatting source files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,12 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass (`make test-py` and `make test-protocols`).
-4. Run `make lint-py` and `make check-py` if you've changed any python sources.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+3. Ensure local tests pass (`make test-py`, `make build-java`, and `make test-protocols`).
+4. Run `make lint-py` and `make check-py` if you've changed any Python sources.
+5. Run `make format-java` and `make check-java` if you've changed any Java or Gradle sources.
+6. Commit to your fork using clear commit messages.
+7. Send us a pull request, answering any default questions in the pull request interface.
+8. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,15 @@ install: ## Sets up workspace (* you should run this first! *)
 	@printf "\n\nWorkspace initialized, please run:\n\033[36msource .venv/bin/activate\033[0m"
 
 
-build-java: ## Builds the Java code generation packages.
+format-java: ## Formats the Java code generation packages.
+	cd codegen && ./gradlew spotlessApply
+
+
+check-java: ## Checks Java and Gradle formatting without modifying source.
+	cd codegen && ./gradlew spotlessCheck
+
+
+build-java: ## Builds and tests the Java code generation packages without modifying source.
 	cd codegen && ./gradlew clean build
 
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ the `codegen` directory. If this is the first time you have run this
 (or if you didn't already run `make install`), it will download Gradle onto your
 system to run along with any dependencies of the Java packages.
 
+Java builds check formatting without modifying source. From the repository
+root, run `make format-java` to apply formatting and `make check-java` to check
+it explicitly.
+
 For more details on working on the code generator, see the readme in the
 `codegen` directory.
 

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -26,8 +26,11 @@ clients.
 
 The code generator uses the [gradle](https://gradle.org) build system, accessed
 via the gradle wrapper `gradlew`. To build the generator, simply run
-`./gradlew clean build`. Alternatively, run `make smithy-build` from the repo
-root. To run the protocol tests, run `make test-protocols`.
+`./gradlew clean build`. Alternatively, run `make build-java` from the repo
+root. Builds check formatting without modifying source. Run `make format-java`
+from the repo root to apply Java and Gradle formatting, and run
+`make check-java` to check formatting explicitly. To run the protocol tests,
+run `make test-protocols`.
 
 **WARNING: All interfaces are subject to change.**
 

--- a/codegen/buildSrc/src/main/kotlin/smithy-python.java-conventions.gradle.kts
+++ b/codegen/buildSrc/src/main/kotlin/smithy-python.java-conventions.gradle.kts
@@ -129,12 +129,6 @@ tasks.named("spotbugsTest") {
     enabled = false
 }
 
-tasks {
-    spotlessCheck {
-        dependsOn(tasks.spotlessApply)
-    }
-}
-
 /*
  * Repositories
  * ================================

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/EnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/EnumGenerator.java
@@ -41,20 +41,24 @@ public final class EnumGenerator implements Runnable {
             writer.addStdlibImport("enum", "StrEnum");
             writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
             writer.addLocallyDefinedSymbol(enumSymbol);
-            writer.openBlock("class $L($T, StrEnum):", "", enumSymbol.getName(), RuntimeTypes.UNKNOWN_ENUM_MIXIN, () -> {
-                shape.getTrait(DocumentationTrait.class).ifPresent(trait -> {
-                    writer.writeDocs(trait.getValue(), context);
-                });
+            writer.openBlock("class $L($T, StrEnum):",
+                    "",
+                    enumSymbol.getName(),
+                    RuntimeTypes.UNKNOWN_ENUM_MIXIN,
+                    () -> {
+                        shape.getTrait(DocumentationTrait.class).ifPresent(trait -> {
+                            writer.writeDocs(trait.getValue(), context);
+                        });
 
-                for (MemberShape member : shape.members()) {
-                    var name = context.symbolProvider().toMemberName(member);
-                    var value = member.expectTrait(EnumValueTrait.class).expectStringValue();
-                    writer.write("$L = $S", name, value);
-                    member.getTrait(DocumentationTrait.class).ifPresent(trait -> {
-                        writer.writeDocs(trait.getValue(), context);
+                        for (MemberShape member : shape.members()) {
+                            var name = context.symbolProvider().toMemberName(member);
+                            var value = member.expectTrait(EnumValueTrait.class).expectStringValue();
+                            writer.write("$L = $S", name, value);
+                            member.getTrait(DocumentationTrait.class).ifPresent(trait -> {
+                                writer.writeDocs(trait.getValue(), context);
+                            });
+                        }
                     });
-                }
-            });
         });
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/IntEnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/IntEnumGenerator.java
@@ -41,20 +41,24 @@ public final class IntEnumGenerator implements Runnable {
             writer.addStdlibImport("enum", "IntEnum");
             writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
             writer.addLocallyDefinedSymbol(enumSymbol);
-            writer.openBlock("class $L($T, IntEnum):", "", enumSymbol.getName(), RuntimeTypes.UNKNOWN_ENUM_MIXIN, () -> {
-                directive.shape().getTrait(DocumentationTrait.class).ifPresent(trait -> {
-                    writer.writeDocs(trait.getValue(), directive.context());
-                });
+            writer.openBlock("class $L($T, IntEnum):",
+                    "",
+                    enumSymbol.getName(),
+                    RuntimeTypes.UNKNOWN_ENUM_MIXIN,
+                    () -> {
+                        directive.shape().getTrait(DocumentationTrait.class).ifPresent(trait -> {
+                            writer.writeDocs(trait.getValue(), directive.context());
+                        });
 
-                for (MemberShape member : directive.shape().members()) {
-                    var name = directive.symbolProvider().toMemberName(member);
-                    var value = member.expectTrait(EnumValueTrait.class).expectIntValue();
-                    writer.write("$L = $L", name, value);
-                    member.getTrait(DocumentationTrait.class).ifPresent(trait -> {
-                        writer.writeDocs(trait.getValue(), directive.context());
+                        for (MemberShape member : directive.shape().members()) {
+                            var name = directive.symbolProvider().toMemberName(member);
+                            var value = member.expectTrait(EnumValueTrait.class).expectIntValue();
+                            writer.write("$L = $L", name, value);
+                            member.getTrait(DocumentationTrait.class).ifPresent(trait -> {
+                                writer.writeDocs(trait.getValue(), directive.context());
+                            });
+                        }
                     });
-                }
-            });
         });
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/UnionGenerator.java
@@ -157,30 +157,31 @@ public final class UnionGenerator implements Runnable {
         var schemaSymbol = symbol.expectProperty(SymbolProperties.SCHEMA);
         var unknownSymbol = symbol.expectProperty(SymbolProperties.UNION_UNKNOWN);
         writer.putContext("schema", schemaSymbol);
-        writer.write("""
-                class $1L:
-                    _result: $2T | None = None
+        writer.write(
+                """
+                        class $1L:
+                            _result: $2T | None = None
 
-                    def deserialize(self, deserializer: ${shapeDeserializer:T}) -> $2T:
-                        self._result = None
-                        deserializer.read_struct($3T, self._consumer)
+                            def deserialize(self, deserializer: ${shapeDeserializer:T}) -> $2T:
+                                self._result = None
+                                deserializer.read_struct($3T, self._consumer)
 
-                        if self._result is None:
-                            raise ${serializationError:T}("Unions must have exactly one value, but found none.")
+                                if self._result is None:
+                                    raise ${serializationError:T}("Unions must have exactly one value, but found none.")
 
-                        return self._result
+                                return self._result
 
-                    def _consumer(self, schema: $4T, de: ${shapeDeserializer:T}) -> None:
-                        match schema.expect_member_index():
-                            ${5C|}
-                            case _:
-                                self._set_result($6L(tag=schema.expect_member_name()))
+                            def _consumer(self, schema: $4T, de: ${shapeDeserializer:T}) -> None:
+                                match schema.expect_member_index():
+                                    ${5C|}
+                                    case _:
+                                        self._set_result($6L(tag=schema.expect_member_name()))
 
-                    def _set_result(self, value: $2T) -> None:
-                        if self._result is not None:
-                            raise ${serializationError:T}("Unions must have exactly one value, but found more than one.")
-                        self._result = value
-                """,
+                            def _set_result(self, value: $2T) -> None:
+                                if self._result is not None:
+                                    raise ${serializationError:T}("Unions must have exactly one value, but found more than one.")
+                                self._result = value
+                        """,
                 deserializerSymbol.getName(),
                 symbol,
                 schemaSymbol,


### PR DESCRIPTION
## Summary

Our Java formatting check currently rewrites files before validating them. Because `spotlessCheck` invokes `spotlessApply`, `make build-java` silently fixes formatting errors and CI passes. This allows unformatted code to reach `develop`, causing unrelated formatting changes to appear in later PRs.

This PR separates formatting from validation so builds and CI fail on unformatted code without modifying source files. It also adds explicit formatting commands and applies the outstanding formatting fixes.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
