### PR TITLE
smithy-http: fix aiohttp to not drop query params or add Content-Type to bodyless requests

### DIFF
--- a/packages/smithy-http/.changes/next-release/smithy-http-bugfix-40b9106fe44145a08dce592704cc437d.json
+++ b/packages/smithy-http/.changes/next-release/smithy-http-bugfix-40b9106fe44145a08dce592704cc437d.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Fixed `AIOHTTPClient` to stop dropping valueless query parameters and automatically adding a `Content-Type` to bodyless POST, PUT, and PATCH requests."
+}

--- a/packages/smithy-http/src/smithy_http/aio/aiohttp.py
+++ b/packages/smithy-http/src/smithy_http/aio/aiohttp.py
@@ -4,7 +4,6 @@ from collections.abc import AsyncIterable, AsyncIterator
 from copy import copy, deepcopy
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Self
-from urllib.parse import parse_qs
 
 import yarl
 
@@ -125,16 +124,13 @@ class AIOHTTPClient(HTTPClient):
         elif not isinstance(body, AsyncBytesReader):
             body = AsyncBytesReader(body)
 
-        # The typing on `params` is incorrect, it'll happily accept a mapping whose
-        # values are lists (or tuples) and produce expected values.
-        # See: https://github.com/aio-libs/aiohttp/issues/8563
         resp = await self._session.request(
             method=request.method,
-            url=self._serialize_uri_without_query(request.destination),
-            params=parse_qs(request.destination.query),  # type: ignore
+            url=self._serialize_uri(request.destination),
             headers=headers_list,
             data=body,
             allow_redirects=False,
+            skip_auto_headers={"Content-Type"},
         )
         try:
             return self._marshal_response(resp)
@@ -170,8 +166,8 @@ class AIOHTTPClient(HTTPClient):
         await body.seek(position)
         return None if position == end else body
 
-    def _serialize_uri_without_query(self, uri: URI) -> yarl.URL:
-        """Serialize all parts of the URI up to and including the path."""
+    def _serialize_uri(self, uri: URI) -> yarl.URL:
+        """Serialize the URI, preserving the already-encoded query string as-is."""
         return yarl.URL.build(
             scheme=uri.scheme or "",
             host=uri.host,
@@ -179,6 +175,7 @@ class AIOHTTPClient(HTTPClient):
             user=uri.username,
             password=uri.password,
             path=uri.path or "",
+            query_string=uri.query or "",
             encoded=True,
         )
 

--- a/packages/smithy-http/tests/unit/aio/test_aiohttp.py
+++ b/packages/smithy-http/tests/unit/aio/test_aiohttp.py
@@ -94,6 +94,40 @@ async def test_send_disables_redirects() -> None:
     assert session.request.call_args.kwargs["allow_redirects"] is False
 
 
+async def test_send_skips_automatic_content_type() -> None:
+    client, session = _create_client()
+
+    await client.send(_create_request())
+
+    assert session.request.call_args.kwargs["skip_auto_headers"] == {"Content-Type"}
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "",
+        "sync",
+        "key=",
+        "a=1&a=2",
+        "sync&filter=a%2Fb&q=hello%20world&plus=a%2Bb",
+    ],
+)
+async def test_send_preserves_encoded_query_string(query: str) -> None:
+    client, session = _create_client()
+    request = HTTPRequest(
+        method="POST",
+        destination=URI(scheme="https", host="example.com", path="/p", query=query),
+        body=AsyncBytesReader(b""),
+        fields=Fields(),
+    )
+
+    await client.send(request)
+
+    url = session.request.call_args.kwargs["url"]
+    assert url.raw_path_qs == (f"/p?{query}" if query else "/p")
+    assert "params" not in session.request.call_args.kwargs
+
+
 async def test_send_streams_response_body_and_releases_it_on_close() -> None:
     async def chunks() -> AsyncIterator[bytes]:
         yield b"first"


### PR DESCRIPTION
### Description

This PR stops `AIOHTTPClient` from dropping valueless query parameters and from adding a `Content-Type` to requests that have no body. Both cause services to reject requests that are otherwise valid, and both were found while migrating the [aws-sdk-python](https://github.com/aws/aws-sdk-python) integration tests to use `AIOHTTPClient` for non-bidirectional operations.

The client currently reparses the query string with [`parse_qs`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.parse_qs), which drops parameters that have no value because `keep_blank_values` defaults to `False`. An operation whose URI ends in a query literal, like the QBusiness `ChatSync` operation with `?sync`, loses that parameter in the request. As a result, the service responds with `InvalidSignatureException` because the signer canonicalized `sync=` into the signature. The serializer already percent-encodes the query in [`join_query_params`](https://github.com/smithy-lang/smithy-python/blob/06e350ea186fbe8b9c935195aca52f6dd7f1f878/packages/smithy-http/src/smithy_http/utils.py#L109-L125), and the signature is computed over those exact bytes. Anything handed to `params` is parsed and re-encoded before it goes out, so this change drops that argument and passes the string straight into `yarl.URL.build` as `query_string`, which the existing `encoded=True` leaves untouched.

aiohttp also sets a default `Content-Type` of `application/octet-stream` on every POST, PUT, and PATCH, even when there is no body ([reference](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.content_type)). An operation that binds no body members, like ConnectHealth `CreateSubscription`, is rejected with `UnsupportedMediaTypeException`. This change passes `skip_auto_headers={"Content-Type"}` so that a `Content-Type` is only sent when the protocol sets one.

### Testing

- Added unit test coverage for valueless and pre-encoded query strings, and for the skipped `Content-Type` header.
- Ran `make check-py` and `make test-py` - 1984 passed, 9 skipped.
- Updated the integration tests in `aws-sdk-python` for both clients to use `AIOHTTPClient`. Before the fix, the non-bidirectional operations failed:

```
smithy_core.exceptions.CallError: Unknown error for operation com.amazonaws.qbusiness#ChatSync - status: 403 - id: com.amazonaws.qbusiness#InvalidSignatureException - reason: 403

smithy_core.exceptions.CallError: Unknown error for operation com.amazonaws.connecthealth#CreateSubscription - status: 415 - id: com.amazonaws.connecthealth#UnsupportedMediaTypeException - reason: 415
```

With the fix applied, both pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.