### PR TITLE
codegen: default AWS clients to aiohttp and drop deprecated client aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+## v0.5.0
+
+### Breaking Changes
+
+* Removed the deprecated unprefixed aliases for generated AWS service clients.
+  Imports such as `BedrockRuntimeClient` must now use the `Async`-prefixed name,
+  such as `AsyncBedrockRuntimeClient`.
+* Changed all generated AWS clients to use `AIOHTTPClient` as their default
+  transport, including services configured for HTTP/2 or event streaming.
+  Applications that require the CRT transport, such as those using
+  bidirectional event streams, must install the generated client's `awscrt`
+  extra and explicitly configure `AWSCRTHTTPClient`.
+* Removed the legacy `Config` class from generated AWS clients in favor of the
+  service-specific, async-resolved `Async<SdkId>Config` class, such as
+  `AsyncBedrockRuntimeConfig`. Explicit configuration must now be resolved with
+  `await Async<SdkId>Config.resolve(...)` before it is passed to the client.
+
 ## v0.4.0
 
 ### Breaking Changes

--- a/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
+++ b/codegen/aws/core/src/it/java/software/amazon/smithy/python/codegen/test/AwsCodegenTest.java
@@ -54,6 +54,8 @@ public class AwsCodegenTest {
         assertTrue(config.contains("auth_schemes = dict(self.auth_schemes or {})"));
         assertTrue(config.contains("auth_schemes[scheme.scheme_id] = scheme"));
         assertTrue(config.contains("self.auth_schemes = auth_schemes"));
+        assertTrue(config.contains("default_factory=lambda: AIOHTTPClient()"));
+        assertFalse(config.contains("from smithy_http.aio.crt import AWSCRTHTTPClient"));
 
         var client = Files.readString(tempDir.resolve("src/restjson/client.py"));
         assertInOrder(

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAsyncConfigIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsAsyncConfigIntegration.java
@@ -6,16 +6,10 @@ package software.amazon.smithy.python.aws.codegen;
 
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.Symbol;
-import software.amazon.smithy.model.knowledge.EventStreamIndex;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
-import software.amazon.smithy.model.knowledge.TopDownIndex;
-import software.amazon.smithy.model.node.ArrayNode;
-import software.amazon.smithy.model.node.StringNode;
-import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.ConfigProperty;
 import software.amazon.smithy.python.codegen.GenerationContext;
@@ -295,13 +289,8 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
             // transport FieldSpec
             writer.write("\"transport\": $T(", fieldSpecSymbol);
             writer.indent();
-            if (usesHttp2(context)) {
-                writer.addDependency(SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("awscrt"));
-                writer.write("default_factory=lambda: $T(),", RuntimeTypes.AWS_CRT_HTTP_CLIENT);
-            } else {
-                writer.addDependency(SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("aiohttp"));
-                writer.write("default_factory=lambda: $T(),", RuntimeTypes.AIOHTTP_CLIENT);
-            }
+            writer.addDependency(SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("aiohttp"));
+            writer.write("default_factory=lambda: $T(),", RuntimeTypes.AIOHTTP_CLIENT);
             writer.dedent();
             writer.write("),");
 
@@ -367,29 +356,5 @@ public class AwsAsyncConfigIntegration implements PythonIntegration {
             writer.closeBlock("}");
         }
 
-        private static boolean usesHttp2(GenerationContext context) {
-            var configuration = context.applicationProtocol().configuration();
-            var httpVersions = configuration.getArrayMember("http")
-                    .orElse(ArrayNode.arrayNode())
-                    .getElementsAs(StringNode.class)
-                    .stream()
-                    .map(node -> node.getValue().toLowerCase(Locale.ENGLISH))
-                    .toList();
-
-            if (httpVersions.contains("h2")) {
-                return true;
-            }
-
-            var eventIndex = EventStreamIndex.of(context.model());
-            var topDownIndex = TopDownIndex.of(context.model());
-            for (OperationShape operation : topDownIndex.getContainedOperations(context.settings().service())) {
-                if (eventIndex.getInputInfo(operation).isPresent()
-                        || eventIndex.getOutputInfo(operation).isPresent()) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegration.java
@@ -4,7 +4,6 @@
  */
 package software.amazon.smithy.python.aws.codegen;
 
-import java.util.Set;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -12,29 +11,10 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.python.codegen.PythonSettings;
-import software.amazon.smithy.python.codegen.SymbolProperties;
 import software.amazon.smithy.python.codegen.integrations.PythonIntegration;
 import software.amazon.smithy.utils.StringUtils;
 
 public final class AwsServiceIdIntegration implements PythonIntegration {
-
-    /**
-     * SDK IDs of the AWS clients that were published under the unprefixed
-     * {@code <SdkId>Client} name before the {@code Async} prefix was adopted.
-     *
-     * <p>Only these clients generate a deprecated alias for the old name so that
-     * existing imports keep working. New clients are generated with the
-     * {@code Async}-prefixed name from the start and need no alias. This set can
-     * be removed once the aliases are dropped.
-     */
-    private static final Set<String> LEGACY_ALIAS_SDK_IDS = Set.of(
-            "Bedrock Runtime",
-            "ConnectHealth",
-            "Lex Runtime V2",
-            "Polly",
-            "QBusiness",
-            "SageMaker Runtime HTTP2",
-            "Transcribe Streaming");
 
     @Override
     public SymbolProvider decorateSymbolProvider(Model model, PythonSettings settings, SymbolProvider symbolProvider) {
@@ -55,13 +35,7 @@ public final class AwsServiceIdIntegration implements PythonIntegration {
             if (shape.isServiceShape() && shape.hasTrait(ServiceTrait.class)) {
                 var serviceTrait = shape.expectTrait(ServiceTrait.class);
                 var baseClientName = StringUtils.capitalize(serviceTrait.getSdkId() + "Client").replace(" ", "");
-                var symbolBuilder = symbol.toBuilder().name("Async" + baseClientName);
-                // Only clients that already shipped under the unprefixed name get a
-                // backwards-compatible alias; new clients start life Async-prefixed.
-                if (LEGACY_ALIAS_SDK_IDS.contains(serviceTrait.getSdkId())) {
-                    symbolBuilder.putProperty(SymbolProperties.DEPRECATED_ALIAS, baseClientName);
-                }
-                symbol = symbolBuilder.build();
+                symbol = symbol.toBuilder().name("Async" + baseClientName).build();
             }
             return symbol;
         }

--- a/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegrationTest.java
@@ -19,11 +19,23 @@ public class AwsServiceIdIntegrationTest {
     private static final String NS = "smithy.example";
 
     @Test
-    public void testClientGetsAsyncName() {
+    public void testFormerlyAliasedClientGetsAsyncNameWithoutAlias() {
+        // "Bedrock Runtime" shipped under the unprefixed name and used to carry a
+        // deprecated alias; it must now be Async-prefixed with no alias residue.
         var symbol = toServiceSymbol("Bedrock Runtime");
 
         assertEquals("AsyncBedrockRuntimeClient", symbol.getName());
         assertFalse(symbol.getTypedProperties().containsValue("BedrockRuntimeClient"));
+    }
+
+    @Test
+    public void testNeverAliasedClientGetsAsyncNameWithoutAlias() {
+        // "Weather" never shipped an unprefixed name; it must be Async-prefixed and,
+        // like every other client, carry no alias.
+        var symbol = toServiceSymbol("Weather");
+
+        assertEquals("AsyncWeatherClient", symbol.getName());
+        assertFalse(symbol.getTypedProperties().containsValue("WeatherClient"));
     }
 
     private static Symbol toServiceSymbol(String sdkId) {

--- a/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/aws/core/src/test/java/software/amazon/smithy/python/aws/codegen/AwsServiceIdIntegrationTest.java
@@ -13,26 +13,17 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.python.codegen.PythonSettings;
 import software.amazon.smithy.python.codegen.PythonSymbolProvider;
-import software.amazon.smithy.python.codegen.SymbolProperties;
 
 public class AwsServiceIdIntegrationTest {
 
     private static final String NS = "smithy.example";
 
     @Test
-    public void testLegacyClientGetsAsyncNameWithDeprecatedAlias() {
+    public void testClientGetsAsyncName() {
         var symbol = toServiceSymbol("Bedrock Runtime");
 
         assertEquals("AsyncBedrockRuntimeClient", symbol.getName());
-        assertEquals("BedrockRuntimeClient", symbol.expectProperty(SymbolProperties.DEPRECATED_ALIAS));
-    }
-
-    @Test
-    public void testNewClientGetsAsyncNameWithoutDeprecatedAlias() {
-        var symbol = toServiceSymbol("Weather");
-
-        assertEquals("AsyncWeatherClient", symbol.getName());
-        assertFalse(symbol.getProperty(SymbolProperties.DEPRECATED_ALIAS).isPresent());
+        assertFalse(symbol.getTypedProperties().containsValue("BedrockRuntimeClient"));
     }
 
     private static Symbol toServiceSymbol(String sdkId) {

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -15,5 +15,5 @@
 
 allprojects {
     group = "software.amazon.smithy.python"
-    version = "0.4.0"
+    version = "0.5.0"
 }

--- a/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/python/codegen/test/PythonCodegenTest.java
@@ -49,5 +49,9 @@ public class PythonCodegenTest {
         assertFalse(client.contains("max_attempts="));
         assertTrue(client.contains("async def close(self) -> None:"));
         assertTrue(client.contains("if self._closed:"));
+
+        var config = Files.readString(tempDir.resolve("src/weather/config.py"));
+        assertTrue(config.contains("self.transport = transport or AIOHTTPClient()"));
+        assertFalse(config.contains("self.transport = transport or AWSCRTHTTPClient()"));
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/ClientGenerator.java
@@ -177,29 +177,6 @@ final class ClientGenerator implements Runnable {
             }
         });
 
-        serviceSymbol.getProperty(SymbolProperties.DEPRECATED_ALIAS).ifPresent(alias -> {
-            writer.addStdlibImport("typing", "TYPE_CHECKING");
-            writer.addStdlibImport("typing", "Any");
-            writer.addStdlibImport("warnings");
-            writer.write("""
-
-                    if TYPE_CHECKING:
-                        # Deprecated alias for backwards compatibility, to be removed.
-                        $1L = $2L
-
-
-                    def __getattr__(name: str) -> Any:
-                        if name == $1S:
-                            warnings.warn(
-                                "$1L is deprecated, use $2L instead. "
-                                "This alias will be removed in a future version.",
-                                DeprecationWarning,
-                                stacklevel=2,
-                            )
-                            return $2L
-                        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-                    """, alias, serviceSymbol.getName());
-        });
     }
 
     private void writeDefaultPlugins(PythonWriter writer, Collection<SymbolReference> plugins) {

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/SymbolProperties.java
@@ -77,11 +77,5 @@ public final class SymbolProperties {
      */
     public static final Property<Boolean> IMPORTABLE = Property.named("nonImportable");
 
-    /**
-     * Contains a deprecated name for the symbol that is generated as an alias
-     * for backwards compatibility. This is only used for services.
-     */
-    public static final Property<String> DEPRECATED_ALIAS = Property.named("deprecatedAlias");
-
     private SymbolProperties() {}
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/ConfigGenerator.java
@@ -8,16 +8,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.TreeSet;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.Symbol;
-import software.amazon.smithy.model.knowledge.EventStreamIndex;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
-import software.amazon.smithy.model.node.ArrayNode;
-import software.amazon.smithy.model.node.StringNode;
-import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.python.codegen.CodegenUtils;
 import software.amazon.smithy.python.codegen.ConfigProperty;
 import software.amazon.smithy.python.codegen.GenerationContext;
@@ -154,55 +149,18 @@ public final class ConfigGenerator implements Runnable {
 
         if (context.applicationProtocol().isHttpProtocol()) {
             properties.addAll(HTTP_PROPERTIES);
-            if (usesHttp2(context)) {
-                transportBuilder
-                        .initialize(writer -> {
-                            writer.addDependency(SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("awscrt"));
-                            writer.write("self.transport = transport or $T()",
-                                    RuntimeTypes.AWS_CRT_HTTP_CLIENT);
-                        });
-
-            } else {
-                transportBuilder
-                        .initialize(writer -> {
-                            writer.addDependency(
-                                    SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("aiohttp"));
-                            writer.write("self.transport = transport or $T()",
-                                    RuntimeTypes.AIOHTTP_CLIENT);
-                        });
-            }
+            transportBuilder
+                    .initialize(writer -> {
+                        writer.addDependency(
+                                SmithyPythonDependency.SMITHY_HTTP.withOptionalDependencies("aiohttp"));
+                        writer.write("self.transport = transport or $T()",
+                                RuntimeTypes.AIOHTTP_CLIENT);
+                    });
         }
 
         properties.add(protocolBuilder.build());
         properties.add(transportBuilder.build());
         return properties;
-    }
-
-    private static boolean usesHttp2(GenerationContext context) {
-        var configuration = context.applicationProtocol().configuration();
-        var httpVersions = configuration.getArrayMember("http")
-                .orElse(ArrayNode.arrayNode())
-                .getElementsAs(StringNode.class)
-                .stream()
-                .map(node -> node.getValue().toLowerCase(Locale.ENGLISH))
-                .toList();
-
-        // An explicit http2 configuration
-        if (httpVersions.contains("h2")) {
-            return true;
-        }
-
-        // enable CRT/http2 client if the service supports any event streams (single or bi-directional)
-        // TODO: Long term, only bi-directional evenstreams strictly require h2
-        var eventIndex = EventStreamIndex.of(context.model());
-        var topDownIndex = TopDownIndex.of(context.model());
-        for (OperationShape operation : topDownIndex.getContainedOperations(context.settings().service())) {
-            if (eventIndex.getInputInfo(operation).isPresent() || eventIndex.getOutputInfo(operation).isPresent()) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static List<ConfigProperty> getAuthProperties(GenerationContext context) {

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/SetupGenerator.java
@@ -234,8 +234,9 @@ public final class SetupGenerator {
         // Let users opt into the CRT transport (AWSCRTHTTPClient) without guessing a compatible
         // awscrt version, by re-exporting smithy_http's awscrt extra. This keeps the version
         // constraint sourced from smithy-http, the single source of truth. Skipped when the client
-        // already requires awscrt (e.g. an http2 service that defaults to the CRT transport), where
-        // there is nothing to opt into.
+        // already requires awscrt as a hard dependency, where there is nothing to opt into. No
+        // client defaults to CRT today, so the guard is currently always taken; it remains as a
+        // safeguard should a client ever pull awscrt as a hard dependency again.
         var smithyHttp = dependencies.get(SmithyPythonDependency.SMITHY_HTTP.packageName());
         if (smithyHttp != null && !getOptionalDependencies(smithyHttp).contains("awscrt")) {
             extras.put("awscrt", List.of("smithy_http[awscrt]" + smithyHttp.getVersion()));


### PR DESCRIPTION
### Description

This PR makes `AIOHTTPClient` the default transport for **all** generated AWS clients and **removes** the deprecated unprefixed client aliases. It also bumps codegen to `0.5.0`.

- **`AIOHTTPClient` is now the default transport for every generated AWS client.** HTTP/2 and bidirectional (duplex) event streams become opt-in: applications that need them install the client's `awscrt` extra and explicitly configure `AWSCRTHTTPClient`.
- **The deprecated unprefixed client aliases are removed entirely.** The `DEPRECATED_ALIAS` symbol property, the `LEGACY_ALIAS_SDK_IDS` set in `AwsServiceIdIntegration`, and the `__getattr__` deprecation shim emitted by `ClientGenerator` are all deleted. Clients that previously also shipped an unprefixed `<SdkId>Client` name (Bedrock Runtime, Polly, Transcribe Streaming, etc.) are now generated *only* under the `Async`-prefixed name, consistent with every other client. Imports such as `BedrockRuntimeClient` must move to `AsyncBedrockRuntimeClient`.

### Testing

- `make build-java` passes
- `AwsCodegenTest` and `PythonCodegenTest` now assert the generated config defaults to `AIOHTTPClient` and no longer imports/uses `AWSCRTHTTPClient`.
- Expanded `AwsServiceIdIntegrationTest` to cover both a formerly-aliased service (Bedrock Runtime) and a never-aliased service (Weather), asserting each gets the `Async`-prefixed name with no alias residue.
- Generated the Bedrock Runtime client locally with these changes and confirmed it defaults to `AIOHTTPClient` and is generated only as `AsyncBedrockRuntimeClient` (no unprefixed alias).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.