### PR TITLE
Fix blob default decoding in generated clients

### DIFF
--- a/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsJson10ProtocolGenerator.java
+++ b/codegen/aws/core/src/main/java/software/amazon/smithy/python/aws/codegen/AwsJson10ProtocolGenerator.java
@@ -32,17 +32,11 @@ public final class AwsJson10ProtocolGenerator implements ProtocolGenerator {
             "AwsJson10ClientPopulatesDefaultValuesInInput",
             "AwsJson10ClientSkipsTopLevelDefaultValuesInInput",
             "AwsJson10ClientUsesExplicitlyProvidedMemberValuesOverDefaults",
-            "AwsJson10ClientPopulatesDefaultsValuesWhenMissingInResponse",
             "AwsJson10ClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional",
 
             // TODO: support the endpoint trait.
             "AwsJson10EndpointTrait",
-            "AwsJson10EndpointTraitWithHostLabel",
-
-            // TODO: support client error-correction behavior when the server
-            // omits required values in modeled error responses.
-            "AwsJson10ClientErrorCorrectsWhenServerFailsToSerializeRequiredValues",
-            "AwsJson10ClientErrorCorrectsWithDefaultValuesWhenServerFailsToSerializeRequiredValues");
+            "AwsJson10EndpointTraitWithHostLabel");
 
     @Override
     public ShapeId getProtocol() {

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/generators/StructureGenerator.java
@@ -297,7 +297,8 @@ public final class StructureGenerator implements Runnable {
             ZonedDateTime value = CodegenUtils.parseTimestampNode(model, member, defaultNode);
             return CodegenUtils.getDatetimeConstructor(writer, value);
         } else if (target.isBlobShape()) {
-            return String.format("b'%s'", defaultNode.expectStringNode().getValue());
+            writer.addStdlibImport("base64", "b64decode");
+            return String.format("b64decode(\"%s\")", defaultNode.expectStringNode().getValue());
         } else if (target.isEnumShape()) {
             // Wrap rather than emit a bare string so the value matches the field type.
             var enumSymbol = symbolProvider.toSymbol(target);

--- a/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/python/codegen/integrations/RestJsonProtocolGenerator.java
@@ -63,7 +63,6 @@ public class RestJsonProtocolGenerator implements ProtocolGenerator {
             "RestJsonClientSkipsTopLevelDefaultValuesInInput",
             "RestJsonClientUsesExplicitlyProvidedMemberValuesOverDefaults",
             "RestJsonClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional",
-            "RestJsonClientPopulatesDefaultsValuesWhenMissingInResponse",
             "HttpPrefixEmptyHeaders");
 
     @Override


### PR DESCRIPTION
## Overview

Client error correction was implemented in [#702](https://github.com/smithy-lang/smithy-python/pull/702), but its AWS JSON protocol tests stayed included in our skip list. After removing those tests, the test for required members without modeled defaults passed. The explicit blob-default test failed with `required_blob: b'YmxvYg==' != b'blob'`. Smithy stores blob defaults as base64 strings, and codegen was copying that string into a bytes literal without decoding it. This PR generates blob defaults with `base64.b64decode()` and enables the related AWS JSON and REST JSON protocol tests.

## Testing

Ran `make test-protocols` successfully after removing the related tests from the protocol skip list.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
