### PR TITLE
Improve async AWS config typing and plugin lifecycle

### DIFF
--- a/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
+++ b/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
@@ -47,6 +47,13 @@ public class AwsCodegenTest {
         assertTrue(config.contains("api_key: str | None"));
         assertTrue(config.contains("@dataclass(kw_only=True, repr=False, init=False)"));
         assertTrue(config.contains("**overrides: Unpack["));
+        assertTrue(config.contains(
+                "interceptors: list[_ServiceInterceptor] = field(default_factory=lambda: [])"));
+        assertTrue(config.contains(
+                "def set_auth_scheme(self, scheme: AuthScheme[Any, Any, Any, Any]) -> None:"));
+        assertTrue(config.contains("auth_schemes = dict(self.auth_schemes or {})"));
+        assertTrue(config.contains("auth_schemes[scheme.scheme_id] = scheme"));
+        assertTrue(config.contains("self.auth_schemes = auth_schemes"));
 
         var client = Files.readString(tempDir.resolve("src/restjson/client.py"));
         var resolveConfig = "config = await AsyncRESTJSONConfig.resolve()";

--- a/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
+++ b/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
@@ -4,6 +4,10 @@
  */
 package software.amazon.smithy.python.codegen.test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -19,7 +23,7 @@ import software.amazon.smithy.python.codegen.PythonClientCodegenPlugin;
 public class AwsCodegenTest {
 
     @Test
-    public void testCodegen(@TempDir Path tempDir) {
+    public void testCodegen(@TempDir Path tempDir) throws IOException {
         PythonClientCodegenPlugin plugin = new PythonClientCodegenPlugin();
         Model model = Model.assembler(AwsCodegenTest.class.getClassLoader())
                 .discoverModels(AwsCodegenTest.class.getClassLoader())
@@ -36,6 +40,12 @@ public class AwsCodegenTest {
                 .model(model)
                 .build();
         plugin.execute(context);
+
+        var config = Files.readString(tempDir.resolve("src/restjson/config.py"));
+        assertTrue(config.contains("Overrides(AwsConfigOverrides, total=False):"));
+        assertTrue(config.contains("api_key: str | None"));
+        assertTrue(config.contains("@dataclass(kw_only=True, repr=False, init=False)"));
+        assertTrue(config.contains("**overrides: Unpack["));
     }
 
 }

--- a/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
+++ b/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
@@ -56,32 +56,16 @@ public class AwsCodegenTest {
         assertTrue(config.contains("self.auth_schemes = auth_schemes"));
 
         var client = Files.readString(tempDir.resolve("src/restjson/client.py"));
-        var resolveConfig = "config = await AsyncRESTJSONConfig.resolve()";
-        var applyServicePlugins = "for plugin in self._client_plugins:";
-        var applyConfiguredPlugins = "for plugin in self._plugins:";
-        var publishConfig = "self._config = config";
-        var checkOperationPlugins = "if operation_plugins:";
-        var copyOperationConfig = "config = deepcopy(self._config)";
-        var applyOperationPlugins = "for plugin in operation_plugins:";
-        var reuseBaseConfig = "config = self._config";
-
-        var resolveConfigIndex = client.indexOf(resolveConfig);
-        var applyServicePluginsIndex = client.indexOf(applyServicePlugins);
-        var applyConfiguredPluginsIndex = client.indexOf(applyConfiguredPlugins);
-        var publishConfigIndex = client.indexOf(publishConfig, applyConfiguredPluginsIndex);
-        var checkOperationPluginsIndex = client.indexOf(checkOperationPlugins, publishConfigIndex);
-        var copyOperationConfigIndex = client.indexOf(copyOperationConfig, checkOperationPluginsIndex);
-        var applyOperationPluginsIndex = client.indexOf(applyOperationPlugins, copyOperationConfigIndex);
-        var reuseBaseConfigIndex = client.indexOf(reuseBaseConfig, applyOperationPluginsIndex);
-
-        assertTrue(resolveConfigIndex >= 0);
-        assertTrue(resolveConfigIndex < applyServicePluginsIndex);
-        assertTrue(applyServicePluginsIndex < applyConfiguredPluginsIndex);
-        assertTrue(applyConfiguredPluginsIndex < publishConfigIndex);
-        assertTrue(publishConfigIndex < checkOperationPluginsIndex);
-        assertTrue(checkOperationPluginsIndex < copyOperationConfigIndex);
-        assertTrue(copyOperationConfigIndex < applyOperationPluginsIndex);
-        assertTrue(applyOperationPluginsIndex < reuseBaseConfigIndex);
+        assertInOrder(
+                client,
+                "config = await AsyncRESTJSONConfig.resolve()",
+                "for plugin in self._client_plugins:",
+                "for plugin in self._plugins:",
+                "self._config = config",
+                "if operation_plugins:",
+                "config = deepcopy(self._config)",
+                "for plugin in operation_plugins:",
+                "config = self._config");
         assertFalse(client.contains("plugin(self._config)"));
         assertTrue(client.contains("retry_mode=config.retry_mode"));
         assertTrue(client.contains("max_attempts=config.max_attempts"));
@@ -89,4 +73,12 @@ public class AwsCodegenTest {
         assertFalse(client.contains("getattr(config, \"max_attempts\""));
     }
 
+    private static void assertInOrder(String value, String... fragments) {
+        var index = 0;
+        for (String fragment : fragments) {
+            index = value.indexOf(fragment, index);
+            assertTrue(index >= 0, "Missing or out-of-order fragment: " + fragment);
+            index += fragment.length();
+        }
+    }
 }

--- a/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
+++ b/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.python.codegen.test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -46,6 +47,33 @@ public class AwsCodegenTest {
         assertTrue(config.contains("api_key: str | None"));
         assertTrue(config.contains("@dataclass(kw_only=True, repr=False, init=False)"));
         assertTrue(config.contains("**overrides: Unpack["));
+
+        var client = Files.readString(tempDir.resolve("src/restjson/client.py"));
+        var resolveConfig = "config = await AsyncRESTJSONConfig.resolve()";
+        var applyServicePlugins = "for plugin in self._client_plugins:";
+        var applyConfiguredPlugins = "for plugin in self._plugins:";
+        var publishConfig = "self._config = config";
+        var copyOperationConfig = "config = deepcopy(self._config)";
+        var applyOperationPlugins = "for plugin in operation_plugins:";
+
+        var resolveConfigIndex = client.indexOf(resolveConfig);
+        var applyServicePluginsIndex = client.indexOf(applyServicePlugins);
+        var applyConfiguredPluginsIndex = client.indexOf(applyConfiguredPlugins);
+        var publishConfigIndex = client.indexOf(publishConfig, applyConfiguredPluginsIndex);
+        var copyOperationConfigIndex = client.indexOf(copyOperationConfig, publishConfigIndex);
+        var applyOperationPluginsIndex = client.indexOf(applyOperationPlugins, copyOperationConfigIndex);
+
+        assertTrue(resolveConfigIndex >= 0);
+        assertTrue(resolveConfigIndex < applyServicePluginsIndex);
+        assertTrue(applyServicePluginsIndex < applyConfiguredPluginsIndex);
+        assertTrue(applyConfiguredPluginsIndex < publishConfigIndex);
+        assertTrue(publishConfigIndex < copyOperationConfigIndex);
+        assertTrue(copyOperationConfigIndex < applyOperationPluginsIndex);
+        assertFalse(client.contains("plugin(self._config)"));
+        assertTrue(client.contains("retry_mode=config.retry_mode"));
+        assertTrue(client.contains("max_attempts=config.max_attempts"));
+        assertFalse(client.contains("getattr(config, \"retry_mode\""));
+        assertFalse(client.contains("getattr(config, \"max_attempts\""));
     }
 
 }

--- a/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
+++ b/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
@@ -60,22 +60,28 @@ public class AwsCodegenTest {
         var applyServicePlugins = "for plugin in self._client_plugins:";
         var applyConfiguredPlugins = "for plugin in self._plugins:";
         var publishConfig = "self._config = config";
+        var checkOperationPlugins = "if operation_plugins:";
         var copyOperationConfig = "config = deepcopy(self._config)";
         var applyOperationPlugins = "for plugin in operation_plugins:";
+        var reuseBaseConfig = "config = self._config";
 
         var resolveConfigIndex = client.indexOf(resolveConfig);
         var applyServicePluginsIndex = client.indexOf(applyServicePlugins);
         var applyConfiguredPluginsIndex = client.indexOf(applyConfiguredPlugins);
         var publishConfigIndex = client.indexOf(publishConfig, applyConfiguredPluginsIndex);
-        var copyOperationConfigIndex = client.indexOf(copyOperationConfig, publishConfigIndex);
+        var checkOperationPluginsIndex = client.indexOf(checkOperationPlugins, publishConfigIndex);
+        var copyOperationConfigIndex = client.indexOf(copyOperationConfig, checkOperationPluginsIndex);
         var applyOperationPluginsIndex = client.indexOf(applyOperationPlugins, copyOperationConfigIndex);
+        var reuseBaseConfigIndex = client.indexOf(reuseBaseConfig, applyOperationPluginsIndex);
 
         assertTrue(resolveConfigIndex >= 0);
         assertTrue(resolveConfigIndex < applyServicePluginsIndex);
         assertTrue(applyServicePluginsIndex < applyConfiguredPluginsIndex);
         assertTrue(applyConfiguredPluginsIndex < publishConfigIndex);
-        assertTrue(publishConfigIndex < copyOperationConfigIndex);
+        assertTrue(publishConfigIndex < checkOperationPluginsIndex);
+        assertTrue(checkOperationPluginsIndex < copyOperationConfigIndex);
         assertTrue(copyOperationConfigIndex < applyOperationPluginsIndex);
+        assertTrue(applyOperationPluginsIndex < reuseBaseConfigIndex);
         assertFalse(client.contains("plugin(self._config)"));
         assertTrue(client.contains("retry_mode=config.retry_mode"));
         assertTrue(client.contains("max_attempts=config.max_attempts"));

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAsyncConfigIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAsyncConfigIntegration.java
@@ -161,6 +161,7 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
             writer.addStdlibImport("typing", "Self");
             writer.addStdlibImport("typing", "Unpack");
             writer.addStdlibImport("dataclasses", "dataclass");
+            writer.addStdlibImport("dataclasses", "field");
 
             writer.write("");
             writer.write("");
@@ -199,6 +200,12 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
 
             writer.write("protocol: $T | None = None", protocolSymbol);
             writer.writeDocs("The protocol to serialize and deserialize requests with.", context);
+            writer.write("");
+
+            writer.write("interceptors: list[_ServiceInterceptor] = field(default_factory=lambda: [])");
+            writer.writeDocs(
+                    "The list of interceptors, which are hooks that are called during the execution of a request.",
+                    context);
             writer.write("");
 
             if (hasAuth) {
@@ -305,6 +312,20 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
 
             writer.closeBlock("}");
             writer.write("");
+            if (hasAuth) {
+                writer.write("def set_auth_scheme(self, scheme: $T) -> None:", authSchemeSymbol);
+                writer.indent();
+                writer.writeDocs("""
+                        Set an auth scheme implementation using its scheme ID.
+
+                        :param scheme: The auth scheme to add or replace.
+                        """, context);
+                writer.write("auth_schemes = dict(self.auth_schemes or {})");
+                writer.write("auth_schemes[scheme.scheme_id] = scheme");
+                writer.write("self.auth_schemes = auth_schemes");
+                writer.dedent();
+                writer.write("");
+            }
             writer.write("@classmethod");
             writer.write("async def resolve(  # pyright: ignore[reportIncompatibleMethodOverride]");
             writer.indent();

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAsyncConfigIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAsyncConfigIntegration.java
@@ -4,9 +4,10 @@
  */
 package software.amazon.smithy.python.aws.codegen;
 
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.knowledge.EventStreamIndex;
@@ -34,6 +35,30 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public class AwsAsyncConfigIntegration implements PythonIntegration {
+    // Fields the overrides TypedDict already gets from its base or from this file, so a
+    // same-named plugin ConfigProperty must not be re-emitted (see pluginProperties loop).
+    // Hand-synced, no cross-language guard: the base fields mirror AwsConfigOverrides /
+    // AsyncAwsConfig._FIELDS in smithy-aws-core's config/aws_config.py (update here when
+    // those change); the last four are the codegen-managed fields written below.
+    private static final Set<String> PREDEFINED_CONFIG_FIELDS = Set.of(
+            "region",
+            "retry_mode",
+            "max_attempts",
+            "endpoint_uri",
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+            "aws_credentials_identity_resolver",
+            "sdk_ua_app_id",
+            "user_agent_extra",
+            "interceptors",
+            "http_request_config",
+            "transport",
+            "retry_strategy",
+            "endpoint_resolver",
+            "protocol",
+            "auth_schemes",
+            "auth_scheme_resolver");
 
     @Override
     public List<? extends CodeInterceptor<? extends CodeSection, PythonWriter>> interceptors(
@@ -77,29 +102,91 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
                     .map(ServiceTrait::getSdkId)
                     .orElse(context.settings().service().getName());
 
-            // Import AsyncAwsConfig base class
+            var serviceIndex = ServiceIndex.of(context.model());
+            var hasAuth = !serviceIndex.getAuthSchemes(context.settings().service()).isEmpty();
+            // Multiple plugins can contribute the same property. Preserve the first
+            // declaration, matching the previous generated field behavior.
+            var pluginProperties = new LinkedHashMap<String, ConfigProperty>();
+            for (PythonIntegration integration : context.integrations()) {
+                for (RuntimeClientPlugin plugin : integration.getClientPlugins(context)) {
+                    if (plugin.matchesService(model, service)) {
+                        for (ConfigProperty property : plugin.getConfigProperties()) {
+                            pluginProperties.putIfAbsent(property.name(), property);
+                        }
+                    }
+                }
+            }
+
             var asyncAwsConfigSymbol = Symbol.builder()
                     .name("AsyncAwsConfig")
                     .namespace("smithy_aws_core.config.aws_config", ".")
                     .addDependency(AwsPythonDependency.SMITHY_AWS_CORE)
                     .build();
-
-            // Import FieldSpec and ClassVar
+            var awsConfigOverridesSymbol = Symbol.builder()
+                    .name("AwsConfigOverrides")
+                    .namespace("smithy_aws_core.config", ".")
+                    .addDependency(AwsPythonDependency.SMITHY_AWS_CORE)
+                    .build();
+            var fileSystemSymbol = Symbol.builder()
+                    .name("FileSystem")
+                    .namespace("smithy_aws_core.config", ".")
+                    .addDependency(AwsPythonDependency.SMITHY_AWS_CORE)
+                    .build();
             var fieldSpecSymbol = Symbol.builder()
                     .name("FieldSpec")
                     .namespace("smithy_aws_core.config.types", ".")
                     .addDependency(AwsPythonDependency.SMITHY_AWS_CORE)
                     .build();
+            var protocolSymbol = Symbol.builder()
+                    .name("ClientProtocol[Any, Any]")
+                    .addReference(Symbol.builder()
+                            .name("ClientProtocol")
+                            .namespace("smithy_core.aio.interfaces", ".")
+                            .addDependency(SmithyPythonDependency.SMITHY_CORE)
+                            .build())
+                    .build();
+            var authSchemeSymbol = Symbol.builder()
+                    .name("AuthScheme[Any, Any, Any, Any]")
+                    .addReference(Symbol.builder()
+                            .name("AuthScheme")
+                            .namespace("smithy_core.aio.interfaces.auth", ".")
+                            .addDependency(SmithyPythonDependency.SMITHY_CORE)
+                            .build())
+                    .build();
+            var authSchemeResolverSymbol = CodegenUtils.getHttpAuthSchemeResolverSymbol(context.settings());
+            var overridesTypeName = "_" + asyncConfigSymbol.getName() + "Overrides";
+
             writer.addStdlibImport("typing", "ClassVar");
             writer.addStdlibImport("typing", "Any");
+            writer.addStdlibImport("typing", "Self");
+            writer.addStdlibImport("typing", "Unpack");
             writer.addStdlibImport("dataclasses", "dataclass");
 
             writer.write("");
             writer.write("");
+            writer.openBlock("class $L($T, total=False):", overridesTypeName, awsConfigOverridesSymbol);
+            writer.write("endpoint_resolver: $T | None", RuntimeTypes.ENDPOINT_RESOLVER);
+            writer.write("protocol: $T | None", protocolSymbol);
+            if (hasAuth) {
+                writer.write("auth_schemes: dict[$T, $T] | None",
+                        RuntimeTypes.SHAPE_ID,
+                        authSchemeSymbol);
+                writer.write("auth_scheme_resolver: $T | None", authSchemeResolverSymbol);
+            }
+            for (ConfigProperty property : pluginProperties.values()) {
+                if (!PREDEFINED_CONFIG_FIELDS.contains(property.name())) {
+                    // Always nullable to match the dataclass field and FieldSpec below,
+                    // both of which are unconditionally "<T> | None = None".
+                    writer.write("$L: $T | None", property.name(), property.type());
+                }
+            }
+            writer.closeBlock("");
+            writer.write("");
+
             // repr=False is required: AsyncAwsConfig defines a __repr__ that filters out
             // credential fields, and a generated __repr__ on this subclass would shadow it
             // and leak secrets.
-            writer.write("@dataclass(kw_only=True, repr=False)");
+            writer.write("@dataclass(kw_only=True, repr=False, init=False)");
             writer.openBlock("class $L($T):", asyncConfigSymbol.getName(), asyncAwsConfigSymbol);
             writer.writeDocs(serviceId + " configuration (async-resolved).", context);
             writer.write("");
@@ -110,61 +197,28 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
                     + "based on the configuration.", context);
             writer.write("");
 
-            writer.write("protocol: $T | None = None",
-                    Symbol.builder()
-                            .name("ClientProtocol[Any, Any]")
-                            .addReference(Symbol.builder()
-                                    .name("ClientProtocol")
-                                    .namespace("smithy_core.aio.interfaces", ".")
-                                    .addDependency(SmithyPythonDependency.SMITHY_CORE)
-                                    .build())
-                            .build());
+            writer.write("protocol: $T | None = None", protocolSymbol);
             writer.writeDocs("The protocol to serialize and deserialize requests with.", context);
             writer.write("");
-
-            var serviceIndex = ServiceIndex.of(context.model());
-            var hasAuth = !serviceIndex.getAuthSchemes(context.settings().service()).isEmpty();
 
             if (hasAuth) {
                 writer.write("auth_schemes: dict[$T, $T] | None = None",
                         RuntimeTypes.SHAPE_ID,
-                        Symbol.builder()
-                                .name("AuthScheme[Any, Any, Any, Any]")
-                                .addReference(Symbol.builder()
-                                        .name("AuthScheme")
-                                        .namespace("smithy_core.aio.interfaces.auth", ".")
-                                        .addDependency(SmithyPythonDependency.SMITHY_CORE)
-                                        .build())
-                                .build());
+                        authSchemeSymbol);
                 writer.writeDocs("A map of auth scheme ids to auth schemes.", context);
                 writer.write("");
 
-                writer.write("auth_scheme_resolver: $T | None = None",
-                        CodegenUtils.getHttpAuthSchemeResolverSymbol(context.settings()));
+                writer.write("auth_scheme_resolver: $T | None = None", authSchemeResolverSymbol);
                 writer.writeDocs("An auth scheme resolver that determines the auth scheme "
                         + "for each operation.", context);
                 writer.write("");
             }
 
             // Plugin-contributed field declarations (e.g., api_key for @httpApiKeyAuth).
-            //
-            // More than one plugin can contribute the same property — region, for
-            // instance, comes from both the auth and regional-endpoints integrations
-            // — so track the names already written and emit each only once.
-            var writtenProperties = new LinkedHashSet<String>();
-            for (PythonIntegration integration : context.integrations()) {
-                for (RuntimeClientPlugin plugin : integration.getClientPlugins(context)) {
-                    if (plugin.matchesService(model, service)) {
-                        for (ConfigProperty property : plugin.getConfigProperties()) {
-                            if (!writtenProperties.add(property.name())) {
-                                continue;
-                            }
-                            writer.write("$L: $T | None = None", property.name(), property.type());
-                            writer.writeDocs(property.documentation(), context);
-                            writer.write("");
-                        }
-                    }
-                }
+            for (ConfigProperty property : pluginProperties.values()) {
+                writer.write("$L: $T | None = None", property.name(), property.type());
+                writer.writeDocs(property.documentation(), context);
+                writer.write("");
             }
 
             // Write _FIELDS class variable with service-specific defaults
@@ -175,7 +229,7 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
             // region, sdk_ua_app_id) — these are harmlessly overwritten by the spread
             // below. Fields unique to this service (e.g., api_key from @httpApiKeyAuth)
             // survive and participate in the resolution pipeline.
-            for (String propertyName : writtenProperties) {
+            for (String propertyName : pluginProperties.keySet()) {
                 writer.write("\"$L\": $T(default=None),", propertyName, fieldSpecSymbol);
             }
 
@@ -250,6 +304,33 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
             writer.write("),");
 
             writer.closeBlock("}");
+            writer.write("");
+            writer.write("@classmethod");
+            writer.write("async def resolve(  # pyright: ignore[reportIncompatibleMethodOverride]");
+            writer.indent();
+            writer.write("cls,");
+            writer.write("*,");
+            writer.write("profile: str | None = None,");
+            writer.write("fs: $T | None = None,", fileSystemSymbol);
+            writer.write("config_file_path: str | None = None,");
+            writer.write("credentials_file_path: str | None = None,");
+            writer.write("**overrides: Unpack[$L],", overridesTypeName);
+            writer.dedent();
+            writer.write(") -> Self:");
+            writer.indent();
+            writer.writeDocs(
+                    "Resolve config from environment, config files, defaults, and explicit overrides.",
+                    context);
+            writer.write("return await cls._resolve(");
+            writer.indent();
+            writer.write("profile=profile,");
+            writer.write("fs=fs,");
+            writer.write("config_file_path=config_file_path,");
+            writer.write("credentials_file_path=credentials_file_path,");
+            writer.write("overrides=overrides,");
+            writer.dedent();
+            writer.write(")");
+            writer.dedent();
             writer.closeBlock("");
         }
 

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAsyncConfigIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAsyncConfigIntegration.java
@@ -35,11 +35,8 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public class AwsAsyncConfigIntegration implements PythonIntegration {
-    // Fields the overrides TypedDict already gets from its base or from this file, so a
-    // same-named plugin ConfigProperty must not be re-emitted (see pluginProperties loop).
-    // Hand-synced, no cross-language guard: the base fields mirror AwsConfigOverrides /
-    // AsyncAwsConfig._FIELDS in smithy-aws-core's config/aws_config.py (update here when
-    // those change); the last four are the codegen-managed fields written below.
+    // Keep base fields synchronized with AwsConfigOverrides. The remaining fields are
+    // generated explicitly below.
     private static final Set<String> PREDEFINED_CONFIG_FIELDS = Set.of(
             "region",
             "retry_mode",
@@ -104,8 +101,7 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
 
             var serviceIndex = ServiceIndex.of(context.model());
             var hasAuth = !serviceIndex.getAuthSchemes(context.settings().service()).isEmpty();
-            // Multiple plugins can contribute the same property. Preserve the first
-            // declaration, matching the previous generated field behavior.
+            // Preserve the first declaration when plugins contribute duplicate properties.
             var pluginProperties = new LinkedHashMap<String, ConfigProperty>();
             for (PythonIntegration integration : context.integrations()) {
                 for (RuntimeClientPlugin plugin : integration.getClientPlugins(context)) {
@@ -176,8 +172,7 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
             }
             for (ConfigProperty property : pluginProperties.values()) {
                 if (!PREDEFINED_CONFIG_FIELDS.contains(property.name())) {
-                    // Always nullable to match the dataclass field and FieldSpec below,
-                    // both of which are unconditionally "<T> | None = None".
+                    // Match the nullable dataclass field and FieldSpec below.
                     writer.write("$L: $T | None", property.name(), property.type());
                 }
             }

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAuthIntegration.java
@@ -79,7 +79,7 @@ public class AwsAuthIntegration implements PythonIntegration {
                         .addConfigProperty(ConfigProperty.builder()
                                 .name("aws_session_token")
                                 .type(Symbol.builder().name("str").build())
-                                .documentation("An access key ID that identifies temporary security credentials.")
+                                .documentation("The session token used with temporary AWS credentials.")
                                 .nullable(true)
                                 .build())
                         .authScheme(new Sigv4AuthScheme())

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/customizations/apigateway/ApiGatewayIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/customizations/apigateway/ApiGatewayIntegration.java
@@ -100,7 +100,8 @@ public class ApiGatewayIntegration implements PythonIntegration {
                                                         httpRequest,
                                                         requestContext,
                                                         field,
-                                                        CodegenUtils.getConfigSymbol(c.settings()));
+                                                        CodegenUtils.getAsyncConfigSymbol(c.settings(), c.model())
+                                                                .orElseThrow());
                                             });
                             return List.of(filename);
                         })

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/customizations/dynamodb/AwsDynamoDbRetryIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/customizations/dynamodb/AwsDynamoDbRetryIntegration.java
@@ -10,6 +10,7 @@ import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.python.aws.codegen.AwsPythonDependency;
+import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.GenerationContext;
 import software.amazon.smithy.python.codegen.SmithyPythonDependency;
 import software.amazon.smithy.python.codegen.integrations.PythonIntegration;
@@ -29,11 +30,7 @@ public final class AwsDynamoDbRetryIntegration implements PythonIntegration {
             _DYNAMODB_DEFAULT_MAX_BACKOFF = 20
 
 
-            class _RetryConfig(Protocol):
-                retry_strategy: $1T | $2T | None
-
-
-            def dynamodb_retry_plugin(config: _RetryConfig) -> None:
+            def dynamodb_retry_plugin(config: $1T) -> None:
                 \"\"\"Apply DynamoDB's standard-mode retry defaults for any option left unset.\"\"\"
                 retry_strategy = config.retry_strategy
                 if retry_strategy is not None and not isinstance(
@@ -46,15 +43,10 @@ public final class AwsDynamoDbRetryIntegration implements PythonIntegration {
                     retry_mode = retry_strategy.retry_mode
                     max_attempts = retry_strategy.max_attempts
                 else:
-                    # Read independently resolved AsyncConfig fields when available. A legacy
-                    # Config has no scalar retry fields, so None represents an unset value.
-                    retry_mode = getattr(config, "retry_mode", None) or "standard"
-                    max_attempts = getattr(config, "max_attempts", None)
-                    source_of = getattr(config, "source_of", None)
-                    if (
-                        source_of is not None
-                        and source_of("max_attempts") == $4T.DEFAULT
-                    ):
+                    # Fall back to the config's independently resolved retry fields.
+                    retry_mode = config.retry_mode or "standard"
+                    max_attempts = config.max_attempts
+                    if config.source_of("max_attempts") == $4T.DEFAULT:
                         max_attempts = None
 
                 if retry_mode != "standard":
@@ -85,10 +77,6 @@ public final class AwsDynamoDbRetryIntegration implements PythonIntegration {
                         .definitionFile(String.format("./src/%s/%s.py", moduleName, pluginFile))
                         .name("dynamodb_retry_plugin")
                         .build())
-                .build();
-        final Symbol retryStrategy = Symbol.builder()
-                .namespace("smithy_core.aio.interfaces.retries", ".")
-                .name("RetryStrategy")
                 .build();
         final Symbol retryStrategyOptions = Symbol.builder()
                 .namespace("smithy_core.retries", ".")
@@ -126,10 +114,10 @@ public final class AwsDynamoDbRetryIntegration implements PythonIntegration {
                                             writer -> {
                                                 writer.addDependency(SmithyPythonDependency.SMITHY_CORE);
                                                 writer.addDependency(AwsPythonDependency.SMITHY_AWS_CORE);
-                                                writer.addStdlibImport("typing", "Protocol");
                                                 writer.write(
                                                         DYNAMODB_RETRY_MODULE,
-                                                        retryStrategy,
+                                                        CodegenUtils.getAsyncConfigSymbol(c.settings(), c.model())
+                                                                .orElseThrow(),
                                                         retryStrategyOptions,
                                                         standardRetryStrategy,
                                                         configSource,

--- a/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
@@ -4,6 +4,10 @@
  */
 package software.amazon.smithy.python.codegen.test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -20,7 +24,7 @@ import software.amazon.smithy.python.codegen.PythonClientCodegenPlugin;
 public class PythonCodegenTest {
 
     @Test
-    public void testCodegen(@TempDir Path tempDir) {
+    public void testCodegen(@TempDir Path tempDir) throws IOException {
         // TODO: Move this to its own package once client codegen is in its own package
         PythonClientCodegenPlugin plugin = new PythonClientCodegenPlugin();
         Model model = Model.assembler(PythonCodegenTest.class.getClassLoader())
@@ -38,5 +42,11 @@ public class PythonCodegenTest {
                 .model(model)
                 .build();
         plugin.execute(context);
+
+        var client = Files.readString(tempDir.resolve("src/weather/client.py"));
+        assertFalse(client.contains("retry_mode=config.retry_mode"));
+        assertFalse(client.contains("max_attempts=config.max_attempts"));
+        assertFalse(client.contains("getattr(config, \"retry_mode\""));
+        assertFalse(client.contains("getattr(config, \"max_attempts\""));
     }
 }

--- a/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
@@ -44,9 +44,7 @@ public class PythonCodegenTest {
         plugin.execute(context);
 
         var client = Files.readString(tempDir.resolve("src/weather/client.py"));
-        assertFalse(client.contains("retry_mode=config.retry_mode"));
-        assertFalse(client.contains("max_attempts=config.max_attempts"));
-        assertFalse(client.contains("getattr(config, \"retry_mode\""));
-        assertFalse(client.contains("getattr(config, \"max_attempts\""));
+        assertFalse(client.contains("retry_mode="));
+        assertFalse(client.contains("max_attempts="));
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -251,9 +251,10 @@ final class ClientGenerator implements Runnable {
                         input:
                             $L
                         plugins:
-                            A list of callables applied to a copy of the configuration for this
-                            invocation. Their changes do not affect the client's base
-                            configuration or any other operation invocation.
+                            A list of callables that modify the configuration dynamically.
+                            Changes made by these plugins only apply for the duration of the
+                            operation execution and will not affect any other operation
+                            invocations.
 
                     Returns:
                         ${L|}

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -66,7 +66,8 @@ final class ClientGenerator implements Runnable {
             // the rest keep the synchronous constructor with old Config.
             var asyncConfigSymbol = CodegenUtils.getAsyncConfigSymbol(context.settings(), context.model());
 
-            // Collect service-scoped plugins (stored in __init__, applied per-call).
+            // Collect service-scoped plugins. They are applied once to the base
+            // config, which is copied for every operation invocation.
             var servicePlugins = new LinkedHashSet<SymbolReference>();
             for (PythonIntegration integration : context.integrations()) {
                 for (RuntimeClientPlugin runtimeClientPlugin : integration.getClientPlugins(context)) {
@@ -76,60 +77,59 @@ final class ClientGenerator implements Runnable {
                 }
             }
 
-            if (asyncConfigSymbol.isPresent()) {
-                writer.addStdlibImport("asyncio");
+            // The config is resolved lazily on first use so plugins are applied
+            // exactly once, after the config exists. Async services await a
+            // resolver; the rest construct the synchronous Config directly.
+            var isAsyncConfig = asyncConfigSymbol.isPresent();
+            var configSym = asyncConfigSymbol.orElse(configSymbol);
+            writer.addStdlibImport("asyncio");
+            writer.addStdlibImport("copy", "deepcopy");
 
-                writer.write("""
-                        def __init__(
-                            self,
-                            config: $1T | None = None,
-                            plugins: list[$2T] | None = None,
-                        ):
-                            ${3C|}
-                            self._config = config
-                            self._plugins = plugins
-                            self._derive_lock = asyncio.Lock()
-                            self._retry_strategy_resolver = $4T()
-                            self._client_plugins: list[$2T] = [
-                                ${5C|}
-                            ]
+            writer.write("""
+                    def __init__(
+                        self,
+                        config: $1T | None = None,
+                        plugins: list[$2T] | None = None,
+                    ):
+                        ${3C|}
+                        self._config = config
+                        self._plugins = plugins
+                        self._derive_lock = asyncio.Lock()
+                        self._setup_done = False
+                        self._retry_strategy_resolver = $4T()
+                        self._client_plugins: list[$2T] = [
+                            ${5C|}
+                        ]
 
-                        async def _ensure_setup(self) -> None:
-                            if self._config is None:
-                                async with self._derive_lock:
+                    async def _ensure_setup(self) -> None:
+                        if not self._setup_done:
+                            async with self._derive_lock:
+                                if not self._setup_done:
                                     if self._config is None:
-                                        self._config = await $1T.resolve()
-                        """,
-                        asyncConfigSymbol.get(),
-                        pluginSymbol,
-                        writer.consumer(w -> writeConstructorDocs(w, serviceSymbol.getName())),
-                        RuntimeTypes.RETRY_STRATEGY_RESOLVER,
-                        writer.consumer(w -> writeDefaultPlugins(w, servicePlugins)));
-            } else {
-
-                writer.write("""
-                        def __init__(
-                            self,
-                            config: $1T | None = None,
-                            plugins: list[$2T] | None = None,
-                        ):
-                            ${3C|}
-                            self._config = config or $1T()
-                            self._plugins = plugins
-                            self._retry_strategy_resolver = $4T()
-                            self._client_plugins: list[$2T] = [
-                                ${5C|}
-                            ]
-
-                        async def _ensure_setup(self) -> None:
-                            pass
-                        """,
-                        configSymbol,
-                        pluginSymbol,
-                        writer.consumer(w -> writeConstructorDocs(w, serviceSymbol.getName())),
-                        RuntimeTypes.RETRY_STRATEGY_RESOLVER,
-                        writer.consumer(w -> writeDefaultPlugins(w, servicePlugins)));
-            }
+                                        ${6C|}
+                                    else:
+                                        # Copy so plugins don't mutate the caller's config.
+                                        config = deepcopy(self._config)
+                                    for plugin in self._client_plugins:
+                                        plugin(config)
+                                    if self._plugins:
+                                        for plugin in self._plugins:
+                                            plugin(config)
+                                    self._config = config
+                                    self._setup_done = True
+                    """,
+                    configSym,
+                    pluginSymbol,
+                    writer.consumer(w -> writeConstructorDocs(w, serviceSymbol.getName())),
+                    RuntimeTypes.RETRY_STRATEGY_RESOLVER,
+                    writer.consumer(w -> writeDefaultPlugins(w, servicePlugins)),
+                    writer.consumer(w -> {
+                        if (isAsyncConfig) {
+                            w.write("config = await $T.resolve()", configSym);
+                        } else {
+                            w.write("config = $T()", configSym);
+                        }
+                    }));
 
             var topDownIndex = TopDownIndex.of(model);
             var eventStreamIndex = EventStreamIndex.of(model);
@@ -184,8 +184,8 @@ final class ClientGenerator implements Runnable {
                             Optional configuration for the client. Here you can set things like
                             the endpoint for HTTP services or auth credentials.
                         plugins:
-                            A list of callables that modify the configuration dynamically. These
-                            can be used to set defaults, for example.
+                            A list of callables applied once to the client's base configuration.
+                            Their changes are inherited by every operation invocation.
                     """, clientName);
         });
     }
@@ -251,10 +251,9 @@ final class ClientGenerator implements Runnable {
                         input:
                             $L
                         plugins:
-                            A list of callables that modify the configuration dynamically.
-                            Changes made by these plugins only apply for the duration of the
-                            operation execution and will not affect any other operation
-                            invocations.
+                            A list of callables applied to a copy of the configuration for this
+                            invocation. Their changes do not affect the client's base
+                            configuration or any other operation invocation.
 
                     Returns:
                         ${L|}
@@ -282,17 +281,11 @@ final class ClientGenerator implements Runnable {
                         ]
                         if plugins:
                             operation_plugins.extend(plugins)
-                        # deepcopy keeps plugin mutations (e.g. appending interceptors) scoped to
-                        # this call, so applying client_plugins per-call cannot accumulate on the
-                        # shared config.
                         await self._ensure_setup()
                         assert self._config is not None
+                        # deepcopy keeps operation-plugin mutations (e.g. appending
+                        # interceptors) scoped to this call.
                         config = deepcopy(self._config)
-                        for plugin in self._client_plugins:
-                            plugin(config)
-                        if self._plugins:
-                            for plugin in self._plugins:
-                                plugin(config)
                         for plugin in operation_plugins:
                             plugin(config)
                         if (
@@ -309,8 +302,7 @@ final class ClientGenerator implements Runnable {
 
                         retry_strategy = await self._retry_strategy_resolver.resolve_retry_strategy(
                             retry_strategy=config.retry_strategy,
-                            retry_mode=getattr(config, "retry_mode", None),
-                            max_attempts=getattr(config, "max_attempts", None),
+                            ${7C|}
                         )
 
                         pipeline = $3T(
@@ -333,7 +325,13 @@ final class ClientGenerator implements Runnable {
                 RuntimeTypes.REQUEST_PIPELINE,
                 RuntimeTypes.CLIENT_CALL,
                 RuntimeTypes.TYPED_PROPERTIES,
-                RuntimeTypes.INTERCEPTOR_CHAIN);
+                RuntimeTypes.INTERCEPTOR_CHAIN,
+                writer.consumer(w -> {
+                    if (CodegenUtils.getAsyncConfigSymbol(context.settings(), context.model()).isPresent()) {
+                        w.write("retry_mode=config.retry_mode,");
+                        w.write("max_attempts=config.max_attempts,");
+                    }
+                }));
 
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -284,11 +284,13 @@ final class ClientGenerator implements Runnable {
                             operation_plugins.extend(plugins)
                         await self._ensure_setup()
                         assert self._config is not None
-                        # deepcopy keeps operation-plugin mutations (e.g. appending
-                        # interceptors) scoped to this call.
-                        config = deepcopy(self._config)
-                        for plugin in operation_plugins:
-                            plugin(config)
+                        if operation_plugins:
+                            # Keep operation-plugin mutations scoped to this call.
+                            config = deepcopy(self._config)
+                            for plugin in operation_plugins:
+                                plugin(config)
+                        else:
+                            config = self._config
                         if (
                             config.protocol is None
                             or config.transport is None

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -66,8 +66,7 @@ final class ClientGenerator implements Runnable {
             // the rest keep the synchronous constructor with old Config.
             var asyncConfigSymbol = CodegenUtils.getAsyncConfigSymbol(context.settings(), context.model());
 
-            // Collect service-scoped plugins. They are applied once to the base
-            // config, which is copied for every operation invocation.
+            // Collect service-scoped plugins applied once during setup.
             var servicePlugins = new LinkedHashSet<SymbolReference>();
             for (PythonIntegration integration : context.integrations()) {
                 for (RuntimeClientPlugin runtimeClientPlugin : integration.getClientPlugins(context)) {
@@ -77,9 +76,7 @@ final class ClientGenerator implements Runnable {
                 }
             }
 
-            // The config is resolved lazily on first use so plugins are applied
-            // exactly once, after the config exists. Async services await a
-            // resolver; the rest construct the synchronous Config directly.
+            // Resolve or construct the config lazily before applying plugins once.
             var isAsyncConfig = asyncConfigSymbol.isPresent();
             var configSym = asyncConfigSymbol.orElse(configSymbol);
             writer.addStdlibImport("asyncio");

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -300,7 +300,11 @@ public final class ConfigGenerator implements Runnable {
             } else {
                 writer.write("$L: TypeAlias = Callable[[$T], None]", plugin.getName(), config);
             }
-            writer.writeDocs("A callable that allows customizing the config object on each request.", context);
+            writer.writeDocs("""
+                    A callable that customizes a client configuration. Service-level plugins are
+                    applied once to the base configuration inherited by every operation.
+                    Operation-level plugins apply only to a single operation invocation.
+                    """, context);
         });
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -367,66 +367,28 @@ public final class ConfigGenerator implements Runnable {
         writer.pushState(new ConfigSection(finalProperties));
         writer.addLocallyDefinedSymbol(configSymbol);
         writer.addStdlibImport("dataclasses", "dataclass");
-        // This class is only deprecated where an async replacement is generated to point
-        // at. For services without one it remains the supported config class.
-        var asyncConfigSymbol = CodegenUtils.getAsyncConfigSymbol(context.settings(), context.model());
-        if (asyncConfigSymbol.isPresent()) {
-            var asyncConfigName = asyncConfigSymbol.get().getName();
-            writer.addStdlibImport("warnings");
-            writer.write("""
-                    @dataclass(init=False)
-                    class $L:
-                        \"""Configuration for $L.
+        // Only reached for non-AWS services (run() gates this on getAsyncConfigSymbol()
+        // being empty), so this Config has no async replacement and is the supported
+        // config class rather than a deprecated shim.
+        writer.write("""
+                @dataclass(init=False)
+                class $L:
+                    \"""Configuration for $L.\"""
 
-                        .. deprecated::
-                            Use :class:`$L` with ``await $L.resolve()`` instead.
-                        \"""
+                    ${C|}
 
+                    def __init__(
+                        self,
+                        *,
                         ${C|}
-
-                        def __init__(
-                            self,
-                            *,
-                            ${C|}
-                        ):
-                            warnings.warn(
-                                "$L is deprecated, use $L.resolve() instead. "
-                                "This class will be removed in a future version.",
-                                DeprecationWarning,
-                                stacklevel=2,
-                            )
-                            ${C|}
-                    """,
-                    configSymbol.getName(),
-                    serviceId,
-                    asyncConfigName,
-                    asyncConfigName,
-                    writer.consumer(w -> writePropertyDeclarations(w, finalProperties)),
-                    writer.consumer(w -> writeInitParams(w, finalProperties)),
-                    configSymbol.getName(),
-                    asyncConfigName,
-                    writer.consumer(w -> initializeProperties(w, finalProperties)));
-        } else {
-            writer.write("""
-                    @dataclass(init=False)
-                    class $L:
-                        \"""Configuration for $L.\"""
-
+                    ):
                         ${C|}
-
-                        def __init__(
-                            self,
-                            *,
-                            ${C|}
-                        ):
-                            ${C|}
-                    """,
-                    configSymbol.getName(),
-                    serviceId,
-                    writer.consumer(w -> writePropertyDeclarations(w, finalProperties)),
-                    writer.consumer(w -> writeInitParams(w, finalProperties)),
-                    writer.consumer(w -> initializeProperties(w, finalProperties)));
-        }
+                """,
+                configSymbol.getName(),
+                serviceId,
+                writer.consumer(w -> writePropertyDeclarations(w, finalProperties)),
+                writer.consumer(w -> writeInitParams(w, finalProperties)),
+                writer.consumer(w -> initializeProperties(w, finalProperties)));
         writer.popState();
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -270,15 +270,12 @@ public final class ConfigGenerator implements Runnable {
         context.writerDelegator().useFileWriter(config.getDefinitionFile(), config.getNamespace(), writer -> {
             writeInterceptorsType(writer);
 
-            // For AWS services, old Config is no longer generated — only the async
-            // config subclass (emitted by AwsAsyncConfigIntegration via section interceptor).
-            // For non-AWS services, generate old Config as usual.
+            // AWS services generate only the async config subclass.
             if (asyncConfigForPlugin.isEmpty()) {
                 generateConfig(context, writer);
             }
 
-            // Emit the async config section — AWS integrations intercept this
-            // to generate the service-specific async config subclass.
+            // AWS integrations intercept this section to emit the async config.
             writer.pushState(new AsyncConfigSection());
             writer.popState();
         });
@@ -287,8 +284,7 @@ public final class ConfigGenerator implements Runnable {
         // like have a class to implement, but that seems unnecessarily burdensome for
         // a single function.
         //
-        // For AWS services, the Plugin type accepts only the async config.
-        // For non-AWS services, the Plugin type accepts only Config.
+        // Plugins accept the config type generated for the service.
         var plugin = CodegenUtils.getPluginSymbol(context.settings());
         context.writerDelegator().useFileWriter(plugin.getDefinitionFile(), plugin.getNamespace(), writer -> {
             writer.addStdlibImport("typing", "Callable");
@@ -371,9 +367,7 @@ public final class ConfigGenerator implements Runnable {
         writer.pushState(new ConfigSection(finalProperties));
         writer.addLocallyDefinedSymbol(configSymbol);
         writer.addStdlibImport("dataclasses", "dataclass");
-        // Only reached for non-AWS services (run() gates this on getAsyncConfigSymbol()
-        // being empty), so this Config has no async replacement and is the supported
-        // config class rather than a deprecated shim.
+        // Only non-AWS services reach this path.
         writer.write("""
                 @dataclass(init=False)
                 class $L:

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/__init__.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from .aws_config import AsyncAwsConfig
+from .aws_config import AsyncAwsConfig, AwsConfigOverrides
 from .context import SharedConfigContext, load_config, shared_config_files_exist
 from .exceptions import (
     ConfigError,
@@ -15,6 +15,7 @@ from .types import ConfigSource
 
 __all__ = [
     "AsyncAwsConfig",
+    "AwsConfigOverrides",
     "ConfigError",
     "ConfigParseError",
     "ConfigSource",

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/aws_config.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/aws_config.py
@@ -1,14 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field, fields
-from typing import TYPE_CHECKING, Any, ClassVar, Self
+from typing import TYPE_CHECKING, Any, ClassVar, Self, TypedDict, Unpack
 
 from smithy_core.retries import RetryStrategyOptions
 
 if TYPE_CHECKING:
     from smithy_core.aio.interfaces import ClientTransport
     from smithy_core.aio.interfaces.identity import IdentityResolver
+    from smithy_core.aio.interfaces.retries import RetryStrategy
     from smithy_core.interfaces import URI
     from smithy_http.interfaces import HTTPRequestConfiguration
 
@@ -38,7 +40,28 @@ from .validators import (
 _CREDENTIAL_FIELDS = ("aws_access_key_id", "aws_secret_access_key", "aws_session_token")
 
 
-@dataclass(kw_only=True)
+class AwsConfigOverrides(TypedDict, total=False):
+    """Common keyword overrides accepted by AWS config resolution."""
+
+    region: str | None
+    retry_mode: str | None
+    max_attempts: int | None
+    endpoint_uri: "str | URI | None"
+    aws_access_key_id: str | None
+    aws_secret_access_key: str | None
+    aws_session_token: str | None
+    aws_credentials_identity_resolver: (
+        "IdentityResolver[AWSCredentialsIdentity, AWSIdentityProperties] | None"
+    )
+    sdk_ua_app_id: str | None
+    user_agent_extra: str | None
+    interceptors: list[Any]
+    http_request_config: "HTTPRequestConfiguration | None"
+    transport: "ClientTransport[Any, Any] | None"
+    retry_strategy: "RetryStrategy | RetryStrategyOptions | None"
+
+
+@dataclass(kw_only=True, init=False)
 class AsyncAwsConfig:
     """Base configuration class for all AWS services.
 
@@ -188,8 +211,8 @@ class AsyncAwsConfig:
         )
         return f"{type(self).__name__}({rendered})"
 
-    def __post_init__(self) -> None:
-        """Block direct construction. Use resolve() instead."""
+    def __init__(self) -> None:
+        """Block direct construction without advertising config fields as parameters."""
         raise ConfigError(
             f"{type(self).__name__} cannot be constructed directly. "
             f"Use `await {type(self).__name__}.resolve(...)` instead."
@@ -203,7 +226,7 @@ class AsyncAwsConfig:
         fs: FileSystem | None = None,
         config_file_path: str | None = None,
         credentials_file_path: str | None = None,
-        **overrides: Any,
+        **overrides: Unpack[AwsConfigOverrides],
     ) -> Self:
         """Resolve a config object from environment, config files, and defaults.
 
@@ -219,6 +242,25 @@ class AsyncAwsConfig:
             the ``AWS_PROFILE`` environment variable but is not defined in the
             config files.
         """
+        return await cls._resolve(
+            profile=profile,
+            fs=fs,
+            config_file_path=config_file_path,
+            credentials_file_path=credentials_file_path,
+            overrides=overrides,
+        )
+
+    @classmethod
+    async def _resolve(
+        cls,
+        *,
+        profile: str | None,
+        fs: FileSystem | None,
+        config_file_path: str | None,
+        credentials_file_path: str | None,
+        overrides: Mapping[str, object],
+    ) -> Self:
+        """Internal resolution entry point for generated typed config factories."""
         ctx = SharedConfigContext(
             profile_name=profile,
             fs=fs,
@@ -232,12 +274,12 @@ class AsyncAwsConfig:
             config_file = await ctx.parsed_profiles()
             validate_profile(ctx.profile_name, config_file.profiles, profile_origin)
 
-        # Create the instance bypassing __post_init__ check
+        # Create the instance without calling the blocked constructor
         instance = cls._create_instance()
         instance._ctx = ctx
 
         # Resolve each field
-        await instance._resolve_fields(overrides)
+        await instance._resolve_fields(dict(overrides))
 
         return instance
 

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/aws_config.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/aws_config.py
@@ -105,7 +105,11 @@ class AsyncAwsConfig:
     """
 
     aws_session_token: str | None = field(default=None, repr=False)
-    """An access key ID that identifies temporary security credentials."""
+    """The session token used with temporary AWS credentials.
+
+    Set this together with ``aws_access_key_id`` and ``aws_secret_access_key``
+    when supplying temporary credentials in code.
+    """
 
     aws_credentials_identity_resolver: "IdentityResolver[AWSCredentialsIdentity, AWSIdentityProperties] | None" = None
     """Resolves AWS Credentials.

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/aws_config.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/aws_config.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any, ClassVar, Self, TypedDict, Unpack
 
-from smithy_core.retries import RetryStrategyOptions
+from smithy_core.retries import RetryStrategyOptions, RetryStrategyType
 
 if TYPE_CHECKING:
     from smithy_core.aio.interfaces import ClientTransport
@@ -44,7 +44,7 @@ class AwsConfigOverrides(TypedDict, total=False):
     """Common keyword overrides accepted by AWS config resolution."""
 
     region: str | None
-    retry_mode: str | None
+    retry_mode: RetryStrategyType | None
     max_attempts: int | None
     endpoint_uri: "str | URI | None"
     aws_access_key_id: str | None
@@ -76,7 +76,7 @@ class AsyncAwsConfig:
     """The AWS region to connect to.
     """
 
-    retry_mode: str | None = None
+    retry_mode: RetryStrategyType | None = None
     """The retry mode to use. ``standard`` is the only accepted override.
 
     ``legacy`` and ``adaptive`` are rejected when set here; when they come from

--- a/packages/smithy-aws-core/src/smithy_aws_core/config/resolvers.py
+++ b/packages/smithy-aws-core/src/smithy_aws_core/config/resolvers.py
@@ -93,9 +93,6 @@ async def resolve_retry_mode(ctx: SharedConfigContext) -> Resolved[str | None]:
         profile_keys=("retry_mode",),
     )
 
-    if result.value is not UNSET:
-        result = Resolved(value=result.value.lower(), source=result.source)
-
     if result.value == "legacy":
         warnings.warn(
             "'legacy' retry mode is not supported, using 'standard' instead.",

--- a/packages/smithy-aws-core/tests/unit/config/test_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_resolver.py
@@ -9,10 +9,11 @@ provenance tracking, and precedence behavior.
 import os
 from copy import deepcopy
 from dataclasses import dataclass
+from inspect import signature
 from unittest.mock import patch
 
 import pytest
-from smithy_aws_core.config.aws_config import AsyncAwsConfig
+from smithy_aws_core.config.aws_config import AsyncAwsConfig, AwsConfigOverrides
 from smithy_aws_core.config.context import SharedConfigContext
 from smithy_aws_core.config.exceptions import (
     ConfigError,
@@ -335,11 +336,21 @@ class TestConstructionBlocking:
         with pytest.raises(ConfigError, match="cannot be constructed directly"):
             AsyncAwsConfig()
 
+    def test_direct_constructor_does_not_advertise_config_fields(self):
+        assert not signature(AsyncAwsConfig).parameters
+
+    def test_typed_overrides_cover_all_base_config_fields(self):
+        assert set(AwsConfigOverrides.__annotations__) == set(
+            AsyncAwsConfig._FIELDS  # pyright: ignore[reportPrivateUsage]
+        )
+
     @pytest.mark.asyncio
     async def test_unknown_override_field_raises_error(self):
         with patch.dict(os.environ, {"AWS_REGION": "us-east-1"}, clear=True):
             with pytest.raises(ConfigValidationError, match="Unknown config field"):
-                await AsyncAwsConfig.resolve(reigon="us-west-2")
+                await AsyncAwsConfig.resolve(
+                    reigon="us-west-2"  # pyright: ignore[reportCallIssue]
+                )
 
     @pytest.mark.parametrize(
         "field_name,invalid_value,match",
@@ -839,7 +850,7 @@ class TestReprDoesNotLeakSecrets:
         This mirrors what codegen emits for service-specific async configs.
         """
 
-        @dataclass(kw_only=True, repr=False)
+        @dataclass(kw_only=True, repr=False, init=False)
         class ServiceConfig(AsyncAwsConfig):
             aws_access_key_id: str | None = None
             aws_secret_access_key: str | None = None

--- a/packages/smithy-aws-core/tests/unit/config/test_resolver.py
+++ b/packages/smithy-aws-core/tests/unit/config/test_resolver.py
@@ -556,24 +556,6 @@ class TestResolveRetryMode:
             assert result.value == "standard"
             assert result.source == ConfigSource.ENV
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "env_value,expected",
-        [
-            ("STANDARD", "standard"),
-            ("Standard", "standard"),
-            ("LEGACY", "standard"),
-            ("Legacy", "standard"),
-            ("ADAPTIVE", "standard"),
-            ("Adaptive", "standard"),
-        ],
-    )
-    async def test_retry_mode_is_case_insensitive(self, env_value: str, expected: str):
-        with patch.dict(os.environ, {"AWS_RETRY_MODE": env_value}, clear=True):
-            ctx = SharedConfigContext(fs=NullFileSystem())
-            result = await resolve_retry_mode(ctx)
-            assert result.value == expected
-
 
 class TestResolveMaxAttempts:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Overview

This PR improves generated async AWS configuration typing and ensures client and operation plugins run at the correct
scope without mutating caller-owned configuration.

## Summary

- Add typed AWS and service-specific `resolve()` overrides using `TypedDict` and `Unpack`.
- Apply client plugins once during lazy setup; isolate operation plugins with a copy only when needed.
- Restore generated interceptor typing and `set_auth_scheme()`.
- Update API Gateway and DynamoDB plugins to use concrete async config types.
- Make retry-mode resolution case-sensitive and pass resolved retry fields directly.
- Improve constructor behavior, credential documentation, and generated-code coverage.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
