### PR TITLE
Remove misleading payload signing performance warnings

### DIFF
--- a/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-enhancement-3ca461cda8534d86bfbbf29d678ef76f.json
+++ b/packages/aws-sdk-signers/.changes/next-release/aws-sdk-signers-enhancement-3ca461cda8534d86bfbbf29d678ef76f.json
@@ -1,0 +1,4 @@
+{
+  "type": "enhancement",
+  "description": "Removed the `AWSSDKWarning` emitted during SigV4 payload signing. It fired on every signed request regardless of body size, adding noise on the default code path (and, under warnings-as-errors, could turn signing into a raised exception)."
+}

--- a/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
+++ b/packages/aws-sdk-signers/src/aws_sdk_signers/signers.py
@@ -5,7 +5,6 @@ import asyncio
 import datetime
 import hmac
 import io
-import warnings
 from binascii import hexlify
 from collections.abc import AsyncIterable, Iterable
 from copy import deepcopy
@@ -16,7 +15,7 @@ from urllib.parse import parse_qsl, quote
 
 from ._http import AWSRequest, Field, URI
 from ._io import AsyncBytesReader
-from .exceptions import AWSSDKWarning, MissingExpectedParameterException
+from .exceptions import MissingExpectedParameterException
 from .interfaces.identity import AWSCredentialsIdentity as _AWSCredentialsIdentity
 from .interfaces.io import AsyncSeekable, ConditionallySeekable, Seekable
 
@@ -399,12 +398,6 @@ class SigV4Signer:
                 "AsyncSigV4Signer for async AWSRequests or ensure your body is "
                 "of type Iterable[bytes]."
             )
-
-        warnings.warn(
-            "Payload signing is enabled. This may result in "
-            "decreased performance for large request bodies.",
-            AWSSDKWarning,
-        )
 
         checksum = sha256()
         if self._seekable(body):
@@ -791,12 +784,6 @@ class AsyncSigV4Signer:
                 "SigV4Signer for sync AWSRequests or ensure your body is "
                 "of type AsyncIterable[bytes]."
             )
-        warnings.warn(
-            "Payload signing is enabled. This may result in "
-            "decreased performance for large request bodies.",
-            AWSSDKWarning,
-        )
-
         checksum = sha256()
         if self._seekable(body):
             position = body.tell()

--- a/packages/aws-sdk-signers/tests/unit/auth/test_sigv4.py
+++ b/packages/aws-sdk-signers/tests/unit/auth/test_sigv4.py
@@ -17,7 +17,6 @@ from aws_sdk_signers import (
     Fields,
     URI,
 )
-from aws_sdk_signers.exceptions import AWSSDKWarning
 from aws_sdk_signers.signers import (
     SIGV4_TIMESTAMP_FORMAT,
     AsyncSigV4Signer,
@@ -103,21 +102,19 @@ def _test_signature_version_4_sync(test_case_name: str, signer: SigV4Signer) -> 
     signing_props = SigV4SigningProperties(
         region=REGION, service=SERVICE, date=DATE_STR
     )
-    with pytest.warns(AWSSDKWarning):
-        actual_canonical_request = signer.canonical_request(
-            signing_properties=signing_props, request=request
-        )
+    actual_canonical_request = signer.canonical_request(
+        signing_properties=signing_props, request=request
+    )
     assert test_case.canonical_request == actual_canonical_request
     actual_string_to_sign = signer.string_to_sign(
         canonical_request=actual_canonical_request, signing_properties=signing_props
     )
     assert test_case.string_to_sign == actual_string_to_sign
-    with pytest.warns(AWSSDKWarning):
-        signed_request = signer.sign(
-            properties=signing_props,
-            request=request,
-            identity=test_case.credentials,
-        )
+    signed_request = signer.sign(
+        properties=signing_props,
+        request=request,
+        identity=test_case.credentials,
+    )
     assert (
         signed_request.fields["Authorization"].as_string()
         == test_case.authorization_header
@@ -142,21 +139,19 @@ async def _test_signature_version_4_async(
         service=SERVICE,
         date=DATE_STR,
     )
-    with pytest.warns(AWSSDKWarning):
-        actual_canonical_request = await signer.canonical_request(
-            signing_properties=signing_props, request=request
-        )
+    actual_canonical_request = await signer.canonical_request(
+        signing_properties=signing_props, request=request
+    )
     assert test_case.canonical_request == actual_canonical_request
     actual_string_to_sign = await signer.string_to_sign(
         canonical_request=actual_canonical_request, signing_properties=signing_props
     )
     assert test_case.string_to_sign == actual_string_to_sign
-    with pytest.warns(AWSSDKWarning):
-        signed_request = await signer.sign(
-            properties=signing_props,
-            request=request,
-            identity=test_case.credentials,
-        )
+    signed_request = await signer.sign(
+        properties=signing_props,
+        request=request,
+        identity=test_case.credentials,
+    )
     assert (
         signed_request.fields["Authorization"].as_string()
         == test_case.authorization_header


### PR DESCRIPTION
## Summary

Remove `AWSSDKWarning` emissions from the synchronous and asynchronous SigV4 signers when hashing request payloads.

Payload signing is enabled by default, and the warning was emitted for every non-empty request body regardless of size. This made normal SDK operations, including small STS requests, produce a noisy and non-actionable warning.

Payload signing behavior remains unchanged and only the warning is removed. Tests are updated accordingly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
