### PR TITLE
Prioritize assume role credentials and deprecate built-in network providers

### DIFF
--- a/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-breaking-3ecac569c6ea4f2691d472816fde80ae.json
+++ b/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-breaking-3ecac569c6ea4f2691d472816fde80ae.json
@@ -1,0 +1,4 @@
+{
+  "type": "breaking",
+  "description": "Updated the credential chain precedence so assume role credentials are resolved before session and static profile keys."
+}

--- a/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-enhancement-168e61426c534a2f92107d39f9241a9e.json
+++ b/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-enhancement-168e61426c534a2f92107d39f9241a9e.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Updated profile session and static key providers to defer when the selected profile declares an assume-role configuration."
+}

--- a/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-enhancement-6fb937c32d5448e88bf1d5f8246389af.json
+++ b/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-enhancement-6fb937c32d5448e88bf1d5f8246389af.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Deprecated the built-in IMDS and container credentials resolvers in favor of the resolvers provided by the `aws-credentials-imds` and `aws-credentials-http` packages."
+}

--- a/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-enhancement-e32f94fda81c4875a1e24a804eef9788.json
+++ b/packages/smithy-aws-core/.changes/next-release/smithy-aws-core-enhancement-e32f94fda81c4875a1e24a804eef9788.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Updated environment credentials provider to defer when `profile_name` is passed to `IdentityChain.create()`."
+}

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/__init__.py
@@ -185,8 +185,9 @@ class IdentityChain[I: Identity](IdentityResolver[I, Mapping[str, Any]]):
         :param identity_type: The identity type to resolve.
         :param config_file: Parsed config/credentials file. Loaded from disk
             when not set.
-        :param profile_name: Profile name to use. If omitted, the shared config
-            provider uses ``AWS_PROFILE`` when set, otherwise ``default``.
+        :param profile_name: Explicit profile name to use. When set, top-level
+            environment credential resolution is suppressed. If omitted, the shared
+            config provider uses ``AWS_PROFILE`` when set, otherwise ``default``.
         :param region_override: Region to use for providers whose resolvers
             fetch credentials through a service call.
         :param http_client: HTTP client to use for providers whose resolvers make

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/ordering.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/ordering.py
@@ -13,9 +13,9 @@ class StandardProvider(Enum):
     ENVIRONMENT = "Environment", None
     WEB_IDENTITY_TOKEN_ENV = "WebIdentityTokenEnv", "aws-credentials-sts"
     SHARED_CONFIG = "SharedConfig", None
+    PROFILE_ASSUME_ROLE = "ProfileAssumeRole", "aws-credentials-sts"
     PROFILE_SESSION_KEYS = "ProfileSessionKeys", None
     PROFILE_STATIC_KEYS = "ProfileStaticKeys", None
-    PROFILE_ASSUME_ROLE = "ProfileAssumeRole", "aws-credentials-sts"
     PROFILE_WEB_IDENTITY = "ProfileWebIdentity", "aws-credentials-sts"
     PROFILE_SSO_SESSION = "ProfileSsoSession", "aws-credentials-sso"
     PROFILE_LOGIN = "Login", "aws-credentials-login"

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/providers/environment.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/providers/environment.py
@@ -14,7 +14,7 @@ _SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"  # noqa: S105
 
 
 class EnvironmentCredentialsProvider:
-    """Adds an environment resolver when credentials are configured in the environment."""
+    """Adds an environment resolver unless an explicit profile is selected."""
 
     @property
     def name(self) -> str:
@@ -33,6 +33,9 @@ class EnvironmentCredentialsProvider:
     ) -> None:
         """Add an environment resolver when env credentials are configured."""
         if identity_type is not AWSCredentialsIdentity:
+            return
+
+        if setup.profile_name is not None:
             return
 
         if not os.getenv(_ACCESS_KEY_ID) or not os.getenv(_SECRET_ACCESS_KEY):

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/providers/profile.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/chain/providers/profile.py
@@ -11,6 +11,7 @@ _ACCESS_KEY_ID = "aws_access_key_id"
 _SECRET_ACCESS_KEY = "aws_secret_access_key"  # noqa: S105
 _SESSION_TOKEN = "aws_session_token"  # noqa: S105
 _ACCOUNT_ID = "aws_account_id"
+_ROLE_ARN = "role_arn"
 
 
 class ProfileSessionCredentialsProvider:
@@ -34,6 +35,9 @@ class ProfileSessionCredentialsProvider:
         config_file = setup.config_file
         profile_name = setup.profile_name
         if config_file is None or profile_name is None:
+            return
+
+        if config_file.get(profile_name, _ROLE_ARN) is not None:
             return
 
         access_key_id = config_file.get(profile_name, _ACCESS_KEY_ID)
@@ -72,6 +76,9 @@ class ProfileStaticCredentialsProvider:
         config_file = setup.config_file
         profile_name = setup.profile_name
         if config_file is None or profile_name is None:
+            return
+
+        if config_file.get(profile_name, _ROLE_ARN) is not None:
             return
 
         access_key_id = config_file.get(profile_name, _ACCESS_KEY_ID)

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/container.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/container.py
@@ -4,6 +4,7 @@ import asyncio
 import ipaddress
 import json
 import os
+import warnings
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from urllib.parse import urlparse
@@ -106,7 +107,12 @@ class ContainerMetadataClient:
 class ContainerCredentialsResolver(
     IdentityResolver[AWSCredentialsIdentity, AWSIdentityProperties]
 ):
-    """Resolves AWS Credentials from container credential sources."""
+    """Resolves AWS Credentials from container credential sources.
+
+    .. warning::
+        This resolver is deprecated. Use the resolver provided by the
+        ``aws-credentials-http`` package instead.
+    """
 
     ENV_VAR = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
     ENV_VAR_FULL = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
@@ -118,6 +124,12 @@ class ContainerCredentialsResolver(
         http_client: HTTPClient,
         config: ContainerCredentialsConfig | None = None,
     ):
+        warnings.warn(
+            "`ContainerCredentialsResolver` is deprecated; install "
+            "`aws-credentials-http` and use its resolver instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._http_client = http_client
         self._config = config or ContainerCredentialsConfig()
         self._client = ContainerMetadataClient(http_client, self._config)

--- a/packages/smithy-aws-core/src/smithy_aws_core/identity/imds.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/identity/imds.py
@@ -2,6 +2,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
+import warnings
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from types import MappingProxyType
@@ -182,11 +183,22 @@ class EC2Metadata:
 class IMDSCredentialsResolver(
     IdentityResolver[AWSCredentialsIdentity, AWSIdentityProperties]
 ):
-    """Resolves AWS Credentials from an EC2 Instance Metadata Service (IMDS) client."""
+    """Resolves AWS Credentials from an EC2 Instance Metadata Service (IMDS) client.
+
+    .. warning::
+        This resolver is deprecated. Use the resolver provided by the
+        ``aws-credentials-imds`` package instead.
+    """
 
     _METADATA_PATH_BASE = "/latest/meta-data/iam/security-credentials"
 
     def __init__(self, http_client: HTTPClient, config: Config | None = None):
+        warnings.warn(
+            "`IMDSCredentialsResolver` is deprecated; install "
+            "`aws-credentials-imds` and use its resolver instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # TODO: Respect IMDS specific config values from aws shared config file and environment.
         self._http_client = http_client
         self._ec2_metadata_client = EC2Metadata(http_client=http_client, config=config)

--- a/packages/smithy-aws-core/tests/unit/identity/chain/providers/test_environment.py
+++ b/packages/smithy-aws-core/tests/unit/identity/chain/providers/test_environment.py
@@ -64,3 +64,34 @@ async def test_registers_terminal_resolver(
     assert len(setup.resolvers) == 1
     assert setup.resolvers[0].provider_name == "Environment"
     assert isinstance(setup.resolvers[0].resolver, EnvironmentCredentialsResolver)
+
+
+async def test_explicit_profile_suppresses_environment_credentials(
+    setup_provider: Callable[..., Awaitable[ChainSetup]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    setup = await setup_provider(
+        EnvironmentCredentialsProvider(),
+        profile_name="work",
+    )
+
+    assert setup.resolvers == ()
+    assert not setup.terminal
+
+
+async def test_aws_profile_env_var_does_not_suppress_environment_credentials(
+    setup_provider: Callable[..., Awaitable[ChainSetup]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_PROFILE", "work")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    setup = await setup_provider(EnvironmentCredentialsProvider())
+
+    assert setup.terminal
+    assert len(setup.resolvers) == 1
+    assert isinstance(setup.resolvers[0].resolver, EnvironmentCredentialsResolver)

--- a/packages/smithy-aws-core/tests/unit/identity/chain/providers/test_profile.py
+++ b/packages/smithy-aws-core/tests/unit/identity/chain/providers/test_profile.py
@@ -115,6 +115,35 @@ async def test_registers_terminal_resolver_for_complete_profile(
 
 
 @pytest.mark.parametrize(
+    "provider",
+    [ProfileSessionCredentialsProvider(), ProfileStaticCredentialsProvider()],
+)
+async def test_defers_when_selected_profile_declares_assume_role(
+    provider: Any,
+    setup_provider: Callable[..., Awaitable[ChainSetup]],
+    merged_config: Callable[..., MergedConfig],
+) -> None:
+    setup = await setup_provider(
+        provider,
+        config_file=merged_config(
+            {
+                "default": {
+                    "aws_access_key_id": "akid",
+                    "aws_secret_access_key": "secret",
+                    "aws_session_token": "token",
+                    "role_arn": "arn:aws:iam::123456789012:role/test",
+                    "source_profile": "default",
+                }
+            }
+        ),
+        profile_name="default",
+    )
+
+    assert setup.resolvers == ()
+    assert not setup.terminal
+
+
+@pytest.mark.parametrize(
     "provider, properties",
     [
         (

--- a/packages/smithy-aws-core/tests/unit/identity/chain/test_chain.py
+++ b/packages/smithy-aws-core/tests/unit/identity/chain/test_chain.py
@@ -131,12 +131,26 @@ def test_sort_orders_standards_by_slot_declaration() -> None:
     static = _StubProvider(
         "static", Standard(slot=StandardProvider.PROFILE_STATIC_KEYS)
     )
+    assume_role = _StubProvider(
+        "assume-role", Standard(slot=StandardProvider.PROFILE_ASSUME_ROLE)
+    )
+    session = _StubProvider(
+        "session", Standard(slot=StandardProvider.PROFILE_SESSION_KEYS)
+    )
     env = _StubProvider("env", Standard(slot=StandardProvider.ENVIRONMENT))
     shared = _StubProvider("shared", Standard(slot=StandardProvider.SHARED_CONFIG))
 
-    ordered = chain_module._sort_by_ordering((static, env, shared))
+    ordered = chain_module._sort_by_ordering(
+        (static, session, env, assume_role, shared)
+    )
 
-    assert [p.name for p in ordered] == ["env", "shared", "static"]
+    assert [p.name for p in ordered] == [
+        "env",
+        "shared",
+        "assume-role",
+        "session",
+        "static",
+    ]
 
 
 def test_sort_places_before_and_after_around_slot() -> None:

--- a/packages/smithy-aws-core/tests/unit/identity/chain/test_ordering.py
+++ b/packages/smithy-aws-core/tests/unit/identity/chain/test_ordering.py
@@ -98,13 +98,13 @@ def test_shared_config_detection(
             "aws-credentials-sts",
         ),
         (StandardProvider.SHARED_CONFIG, "SharedConfig", None),
-        (StandardProvider.PROFILE_SESSION_KEYS, "ProfileSessionKeys", None),
-        (StandardProvider.PROFILE_STATIC_KEYS, "ProfileStaticKeys", None),
         (
             StandardProvider.PROFILE_ASSUME_ROLE,
             "ProfileAssumeRole",
             "aws-credentials-sts",
         ),
+        (StandardProvider.PROFILE_SESSION_KEYS, "ProfileSessionKeys", None),
+        (StandardProvider.PROFILE_STATIC_KEYS, "ProfileStaticKeys", None),
         (
             StandardProvider.PROFILE_WEB_IDENTITY,
             "ProfileWebIdentity",

--- a/packages/smithy-aws-core/tests/unit/identity/test_container.py
+++ b/packages/smithy-aws-core/tests/unit/identity/test_container.py
@@ -30,6 +30,10 @@ DEFAULT_RESPONSE_DATA = {
 
 ISO8601 = "%Y-%m-%dT%H:%M:%SZ"
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:`ContainerCredentialsResolver` is deprecated:DeprecationWarning"
+)
+
 
 def test_config_custom_values():
     config = ContainerCredentialsConfig(timeout=10, retries=5)

--- a/packages/smithy-aws-core/tests/unit/identity/test_imds.py
+++ b/packages/smithy-aws-core/tests/unit/identity/test_imds.py
@@ -19,6 +19,10 @@ from smithy_core import URI
 from smithy_core.aio.retries import SimpleRetryStrategy
 from smithy_http.aio import HTTPRequest
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:`IMDSCredentialsResolver` is deprecated:DeprecationWarning"
+)
+
 
 def test_config_defaults():
     config = Config()


### PR DESCRIPTION
### Description

This PR aligns credential resolution behavior with the modular credential chain spec changes:

- Resolves assume-role profiles before profile session or static keys.
- Defers profile key providers when the selected profile declares `role_arn`.
- Suppresses environment credentials when an explicit `profile_name` is provided.

This PR also deprecates the built-in IMDS and container resolvers in favor of `aws-credentials-imds` and `aws-credentials-http`.

### Testing
- Added unit coverage for the new precedence and deferment behavior.
- Confirmed new behavior with `aws-credentials-sts` package and `aws-sdk-sts` client

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
